### PR TITLE
fix(work-tasks): rename bulk route to /bulk-update to avoid :id collision

### DIFF
--- a/zephix-backend/src/modules/work-management/controllers/work-tasks.controller.ts
+++ b/zephix-backend/src/modules/work-management/controllers/work-tasks.controller.ts
@@ -204,9 +204,9 @@ export class WorkTasksController {
     return this.responseService.success(task);
   }
 
-  // 3. PATCH /api/work/tasks/bulk
-  @Patch('bulk')
-  @ApiOperation({ summary: 'Bulk update task status' })
+  // 3. PATCH /api/work/tasks/bulk-update (collision-proof — 'bulk' was caught by @Patch(':id'))
+  @Patch('bulk-update')
+  @ApiOperation({ summary: 'Bulk update tasks (status, assign, dueDate, priority)' })
   @ApiHeader({
     name: 'x-workspace-id',
     description: 'Workspace ID',

--- a/zephix-frontend/src/features/work-management/workTasks.api.ts
+++ b/zephix-frontend/src/features/work-management/workTasks.api.ts
@@ -392,7 +392,7 @@ export async function bulkUpdate(input: BulkUpdateInput): Promise<{ updated: num
   if (input.assigneeUserId !== undefined) payload.assigneeUserId = input.assigneeUserId;
   if (input.dueDate !== undefined) payload.dueDate = input.dueDate;
   if (input.priority !== undefined) payload.priority = input.priority;
-  const data = await request.patch<{ updated?: number }>("/work/tasks/bulk", payload);
+  const data = await request.patch<{ updated?: number }>("/work/tasks/bulk-update", payload);
   return { updated: typeof data?.updated === "number" ? data.updated : input.taskIds.length };
 }
 


### PR DESCRIPTION
## Root cause
NestJS `@Patch(':id')` intercepted `@Patch('bulk')` — the string `bulk` was matched as a task ID parameter. Requests to `PATCH /work/tasks/bulk` were validated against `UpdateWorkTaskDto` (single-task update) instead of `BulkStatusUpdateDto`, producing `"property 'taskIds' is not allowed"`.

## Fix
Renamed route from `bulk` to `bulk-update`. The path `/work/tasks/bulk-update` cannot collide with UUID-based `:id` routes.

## Files changed (2 files, +4 / -4)
| File | Change |
|------|--------|
| `work-tasks.controller.ts` | `@Patch('bulk')` → `@Patch('bulk-update')` |
| `workTasks.api.ts` | `/work/tasks/bulk` → `/work/tasks/bulk-update` |

## Frontend touched: Yes (1 line — API path update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)