### PR TITLE
feat(admin): admin controls polish + stale page documentation (Phase 3C)

### DIFF
--- a/zephix-frontend/src/components/CommandPalette.tsx
+++ b/zephix-frontend/src/components/CommandPalette.tsx
@@ -72,10 +72,10 @@ export function CommandPalette() {
           </Command.Group>
 
           <Command.Group heading="Navigate">
-            <Command.Item onSelect={() => { navigate('/dashboard'); setOpen(false); }} className="px-3 py-2 hover:bg-gray-100 cursor-pointer rounded">
+            <Command.Item onSelect={() => { navigate('/home'); setOpen(false); }} className="px-3 py-2 hover:bg-gray-100 cursor-pointer rounded">
               <div className="flex items-center gap-2">
-                <span>📊</span>
-                <span>Go to Dashboard</span>
+                <span>🏠</span>
+                <span>Go to Home</span>
               </div>
             </Command.Item>
             <Command.Item onSelect={() => { navigate('/projects'); setOpen(false); }} className="px-3 py-2 hover:bg-gray-100 cursor-pointer rounded">

--- a/zephix-frontend/src/pages/admin/DEPRECATED.md
+++ b/zephix-frontend/src/pages/admin/DEPRECATED.md
@@ -1,0 +1,19 @@
+# Deprecated: pages/admin/
+
+All files in this directory are stale legacy admin pages.
+
+They were replaced by the `features/administration/pages/` module which renders under the `/administration/*` routes. The old `/admin/*` routes redirect to `/administration` in App.tsx.
+
+These files are kept temporarily to avoid breaking any hidden imports. They should be deleted once import analysis confirms zero live references.
+
+Per ADR-003: Administration is accessed from the Admin profile menu via `/administration`, not from these legacy `/admin/*` pages.
+
+Replaced by:
+- `AdministrationOverviewPage` → `/administration`
+- `AdministrationUsersPage` → `/administration/users`
+- `AdministrationWorkspacesPage` → `/administration/workspaces`
+- `AdministrationTemplatesPage` → `/administration/templates`
+- `AdministrationGovernancePage` → `/administration/governance`
+- `AdministrationAuditLogPage` → `/administration/audit`
+- `AdministrationSettingsPage` → `/administration/settings`
+- `AdministrationBillingPage` → `/administration/billing`


### PR DESCRIPTION
## Executive summary
Audit confirmed profile dropdown is ADR-003 compliant. Fixed CommandPalette stale route, documented 36 stale admin pages, and mapped all ADR-003 compliance status.

## Whole-platform impact
**Touches**: CommandPalette (1 route fix), pages/admin/ (documentation only)
**Does NOT touch**: Backend, shell sidebar, profile dropdown, dashboards, governance, risks, templates

## Audit of admin and workspace control surfaces

### ADR-003 Compliance
| Area | Status |
|------|--------|
| Profile dropdown "Administration" | **COMPLIANT** — admin-only, routes to /administration |
| Sidebar navigation | **COMPLIANT** — no Administration link |
| Home "Invite members" | **DOCUMENTED DRIFT** — routes to /administration/users |
| Sidebar "View archive/trash" | **DOCUMENTED DRIFT** — routes to /administration/workspaces |
| CommandPalette "Go to Dashboard" | **FIXED** — was /dashboard (dead route), now /home |
| 36 stale pages/admin/ files | **DOCUMENTED** — all redirected via App.tsx |

### Invite flow audit
| Entry Point | Routes To | Status |
|-------------|-----------|--------|
| Profile dropdown "Invite members" | /administration/users | Canonical |
| Home Priority Actions "Invite members" | /administration/users | ADR-003 drift (documented) |
| Workspace Members "Invite" button | WorkspaceMemberInviteModal | Workspace-level (correct) |
| AdministrationUsersPage "Invite admin" | window.prompt inline | Org-level (correct) |

### Workspace controls verified
- WorkspaceSettingsPage: 4 tabs (General, Members, Permissions, Activity)
- Distinct from org administration: yes
- Member management: accessible via sidebar sub-nav

## Files changed (2 files, +22 / -3)
| File | Change |
|------|--------|
| `CommandPalette.tsx` | /dashboard → /home, emoji update |
| `pages/admin/DEPRECATED.md` | New — documents 36 stale files + ADR-003 reference |

## Intentionally deferred
- 36 stale admin page deletions (kept for import safety)
- Home "Invite members" shortcut removal (documented drift, acceptable for MVP)
- Billing duplication (/administration/billing + SettingsPage Billing tab)
- "My profile" and "Settings" both routing to /settings (minor redundancy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)