### PR TITLE
fix(workspaces): admin endpoint uses createWithOwners for membership

### DIFF
--- a/zephix-backend/src/admin/admin.controller.ts
+++ b/zephix-backend/src/admin/admin.controller.ts
@@ -650,14 +650,15 @@ export class AdminController {
       // Generate slug from name
       const slug = body.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
-      // TODO: Implement workspace creation with member assignment
-      const workspace = await this.workspacesService.create({
+      // Use createWithOwners to ensure creator gets workspace_members entry
+      const workspace = await this.workspacesService.createWithOwners({
         name: body.name,
         slug,
-        ownerId: body.ownerId,
+        description: body.description,
         isPrivate: body.visibility === 'private',
         organizationId,
         createdBy: userId,
+        ownerUserIds: [userId],
       });
       return workspace;
     } catch (_error) {


### PR DESCRIPTION
## Root cause
`POST /api/admin/workspaces` called `workspacesService.create()` which only saves the Workspace row — zero `workspace_members` entries created.

The main `POST /api/workspaces` calls `createWithOwners()` which creates `workspace_members` rows for all owners + the creator with `workspace_owner` role.

This caused every admin-created workspace to have no membership records, making `requireWorkspaceWrite()` reject all mutations with `FORBIDDEN_ROLE`.

## Fix
Admin endpoint now calls `createWithOwners({ ownerUserIds: [userId] })` — same path as the main endpoint.

## Platform impact
This was the single blocker preventing staging verification of:
- Template instantiation (`instantiate-v5_1`)
- Task assignment (single + bulk)
- Capacity governance proof (Phase 2A)
- Sample project seeding
- Any workspace write operation via smoke tests

## 1 file, 4 lines changed
`admin.controller.ts` — `create()` → `createWithOwners()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)