### PR TITLE
fix(work-tasks): add @Type decorator to fix bulk DTO validation failure

### DIFF
--- a/zephix-backend/src/modules/work-management/dto/bulk-status-update.dto.ts
+++ b/zephix-backend/src/modules/work-management/dto/bulk-status-update.dto.ts
@@ -1,4 +1,5 @@
 import { IsArray, IsEnum, IsUUID, IsOptional, IsDateString, ArrayMinSize } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { TaskStatus, TaskPriority } from '../enums/task.enums';
 
@@ -12,6 +13,7 @@ export class BulkStatusUpdateDto {
   @IsArray()
   @ArrayMinSize(1)
   @IsUUID('4', { each: true })
+  @Type(() => String)
   taskIds: string[];
 
   @ApiProperty({ description: 'New status for all tasks', enum: TaskStatus, required: false })


### PR DESCRIPTION
## Root cause
`ValidationPipe` with `transform: true` + `enableImplicitConversion: true` runs `class-transformer`'s `plainToInstance()` BEFORE `class-validator` validates. Without an explicit `@Type(() => String)` decorator on the `taskIds` array property, `class-transformer` mangles the array during implicit conversion, causing `class-validator` to see a non-array value and reject `taskIds`.

The custom error formatter in `buildValidationError.ts` then reports this as `"property 'taskIds' is not allowed"` (the non-whitelist branch of the error formatter), which was misleading — it looked like a route collision or wrong DTO binding when it was actually a class-transformer conversion issue.

## Investigation path
1. Proved route resolves correctly: `actions/nonsense` → 404, `actions/bulk-update` → validation error
2. Proved different handler runs: bulk error = "is not allowed", `:id` error = "should not exist"
3. Proved compiled metadata is correct: `design:paramtypes` shows `BulkStatusUpdateDto`
4. Found custom error formatter in `buildValidationError.ts` line 44 that produces "is not allowed" for non-whitelist validation failures
5. Identified `enableImplicitConversion: true` in global `ValidationPipe` as the trigger for class-transformer mangling arrays without `@Type()`

## Fix
Added `@Type(() => String)` from `class-transformer` to `BulkStatusUpdateDto.taskIds`. This explicitly tells class-transformer to preserve each array element as a string during the transform phase.

## 1 file, 2 lines
`bulk-status-update.dto.ts` — added `import { Type } from 'class-transformer'` and `@Type(() => String)` on `taskIds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)