### PR TITLE
feat(governance): budget governance on mutation paths (Phase 2B)

### DIFF
--- a/zephix-backend/src/modules/budgets/budgets.module.ts
+++ b/zephix-backend/src/modules/budgets/budgets.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProjectBudgetEntity } from './entities/project-budget.entity';
 import { ProjectBudgetsService } from './services/project-budgets.service';
+import { BudgetGovernanceService } from './services/budget-governance.service';
 import { ProjectBudgetsController } from './controllers/project-budgets.controller';
 // KpiQueueModule is @Global() — DomainEventEmitterService available without import
+// AuditModule is @Global() — AuditService available without import
 
 @Module({
   imports: [TypeOrmModule.forFeature([ProjectBudgetEntity])],
-  providers: [ProjectBudgetsService],
+  providers: [ProjectBudgetsService, BudgetGovernanceService],
   controllers: [ProjectBudgetsController],
   exports: [ProjectBudgetsService],
 })

--- a/zephix-backend/src/modules/budgets/controllers/project-budgets.controller.ts
+++ b/zephix-backend/src/modules/budgets/controllers/project-budgets.controller.ts
@@ -47,6 +47,7 @@ export class ProjectBudgetsController {
 
     return this.service.update(workspaceId, projectId, dto, {
       userId: auth.userId,
+      organizationId: auth.organizationId,
       workspaceRole: role,
     });
   }

--- a/zephix-backend/src/modules/budgets/services/budget-governance.service.ts
+++ b/zephix-backend/src/modules/budgets/services/budget-governance.service.ts
@@ -1,0 +1,154 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProjectBudgetEntity } from '../entities/project-budget.entity';
+import { AuditService } from '../../audit/services/audit.service';
+import { AuditEntityType, AuditAction } from '../../audit/audit.constants';
+
+/**
+ * Phase 2B: Budget Governance Service
+ *
+ * Evaluates budget mutations against threshold policy.
+ * Follows ADR-007 governed mutation pattern: auth → scope → policy → domain → audit.
+ *
+ * MVP policy: WARN mode
+ * - If a budget field change exceeds 20% of baseline, attach warning
+ * - The mutation still proceeds (warn, not block)
+ * - The governance decision is recorded as an audit event
+ *
+ * This aligns with Zephix's advisory governance model.
+ */
+
+export interface BudgetEvaluation {
+  allowed: boolean;
+  warning: boolean;
+  reason: string | null;
+  field: string;
+  previousValue: number;
+  newValue: number;
+  changePercent: number;
+  thresholdPercent: number;
+}
+
+export interface GovernedBudgetResult {
+  evaluations: BudgetEvaluation[];
+  hasWarnings: boolean;
+  summary: string | null;
+}
+
+// MVP: warn when any budget field changes by more than 20% of baseline
+const DEFAULT_CHANGE_THRESHOLD_PERCENT = 20;
+
+@Injectable()
+export class BudgetGovernanceService {
+  private readonly logger = new Logger(BudgetGovernanceService.name);
+
+  constructor(
+    @InjectRepository(ProjectBudgetEntity)
+    private readonly budgetRepo: Repository<ProjectBudgetEntity>,
+    private readonly auditService: AuditService,
+  ) {}
+
+  /**
+   * Evaluate a budget update against governance policy.
+   *
+   * Called from ProjectBudgetsService.update() before persisting changes.
+   * Returns evaluation with warnings if thresholds exceeded.
+   */
+  async evaluateBudgetUpdate(input: {
+    workspaceId: string;
+    projectId: string;
+    organizationId: string;
+    actorUserId: string;
+    changes: Record<string, string | undefined>;
+    currentBudget: ProjectBudgetEntity;
+  }): Promise<GovernedBudgetResult> {
+    const evaluations: BudgetEvaluation[] = [];
+    const baseline = parseFloat(input.currentBudget.baselineBudget) || 0;
+
+    const fieldsToCheck: Array<{ key: string; label: string }> = [
+      { key: 'baselineBudget', label: 'Baseline Budget' },
+      { key: 'revisedBudget', label: 'Revised Budget' },
+      { key: 'contingency', label: 'Contingency' },
+      { key: 'approvedChangeBudget', label: 'Approved Change Budget' },
+      { key: 'forecastAtCompletion', label: 'Forecast at Completion' },
+    ];
+
+    for (const field of fieldsToCheck) {
+      const newValueStr = input.changes[field.key];
+      if (newValueStr === undefined) continue;
+
+      const newValue = parseFloat(newValueStr) || 0;
+      const previousValue = parseFloat((input.currentBudget as any)[field.key]) || 0;
+
+      if (newValue === previousValue) continue;
+
+      const changeDelta = Math.abs(newValue - previousValue);
+      const referenceValue = baseline > 0 ? baseline : previousValue;
+      const changePercent = referenceValue > 0
+        ? (changeDelta / referenceValue) * 100
+        : (newValue > 0 ? 100 : 0);
+
+      const overThreshold = changePercent > DEFAULT_CHANGE_THRESHOLD_PERCENT;
+
+      evaluations.push({
+        allowed: true, // MVP: always allow (warn mode)
+        warning: overThreshold,
+        reason: overThreshold
+          ? `${field.label} change of ${changePercent.toFixed(1)}% exceeds ${DEFAULT_CHANGE_THRESHOLD_PERCENT}% threshold (${previousValue.toFixed(2)} → ${newValue.toFixed(2)})`
+          : null,
+        field: field.key,
+        previousValue,
+        newValue,
+        changePercent: Math.round(changePercent * 10) / 10,
+        thresholdPercent: DEFAULT_CHANGE_THRESHOLD_PERCENT,
+      });
+    }
+
+    const hasWarnings = evaluations.some(e => e.warning);
+
+    // Record governance audit event
+    try {
+      await this.auditService.record({
+        organizationId: input.organizationId,
+        workspaceId: input.workspaceId,
+        actorUserId: input.actorUserId,
+        actorPlatformRole: 'SYSTEM',
+        entityType: AuditEntityType.PROJECT,
+        entityId: input.projectId,
+        action: AuditAction.GOVERNANCE_EVALUATE,
+        metadata: {
+          governanceType: 'BUDGET',
+          decision: hasWarnings ? 'WARN' : 'ALLOW',
+          evaluations: evaluations.map(e => ({
+            field: e.field,
+            previousValue: e.previousValue,
+            newValue: e.newValue,
+            changePercent: e.changePercent,
+            thresholdPercent: e.thresholdPercent,
+            warning: e.warning,
+          })),
+          baseline,
+          projectId: input.projectId,
+        },
+      });
+    } catch (err) {
+      this.logger.error('Failed to record budget governance audit event', err);
+    }
+
+    if (hasWarnings) {
+      const warnings = evaluations.filter(e => e.warning);
+      this.logger.warn(
+        `Budget governance warning: project ${input.projectId} — ${warnings.map(w => w.reason).join('; ')}`,
+      );
+    }
+
+    return {
+      evaluations,
+      hasWarnings,
+      summary: hasWarnings
+        ? evaluations.filter(e => e.warning).map(e => e.reason).join('; ')
+        : null,
+    };
+  }
+}

