### PR TITLE
fix(workspaces): add organizationId to WorkspaceMember entity for createWithOwners

### DIFF
--- a/zephix-backend/src/modules/workspaces/entities/workspace-member.entity.ts
+++ b/zephix-backend/src/modules/workspaces/entities/workspace-member.entity.ts
@@ -25,6 +25,9 @@ export class WorkspaceMember {
   @JoinColumn({ name: 'workspace_id' })
   workspace: Workspace;
 
+  @Column({ type: 'uuid', name: 'organization_id' })
+  organizationId: string;
+
   @Column({ type: 'uuid', name: 'workspace_id' })
   workspaceId: string;
 

--- a/zephix-backend/src/modules/workspaces/workspaces.service.ts
+++ b/zephix-backend/src/modules/workspaces/workspaces.service.ts
@@ -438,6 +438,7 @@ export class WorkspacesService {
           }
         } else {
           const member = memberRepo.create({
+            organizationId: input.organizationId,
             workspaceId: savedWorkspace.id,
             userId: ownerUserId,
             role: 'workspace_owner',


### PR DESCRIPTION
## Root cause
`workspace_members` table has `organization_id NOT NULL` column but `WorkspaceMember` entity didn't map it. When `createWithOwners()` inserted a member row via TypeORM `create()` + `save()`, `organization_id` was null → constraint violation.

## Fix
1. Added `organizationId` column mapping to `WorkspaceMember` entity
2. Set `organizationId: input.organizationId` in `createWithOwners()` member creation

## 2 files, 4 lines
- `workspace-member.entity.ts` — added `@Column({ type: 'uuid', name: 'organization_id' }) organizationId: string`
- `workspaces.service.ts` — added `organizationId` to member `create()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)