### PR TITLE
feat(risks): risk basic loop — API completion + dashboard data fix (Phase 2D)

### DIFF
--- a/zephix-backend/src/modules/dashboards/dashboards.module.ts
+++ b/zephix-backend/src/modules/dashboards/dashboards.module.ts
@@ -28,7 +28,7 @@ import { ProjectDashboardService } from './services/project-dashboard.service';
 import { ProjectDashboardController } from './controllers/project-dashboard.controller';
 import { WorkspaceDashboardDataController } from './controllers/workspace-dashboard-data.controller';
 import { WorkspaceDashboardDataService } from './services/workspace-dashboard-data.service';
-import { Risk } from '../risks/entities/risk.entity';
+import { WorkRisk } from '../work-management/entities/work-risk.entity';
 import { DocumentEntity } from '../documents/entities/document.entity';
 import { WorkResourceAllocation } from '../work-management/entities/work-resource-allocation.entity';
 import { DashboardCardRegistryService } from './services/dashboard-card-registry.service';
@@ -48,7 +48,7 @@ import { OperationalDashboardController } from './controllers/operational-dashbo
       WorkTask, // Phase 7.5: For project dashboard
       WorkPhase, // Phase 7.5: For project dashboard
       WorkResourceAllocation,
-      Risk,
+      WorkRisk,
       DocumentEntity,
     ]),
     SharedModule, // Provides ResponseService

--- a/zephix-backend/src/modules/dashboards/services/workspace-dashboard-data.service.ts
+++ b/zephix-backend/src/modules/dashboards/services/workspace-dashboard-data.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { WorkspaceAccessService } from '../../workspace-access/workspace-access.service';
 import { Project } from '../../projects/entities/project.entity';
 import { WorkPhase } from '../../work-management/entities/work-phase.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import { WorkRisk } from '../../work-management/entities/work-risk.entity';
 import { DocumentEntity } from '../../documents/entities/document.entity';
 
 @Injectable()
