### PR TITLE
fix(admin): expose real error from workspace creation

### DIFF
--- a/zephix-backend/src/admin/admin.controller.ts
+++ b/zephix-backend/src/admin/admin.controller.ts
@@ -661,8 +661,12 @@ export class AdminController {
         ownerUserIds: [userId],
       });
       return workspace;
-    } catch (_error) {
-      throw new InternalServerErrorException('Failed to create workspace');
+    } catch (error: any) {
+      // Re-throw known NestJS exceptions (validation, auth, conflict)
+      if (error?.status && error.status < 500) throw error;
+      throw new InternalServerErrorException(
+        error?.message || 'Failed to create workspace',
+      );
     }
   }
 


### PR DESCRIPTION
Exposes the actual error message from createWithOwners instead of generic 500. Needed to diagnose why admin workspace creation fails after the createWithOwners migration.