### PR TITLE
feat(views): consolidated execution toolbar + filter interaction fix (Phase 3B.1)

### DIFF
--- a/zephix-frontend/src/features/projects/tabs/ProjectTableTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectTableTab.tsx
@@ -344,7 +344,14 @@ export const ProjectTableTab: React.FC = () => {
 
   const getFilteredSorted = (taskList: WorkTask[]) => {
     let filtered = taskList.filter((t) => {
-      if (!toolbarConfig.showClosed && (t.status === 'DONE' || t.status === 'CANCELED'))
+      // Show Closed gate: hide DONE/CANCELED unless showClosed is on
+      // OR the user explicitly included that status in the FilterBar
+      const hasExplicitStatusFilter = filters.status && filters.status.length > 0;
+      if (
+        !toolbarConfig.showClosed &&
+        !hasExplicitStatusFilter &&
+        (t.status === 'DONE' || t.status === 'CANCELED')
+      )
         return false;
       if (
         toolbarConfig.search &&
@@ -1028,24 +1035,21 @@ export const ProjectTableTab: React.FC = () => {
 
   return (
     <div data-testid="table-root">
-      {/* ─── View Toolbar ─── */}
-      <ViewToolbar
-        viewType="table"
-        config={toolbarConfig}
-        onChange={(partial) => setToolbarConfig((prev) => ({ ...prev, ...partial }))}
-        className="mb-2"
-      />
-
-      {/* ─── FilterBar (Sprint 1) ─── */}
-      <FilterBar options={filterBarOptions} className="mb-3" />
-
-      {/* ─── Header bar ─── */}
-      <div className="mb-3 flex items-center gap-2">
+      {/* ─── Consolidated Execution Toolbar ─── */}
+      <div className="mb-3 flex items-center gap-2 flex-wrap">
         <Table2 className="h-5 w-5 text-slate-700" />
         <h2 className="text-lg font-semibold text-slate-900">Table</h2>
-        <span className="text-sm text-slate-500 ml-2">{sorted.length} tasks</span>
+        <span className="text-sm text-slate-500">{sorted.length} tasks</span>
 
-        {/* Column picker toggle */}
+        {/* Search + Show Closed from ViewToolbar */}
+        <ViewToolbar
+          viewType="table"
+          config={toolbarConfig}
+          onChange={(partial) => setToolbarConfig((prev) => ({ ...prev, ...partial }))}
+          className="ml-2"
+        />
+
+        {/* Column picker */}
         <div className="relative ml-auto">
           <button
             onClick={() => setShowColumnPicker(!showColumnPicker)}
@@ -1081,6 +1085,9 @@ export const ProjectTableTab: React.FC = () => {
           </button>
         )}
       </div>
+
+      {/* ─── Filters (URL-param based, real data) ─── */}
+      <FilterBar options={filterBarOptions} className="mb-3" />
 
       {/* ─── Bulk Action Bar (B1) — hidden for read-only users ─── */}
       {canEditWork && selectedIds.size > 0 && (


### PR DESCRIPTION
## Executive summary
Consolidates the Table view's 3 separate control rows into 2, and fixes a logic bug where Show Closed silently overrode explicit FilterBar status selections.

## Whole-platform impact
**Touches**: ProjectTableTab only (1 file, layout + filter logic)
**Does NOT touch**: Backend, shell, dashboards, governance, risks, templates, other views

## Audit findings (post PR #100)
All 5 surviving controls are real and connected:
- Search: client-side title filter ✓
- Show Closed: DONE/CANCELED gate ✓
- FilterBar: URL-param multi-field filters → API + client ✓
- Column picker: inline toggle with localStorage persist ✓
- Header sort: column header click → sortField/sortDir state ✓

**Bug found**: Show Closed (line 347) ran before FilterBar status check. If user explicitly filtered by DONE in FilterBar but had Show Closed off, they'd see zero results. Fixed: explicit status filter now bypasses the Show Closed gate.

## Changes (1 file, +23 / -16)

1. **Layout consolidation**: Title, count, Search, Show Closed, Columns, and Add Task all in one row. FilterBar in a second row. Down from 3 rows to 2.

2. **Filter interaction fix**: `hasExplicitStatusFilter` check — if FilterBar has active status selections, Show Closed gate is bypassed so explicit intent wins.

## Intentionally deferred
- Saved views (not real)
- Group by (not implemented)  
- Cross-view toolbar parity
- Toolbar sort (header sort is sufficient and working)

## Verification
- `tsc --noEmit`: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)