@@ -14,8 +14,8 @@ export class WorkspaceDashboardDataService {
     private readonly projectRepo: Repository<Project>,
     @InjectRepository(WorkPhase)
     private readonly phaseRepo: Repository<WorkPhase>,
-    @InjectRepository(Risk)
-    private readonly riskRepo: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private readonly riskRepo: Repository<WorkRisk>,
     @InjectRepository(DocumentEntity)
     private readonly documentRepo: Repository<DocumentEntity>,
     private readonly workspaceAccessService: WorkspaceAccessService,
@@ -152,16 +152,13 @@ export class WorkspaceDashboardDataService {
       userId,
       platformRole,
     );
+    // Phase 2D: Query work_risks directly (has workspaceId column)
     const rows = await this.riskRepo
       .createQueryBuilder('risk')
-      .innerJoin(
-        Project,
-        'project',
-        'project.id = risk.project_id::uuid AND project.organization_id = risk.organization_id::uuid AND project.workspace_id = :workspaceId::uuid AND project.deleted_at IS NULL',
-        { workspaceId },
-      )
       .where('risk.organization_id = :organizationId', { organizationId })
-      .andWhere("COALESCE(risk.status, 'open') <> 'closed'")
+      .andWhere('risk.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('risk.status != :closed', { closed: 'CLOSED' })
+      .andWhere('risk.deleted_at IS NULL')
       .orderBy('risk.created_at', 'DESC')
       .limit(20)
       .getMany();
@@ -196,19 +193,24 @@ export class WorkspaceDashboardDataService {
     organizationId: string,
     workspaceId: string,
   ): Promise<number> {
-    const row = await this.riskRepo
-      .createQueryBuilder('risk')
-      .select('COUNT(risk.id)', 'count')
-      .innerJoin(
-        Project,
-        'project',
-        'project.id = risk.project_id::uuid AND project.organization_id = risk.organization_id::uuid AND project.workspace_id = :workspaceId::uuid AND project.deleted_at IS NULL',
-        { workspaceId },
-      )
-      .where('risk.organization_id = :organizationId', { organizationId })
-      .andWhere("COALESCE(risk.status, 'open') <> 'closed'")
-      .getRawOne<{ count?: string }>();
-    return Number(row?.count || 0);
+    // Phase 2D: Query work_risks directly (has workspaceId column)
+    const count = await this.riskRepo.count({
+      where: {
+        organizationId,
+        workspaceId,
+        deletedAt: null as any,
+      },
+    });
+    // Subtract closed risks
+    const closedCount = await this.riskRepo.count({
+      where: {
+        organizationId,
+        workspaceId,
+        status: 'CLOSED' as any,
+        deletedAt: null as any,
+      },
+    });
+    return count - closedCount;
   }
 
   private async countWorkspaceDocuments(

--- a/zephix-frontend/src/App.tsx
+++ b/zephix-frontend/src/App.tsx
@@ -82,7 +82,7 @@ import AdministrationUsersPage from "@/features/administration/pages/Administrat
 import AdministrationAuditLogPage from "@/features/administration/pages/AdministrationAuditLogPage";
 import AdministrationSettingsPage from "@/features/administration/pages/AdministrationSettingsPage";
 import AdministrationBillingPage from "@/features/administration/pages/AdministrationBillingPage";
-import RisksPage from "@/features/risks/pages/RisksPage";
+// RisksPage retired — risks live inside projects (/projects/:id/risks)
 import { useWorkspaceStore } from "@/state/workspace.store";
 
 /** "/" — authenticated users go to Unified Home (Batch 2); guests see the marketing page */
@@ -210,7 +210,8 @@ export default function App() {
               {/* ── Workspace-scoped routes (redirect to /home if none selected) ── */}
               <Route element={<RequireWorkspace />}>
                 <Route path="/reports" element={<Navigate to="/analytics" replace />} />
-                <Route path="/risks" element={<RisksPage />} />
+                {/* Phase 2D: /risks standalone page retired — risks live inside projects. Use /projects/:id/risks */}
+                <Route path="/risks" element={<Navigate to="/workspaces" replace />} />
                 <Route path="/dashboards" element={<DashboardsIndex />} />
                 <Route path="/dashboards/:id" element={<DashboardView />} />
                 <Route path="/dashboards/:id/edit" element={<DashboardBuilder />} />

--- a/zephix-frontend/src/features/risks/risks.api.ts
+++ b/zephix-frontend/src/features/risks/risks.api.ts
@@ -6,7 +6,7 @@
 
 import { api } from '@/lib/api';
 import { useWorkspaceStore } from '@/state/workspace.store';
-import type { Risk, CreateRiskInput, ListRisksParams, ListRisksResponse } from './types';
+import type { Risk, CreateRiskInput, UpdateRiskInput, ListRisksParams, ListRisksResponse } from './types';
 
 // --- Workspace invariant helper ---
 
@@ -47,6 +47,32 @@ export async function createRisk(input: CreateRiskInput): Promise<Risk> {
 
   const res = await api.post('/work/risks', input);
   return res.data;
+}
+
+/**
+ * Get a single risk by ID.
+ */
+export async function getRisk(riskId: string): Promise<Risk> {
+  requireActiveWorkspace();
+  const res = await api.get(`/work/risks/${riskId}`);
+  return res.data;
+}
+
+/**
+ * Update a risk.
+ */
+export async function updateRisk(riskId: string, input: UpdateRiskInput): Promise<Risk> {
+  requireActiveWorkspace();
+  const res = await api.patch(`/work/risks/${riskId}`, input);
+  return res.data;
+}
+
+/**
+ * Delete (soft-delete) a risk.
+ */
+export async function deleteRisk(riskId: string): Promise<void> {
+  requireActiveWorkspace();
+  await api.delete(`/work/risks/${riskId}`);
 }
 
 /**


### PR DESCRIPTION
## Executive summary
Completes the risk basic loop by adding frontend update/delete API functions, fixing the critical dashboard data source mismatch (was reading from stale `risks` table instead of `work_risks`), and retiring the broken standalone `/risks` route.

## Whole-platform impact

**What this touches**: Frontend risk API (3 new functions), dashboard data service (risk queries rewired), App.tsx route cleanup, dashboards module entity import

**What it does NOT touch**: Onboarding, shell, Home/Inbox, admin placement, templates, work-tasks, capacity/budget/exception governance, frontend UI components (ProjectRisksTab unchanged)

**Why this is the right next MVP step**: Phase 2A-C proved governance. Phase 2D completes the risk operational loop so risks created by users actually appear in dashboards and the full CRUD cycle is API-complete.

## Audit of current risk surfaces

| Surface | Before | After |
|---------|--------|-------|
| WorkRisk entity + WorkRisksController | REAL — full CRUD | Unchanged (already complete) |
| Frontend risk API | create + list only | **+ getRisk, updateRisk, deleteRisk** |
| Dashboard risk data | Read from stale `risks` table (Entity 2) | **FIXED — reads from `work_risks`** |
| `/risks` standalone route | Broken — wrong API, wrong types | **RETIRED → redirect to /workspaces** |
| ProjectRisksTab | List + create modal | Unchanged (edit UI deferred) |
| 3 stale risk entities | pm/risks, modules/risks, pm/project-risk | Documented — cleanup deferred |

## Critical fix: Dashboard data source
The `WorkspaceDashboardDataService` was importing `Risk` from `modules/risks` (table: `risks`) which has no `workspaceId` column. Changed to import `WorkRisk` from `work-management` (table: `work_risks`) which has proper workspace scoping. Dashboard risk queries are now simple direct queries instead of complex joins through the projects table with CAST fixes.

## Files changed (4 files, +57 / -28)
| File | Change |
|------|--------|
| `risks.api.ts` | Added getRisk, updateRisk, deleteRisk |
| `workspace-dashboard-data.service.ts` | Risk → WorkRisk, simplified queries |
| `dashboards.module.ts` | Risk → WorkRisk in forFeature |
| `App.tsx` | /risks route retired → redirect to /workspaces |

## What is intentionally deferred
- Risk edit UI in ProjectRisksTab (backend + API ready, UI not built)
- Risk detail click-through panel
- Create modal: probability, impact, mitigation, owner picker fields
- RiskDetectionService writes to stale `risks` table (separate cleanup)
- 3 stale risk entities (pm module, modules/risks)

## Verification
- `tsc --noEmit` backend: zero new errors
- `tsc --noEmit` frontend: zero errors
- Dashboard risk queries now hit correct table with workspace scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)