--- a/zephix-backend/src/modules/budgets/services/project-budgets.service.ts
+++ b/zephix-backend/src/modules/budgets/services/project-budgets.service.ts
@@ -11,9 +11,11 @@ import { IsOptional, Matches } from 'class-validator';
 import { ProjectBudgetEntity } from '../entities/project-budget.entity';
 import { DomainEventEmitterService } from '../../kpi-queue/services/domain-event-emitter.service';
 import { DOMAIN_EVENTS } from '../../kpi-queue/constants/queue.constants';
+import { BudgetGovernanceService, GovernedBudgetResult } from './budget-governance.service';
 
 export type BudgetActorContext = {
   userId: string;
+  organizationId: string;
   workspaceRole?: 'OWNER' | 'ADMIN' | 'MEMBER' | 'GUEST';
 };
 
@@ -51,6 +53,8 @@ export class ProjectBudgetsService {
     private readonly repo: Repository<ProjectBudgetEntity>,
     @Optional()
     private readonly domainEventEmitter?: DomainEventEmitterService,
+    @Optional()
+    private readonly budgetGovernance?: BudgetGovernanceService,
   ) {}
 
   async get(workspaceId: string, projectId: string) {
@@ -85,6 +89,25 @@ export class ProjectBudgetsService {
 
     const row = await this.get(workspaceId, projectId);
 
+    // Phase 2B: Budget governance evaluation (ADR-007 pipeline)
+    let governanceResult: GovernedBudgetResult | null = null;
+    if (this.budgetGovernance) {
+      governanceResult = await this.budgetGovernance.evaluateBudgetUpdate({
+        workspaceId,
+        projectId,
+        organizationId: actor.organizationId,
+        actorUserId: actor.userId,
+        changes: {
+          baselineBudget: dto.baselineBudget,
+          revisedBudget: dto.revisedBudget,
+          contingency: dto.contingency,
+          approvedChangeBudget: dto.approvedChangeBudget,
+          forecastAtCompletion: dto.forecastAtCompletion,
+        },
+        currentBudget: row,
+      });
+    }
+
     if (dto.baselineBudget !== undefined) row.baselineBudget = dto.baselineBudget;
     if (dto.revisedBudget !== undefined) row.revisedBudget = dto.revisedBudget;
     if (dto.contingency !== undefined) row.contingency = dto.contingency;
@@ -95,17 +118,26 @@ export class ProjectBudgetsService {
 
     const saved = await this.repo.save(row);
 
-    // Wave 10: Emit domain event for KPI recompute
+    // Emit domain event for KPI recompute
     if (this.domainEventEmitter) {
       this.domainEventEmitter
         .emit(DOMAIN_EVENTS.BUDGET_UPDATED, {
           workspaceId,
-          organizationId: '', // Budget service doesn't have org context
+          organizationId: actor.organizationId,
           projectId,
           entityId: saved.id,
           entityType: 'BUDGET',
         })
         .catch(() => {});
+    }
+
+    // Attach governance warning to response if threshold exceeded
+    if (governanceResult?.hasWarnings) {
+      (saved as any)._governanceWarning = {
+        type: 'BUDGET_WARNING',
+        summary: governanceResult.summary,
+        evaluations: governanceResult.evaluations.filter(e => e.warning),
+      };
     }
 
     return saved;


### PR DESCRIPTION
## Executive summary
Wires budget threshold governance into the project budget mutation path. Following ADR-007 (auth → scope → policy → domain → audit), budget changes are now evaluated against a 20% threshold before persist, with governance decisions recorded as audit events.

## Whole-platform impact

**What this touches**: Budgets module only (4 files)

**What it does NOT touch**: Onboarding, shell, Home/Inbox, admin placement, dashboard publishing, template flow, work-task mutations, capacity governance (Phase 2A), frontend

**Why this is the right next MVP step**: Phase 2A proved capacity governance. Phase 2B proves budget governance. Together they demonstrate Engine 2 (Governance) is active in live mutations, not just a concept.

## Audit of budget-sensitive mutation surfaces

| Surface | Verdict | Governed Now? |
|---------|---------|--------------|
| `PATCH .../budget` (ProjectBudgetsController) | **REAL** — 5 budget fields, role-gated | **YES** — governance + audit |
| `PATCH /projects/:id` with budget field | **REAL** — change request guard when CM enabled | Deferred (different module, CM already guards it) |
| `Project.actualCost` | **SCHEMA-ONLY** — never written | Out of scope |
| `BudgetTab` frontend | **COSMETIC** — calls phantom endpoints | Out of scope |
| `PolicyCategory.BUDGET` | **SCHEMA-ONLY** — no active policies | Out of scope |
| Two parallel budget systems | Noted — governance wired to `project_budgets` table | Documented |

## Budget governance model

**Policy**: WARN mode (MVP)
- Evaluates each changed field against 20% of baseline budget
- Per-field: field name, previous value, new value, change%, threshold
- If any field exceeds threshold → warning attached to response
- Mutation always proceeds (advisory governance)

**Response**: `_governanceWarning` on budget response:
```json
{
  "type": "BUDGET_WARNING",
  "summary": "Baseline Budget change of 50.0% exceeds 20% threshold (100000.00 → 150000.00)",
  "evaluations": [{ "field": "baselineBudget", "changePercent": 50, ... }]
}
```

**Audit**: `governance_evaluate` event with metadata:
- governanceType: BUDGET
- decision: ALLOW or WARN
- per-field evaluations with values and thresholds

## Files changed (4 files, +192 / -3)

| File | Change |
|------|--------|
| `budget-governance.service.ts` | New — evaluates budget changes, records audit |
| `project-budgets.service.ts` | Governance evaluation before persist, warning on response |
| `project-budgets.controller.ts` | Passes organizationId from auth context |
| `budgets.module.ts` | Registers BudgetGovernanceService |

## What is intentionally deferred
- `PATCH /projects/:id` budget field (already guarded by change management when CM enabled)
- Frontend budget warning display
- Budget approval workflows
- Portfolio budget rollups
- Full finance suite
- Configurable threshold per workspace/project

## Verification
- `tsc --noEmit`: zero new errors
- Governance evaluation is additive — never blocks mutations
- Audit recording is non-blocking (catch + log)
- No regression risk — budget module is self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)