### PR TITLE
feat(dashboards): standalone default control + widget coherence (Phase 3A)

### DIFF
--- a/zephix-backend/src/modules/dashboards/controllers/dashboards.controller.ts
+++ b/zephix-backend/src/modules/dashboards/controllers/dashboards.controller.ts
@@ -531,4 +531,43 @@ export class DashboardsController {
     );
     return this.responseService.success(dashboards);
   }
+
+  // Phase 3A: Standalone set-default endpoint (decouples from publish)
+  @Post(':id/set-default')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set dashboard as workspace default (admin only)' })
+  async setDefault(
+    @Param('id') id: string,
+    @Req() req: any,
+  ) {
+    const { organizationId, userId } = getAuthContext(req);
+    const platformRole = req.user?.platformRole ?? req.user?.role;
+    const dashboard = await this.dashboardsService.setAsDefault(
+      id,
+      organizationId,
+      userId,
+      platformRole,
+    );
+    return this.responseService.success(dashboard);
+  }
+
+  @Post(':id/unset-default')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove dashboard as workspace default (admin only)' })
+  async unsetDefault(
+    @Param('id') id: string,
+    @Req() req: any,
+  ) {
+    const { organizationId, userId } = getAuthContext(req);
+    const platformRole = req.user?.platformRole ?? req.user?.role;
+    const dashboard = await this.dashboardsService.unsetDefault(
+      id,
+      organizationId,
+      userId,
+      platformRole,
+    );
+    return this.responseService.success(dashboard);
+  }
 }

--- a/zephix-backend/src/modules/dashboards/services/dashboards.service.ts
+++ b/zephix-backend/src/modules/dashboards/services/dashboards.service.ts
@@ -1022,4 +1022,65 @@ export class DashboardsService {
     dashboard.audience = audience;
     return this.dashboardRepository.save(dashboard);
   }
+
+  // Phase 3A: Standalone set/unset default (decoupled from publish)
+
+  async setAsDefault(
+    dashboardId: string,
+    organizationId: string,
+    userId: string,
+    platformRole: string,
+  ): Promise<Dashboard> {
+    const role = normalizePlatformRole(platformRole);
+    if (role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can set default dashboard');
+    }
+
+    const dashboard = await this.getDashboardForMutation(
+      dashboardId,
+      organizationId,
+      userId,
+      platformRole,
+    );
+
+    if (!dashboard.workspaceId) {
+      throw new BadRequestException('Dashboard must be in a workspace to be set as default');
+    }
+
+    // Clear other defaults in this workspace
+    await this.dashboardRepository
+      .createQueryBuilder()
+      .update(Dashboard)
+      .set({ isDefault: false })
+      .where(
+        'organization_id = :organizationId AND workspace_id = :workspaceId AND is_default = true AND id != :id',
+        { organizationId, workspaceId: dashboard.workspaceId, id: dashboardId },
+      )
+      .execute();
+
+    dashboard.isDefault = true;
+    return this.dashboardRepository.save(dashboard);
+  }
+
+  async unsetDefault(
+    dashboardId: string,
+    organizationId: string,
+    userId: string,
+    platformRole: string,
+  ): Promise<Dashboard> {
+    const role = normalizePlatformRole(platformRole);
+    if (role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can unset default dashboard');
+    }
+
+    const dashboard = await this.getDashboardForMutation(
+      dashboardId,
+      organizationId,
+      userId,
+      platformRole,
+    );
+
+    dashboard.isDefault = false;
+    return this.dashboardRepository.save(dashboard);
+  }
 }

--- a/zephix-frontend/src/features/dashboards/api.ts
+++ b/zephix-frontend/src/features/dashboards/api.ts
@@ -310,3 +310,19 @@ export async function listPublishedDashboards(workspaceId: string): Promise<Dash
   const arr = raw.data || response;
   return Array.isArray(arr) ? arr : [];
 }
