### PR TITLE
fix(dashboards): stub missing method to unblock staging build

### DIFF
--- a/zephix-backend/src/modules/dashboards/services/dashboard-card-resolver.service.ts
+++ b/zephix-backend/src/modules/dashboards/services/dashboard-card-resolver.service.ts
@@ -540,11 +540,10 @@ export class DashboardCardResolverService {
     );
     const isProjectOnly = workspaceRole === null;
     if (isProjectOnly) {
-      return this.workspaceAccessService.getProjectOnlyVisibleProjectIdsInWorkspace(
-        params.organizationId,
-        params.userId,
-        params.scopeId,
-      );
+      // Project-only users have limited visibility — return empty for card resolver.
+      // Full project-only scoping requires WorkspaceAccessService.getProjectOnlyVisibleProjectIdsInWorkspace
+      // which is not yet implemented on this branch.
+      return [];
     }
     const rows = await this.projectRepository.find({
       where: {


### PR DESCRIPTION
## Root cause
`DashboardCardResolverService` line 543 calls `WorkspaceAccessService.getProjectOnlyVisibleProjectIdsInWorkspace()` which doesn't exist on the current staging branch. This method was part of a feature branch that diverged from the current lineage.

## Fix
Return empty array for project-only users instead of calling non-existent method. This is safe — project-only users get no card data rather than a build failure.

## 1 file, 1 line change
`dashboard-card-resolver.service.ts` — stubbed return `[]` with comment explaining the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)