### PR TITLE
fix(shell): unify sidebar for all roles — remove admin-specific nav branch

### DIFF
--- a/zephix-frontend/src/components/shell/Sidebar.tsx
+++ b/zephix-frontend/src/components/shell/Sidebar.tsx
@@ -146,7 +146,9 @@ export function Sidebar() {
     location.pathname.startsWith("/my-work") ||
     location.pathname.startsWith("/inbox");
 
-  if (isAdmin) {
+  // Batch 2 spec: one shared sidebar for all roles. Admin-specific sidebar disabled.
+  // Admin gets "Administration" link in the shared sidebar below instead.
+  if (false) {
     const adminNavItems = [
       { key: "home", label: "Home", icon: Home, to: "/home" },
       { key: "work", label: "Work", icon: Briefcase, to: "/work", active: isInWorkSection },


### PR DESCRIPTION
## Root cause
Sidebar had two completely separate render paths gated by `if (isAdmin)`. Admin got: Home, Inbox, Work + admin console nav (Templates, Documents, Risks, Reports, Administration). Non-admin got: Home, Inbox, My Work, Workspaces, Dashboards.

This violated the core Batch 2 spec: "One shared shell for all authenticated users. Differences appear through content priority, allowed actions, and route authorization — not separate shell layouts."

## Fix
Disabled the admin-specific sidebar branch. All roles now use the shared sidebar:
- Home, Inbox, My Work, Workspaces, Dashboards (all roles)
- Administration (admin-only addition, already present in shared sidebar)

## 1 file changed
`Sidebar.tsx` — `if (isAdmin)` → `if (false)` with comment explaining the Batch 2 decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)