+
+// Phase 3A: Standalone set/unset default (decoupled from publish)
+
+export async function setDashboardDefault(dashboardId: string): Promise<DashboardEntity> {
+  const headers = getWorkspaceHeader();
+  const response = await api.post(`/api/dashboards/${dashboardId}/set-default`, {}, { headers });
+  const raw = response as { data?: unknown };
+  return (raw.data || response) as DashboardEntity;
+}
+
+export async function unsetDashboardDefault(dashboardId: string): Promise<DashboardEntity> {
+  const headers = getWorkspaceHeader();
+  const response = await api.post(`/api/dashboards/${dashboardId}/unset-default`, {}, { headers });
+  const raw = response as { data?: unknown };
+  return (raw.data || response) as DashboardEntity;
+}

--- a/zephix-frontend/src/features/dashboards/types.ts
+++ b/zephix-frontend/src/features/dashboards/types.ts
@@ -13,7 +13,6 @@ export type WidgetType =
   | "program_summary"
   | "budget_variance"
   | "risk_summary"
-  | "kpi"
   // Phase 2B: Waterfall core
   | "critical_path_risk"
   | "earned_value_summary";

--- a/zephix-frontend/src/features/dashboards/widget-registry.ts
+++ b/zephix-frontend/src/features/dashboards/widget-registry.ts
@@ -67,13 +67,6 @@ export const widgetRegistry: Record<WidgetType, WidgetRegistryEntry> = {
     displayName: "Risk Summary",
     description: "Risk assessment and mitigation status",
   },
-  kpi: {
-    defaultConfig: {},
-    defaultLayout: { x: 0, y: 14, w: 4, h: 3 },
-    category: "Analytics",
-    displayName: "KPI Dashboard",
-    description: "Key Performance Indicators overview",
-  },
   // Phase 2B: Waterfall core widgets
   critical_path_risk: {
     defaultConfig: {},

--- a/zephix-frontend/src/pages/templates/TemplateKpiSelector.tsx
+++ b/zephix-frontend/src/pages/templates/TemplateKpiSelector.tsx
@@ -1,4 +1,8 @@
 /**
+ * @deprecated Phase 3A: This component uses a hardcoded KPI list that does not match
+ * the backend kpi_definitions table or CALCULATOR_MAP. Should be replaced with a
+ * component that fetches from GET .../kpis/definitions API.
+ *
  * Template KPI Defaults Selector
  * MVP: Hardcoded KPI list for template defaultEnabledKPIs
  */


### PR DESCRIPTION
## Executive summary
Adds standalone set/unset default dashboard endpoints (decoupled from publish), removes invalid frontend widget type, and deprecates stale KPI selector.

## Whole-platform impact
**Touches**: Dashboard controller + service (2 new endpoints), frontend dashboard API + types + widget registry, template KPI selector deprecation
**Does NOT touch**: Onboarding, shell, Home/Inbox, admin placement, templates, work-tasks, governance, risks, frontend UI components

## Audit findings

| Surface | Before | After |
|---------|--------|-------|
| Set default dashboard | Only via publish action | **NEW**: standalone POST /dashboards/:id/set-default |
| Unset default | Only via unpublish | **NEW**: standalone POST /dashboards/:id/unset-default |
| `kpi` widget type | In frontend type union + registry, NOT in backend allowlist | **REMOVED** — prevents silent validation failure |
| TemplateKpiSelector | Hardcoded list not matching backend | **@deprecated** — should use KPI definitions API |
| Dual KPI toggle mechanism | Project.activeKpiIds vs project_kpi_configs | Documented — future unification |
| Dual widget catalogs | widget-registry.ts vs card-definition.ts | Documented — future unification |

## Files changed (6 files, +120 / -8)
| File | Change |
|------|--------|
| `dashboards.controller.ts` | +2 endpoints: set-default, unset-default |
| `dashboards.service.ts` | +2 methods: setAsDefault, unsetDefault (admin-only, clears other defaults) |
| `api.ts` (frontend) | +2 functions: setDashboardDefault, unsetDashboardDefault |
| `types.ts` | Removed `kpi` from WidgetType union |
| `widget-registry.ts` | Removed kpi entry |
| `TemplateKpiSelector.tsx` | @deprecated marker |

## What is intentionally deferred
- Workspace settings dashboard tab
- WorkspaceDefaultsPage functional controls
- Dual KPI toggle unification
- Dual widget catalog unification
- Frontend UI for set-default button (API ready, UI not built)

## Verification
- `tsc --noEmit` backend: zero new errors
- `tsc --noEmit` frontend: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)