### PR TITLE
feat(shell): Pass 2 — Favorites persistence, Shared real data, shell drift corrections

### DIFF
--- a/zephix-backend/src/app.module.ts
+++ b/zephix-backend/src/app.module.ts
@@ -73,6 +73,7 @@ import { KpisModule } from './modules/kpis/kpis.module';
 import { GovernanceRulesModule } from './modules/governance-rules/governance-rules.module';
 import { GovernanceExceptionsModule } from './modules/governance-exceptions/governance-exceptions.module';
 import { KpiQueueModule } from './modules/kpi-queue/kpi-queue.module';
+import { FavoritesModule } from './modules/favorites/favorites.module';
 import { bootLog } from './common/utils/debug-boot';
 
 if (!(global as any).crypto) {
@@ -154,6 +155,7 @@ if (!(global as any).crypto) {
           GovernanceRulesModule, // Wave 9: Governance rule engine
           GovernanceExceptionsModule, // Phase 2C: Exception request basics
           KpiQueueModule, // Wave 10: BullMQ KPI recompute, rollups, scheduling
+          FavoritesModule, // Pass 2: User favorites persistence
         ]
       : [
           HealthModule, // Keep health module for basic health checks

--- a/zephix-backend/src/migrations/18000000000060-CreateFavorites.ts
+++ b/zephix-backend/src/migrations/18000000000060-CreateFavorites.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateFavorites18000000000060 implements MigrationInterface {
+  name = 'CreateFavorites18000000000060';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "favorites" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "user_id" uuid NOT NULL,
+        "organization_id" uuid NOT NULL,
+        "item_type" varchar(50) NOT NULL,
+        "item_id" uuid NOT NULL,
+        "display_order" integer NOT NULL DEFAULT 0,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_favorites" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_favorites_user_item" UNIQUE ("user_id", "item_type", "item_id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_favorites_user_id" ON "favorites" ("user_id")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_favorites_user_org" ON "favorites" ("user_id", "organization_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "favorites"`);
+  }
+}

--- a/zephix-backend/src/modules/favorites/entities/favorite.entity.ts
+++ b/zephix-backend/src/modules/favorites/entities/favorite.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+
+export type FavoriteItemType = 'workspace' | 'project' | 'dashboard';
+
+@Entity('favorites')
+@Unique('UQ_favorites_user_item', ['userId', 'itemType', 'itemId'])
+@Index('IDX_favorites_user_id', ['userId'])
+@Index('IDX_favorites_user_org', ['userId', 'organizationId'])
+export class Favorite {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'organization_id', type: 'uuid' })
+  organizationId: string;
+
+  @Column({ name: 'item_type', type: 'varchar', length: 50 })
+  itemType: FavoriteItemType;
+
+  @Column({ name: 'item_id', type: 'uuid' })
+  itemId: string;
+
+  @Column({ name: 'display_order', type: 'int', default: 0 })
+  displayOrder: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/zephix-backend/src/modules/favorites/favorites.controller.ts
+++ b/zephix-backend/src/modules/favorites/favorites.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Query,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { FavoritesService } from './favorites.service';
+import { FavoriteItemType } from './entities/favorite.entity';
+
+const VALID_ITEM_TYPES: FavoriteItemType[] = ['workspace', 'project', 'dashboard'];
+
+@ApiTags('favorites')
+@Controller('favorites')
+@UseGuards(JwtAuthGuard)
+export class FavoritesController {
+  constructor(private readonly favoritesService: FavoritesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all favorites for the current user' })
+  @ApiResponse({ status: 200, description: 'List of favorited items' })
+  async list(@CurrentUser() user: any) {
+    const favorites = await this.favoritesService.listFavorites(
+      user.id,
+      user.organizationId,
+    );
+    return { favorites };
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Add an item to favorites' })
+  @ApiResponse({ status: 201, description: 'Item favorited' })
+  async add(
+    @CurrentUser() user: any,
+    @Body() body: { itemType: FavoriteItemType; itemId: string },
+  ) {
+    if (!body.itemType || !body.itemId) {
+      throw new BadRequestException('itemType and itemId are required');
+    }
+    if (!VALID_ITEM_TYPES.includes(body.itemType)) {
+      throw new BadRequestException(
+        `itemType must be one of: ${VALID_ITEM_TYPES.join(', ')}`,
+      );
+    }
+
+    const favorite = await this.favoritesService.addFavorite(
+      user.id,
+      user.organizationId,
+      body.itemType,
+      body.itemId,
+    );
+    return { favorite };
+  }
+
+  @Delete()
+  @ApiOperation({ summary: 'Remove an item from favorites' })
+  @ApiResponse({ status: 200, description: 'Item unfavorited' })
+  async remove(
+    @CurrentUser() user: any,
+    @Query('itemType') itemType: FavoriteItemType,
+    @Query('itemId') itemId: string,
+  ) {
+    if (!itemType || !itemId) {
+      throw new BadRequestException('itemType and itemId query params are required');
+    }
+
+    await this.favoritesService.removeFavorite(user.id, itemType, itemId);
+    return { success: true };
+  }
+}

--- a/zephix-backend/src/modules/favorites/favorites.module.ts
+++ b/zephix-backend/src/modules/favorites/favorites.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Favorite } from './entities/favorite.entity';
+import { FavoritesController } from './favorites.controller';
+import { FavoritesService } from './favorites.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Favorite])],
+  controllers: [FavoritesController],
+  providers: [FavoritesService],
+  exports: [FavoritesService],
+})
+export class FavoritesModule {}

--- a/zephix-backend/src/modules/favorites/favorites.service.ts
+++ b/zephix-backend/src/modules/favorites/favorites.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Favorite, FavoriteItemType } from './entities/favorite.entity';
+
+@Injectable()
+export class FavoritesService {
+  constructor(
+    @InjectRepository(Favorite)
+    private readonly favoritesRepo: Repository<Favorite>,
+  ) {}
+
+  async listFavorites(userId: string, organizationId: string): Promise<Favorite[]> {
+    return this.favoritesRepo.find({
+      where: { userId, organizationId },
+      order: { displayOrder: 'ASC', createdAt: 'DESC' },
+    });
+  }
+
+  async addFavorite(
+    userId: string,
+    organizationId: string,
+    itemType: FavoriteItemType,
+    itemId: string,
+  ): Promise<Favorite> {
+    // Upsert: if already favorited, return existing
+    const existing = await this.favoritesRepo.findOne({
+      where: { userId, itemType, itemId },
+    });
+    if (existing) return existing;
+
+    const maxOrder = await this.favoritesRepo
+      .createQueryBuilder('f')
+      .select('COALESCE(MAX(f.display_order), 0)', 'max')
+      .where('f.user_id = :userId', { userId })
+      .getRawOne();
+
+    const favorite = this.favoritesRepo.create({
+      userId,
+      organizationId,
+      itemType,
+      itemId,
+      displayOrder: (maxOrder?.max ?? 0) + 1,
+    });
+
+    return this.favoritesRepo.save(favorite);
+  }
+
+  async removeFavorite(
+    userId: string,
+    itemType: FavoriteItemType,
+    itemId: string,
+  ): Promise<void> {
+    await this.favoritesRepo.delete({ userId, itemType, itemId });
+  }
+
+  async isFavorited(
+    userId: string,
+    itemType: FavoriteItemType,
+    itemId: string,
+  ): Promise<boolean> {
+    const count = await this.favoritesRepo.count({
+      where: { userId, itemType, itemId },
+    });
+    return count > 0;
+  }
+}

--- a/zephix-frontend/src/components/shell/Sidebar.tsx
+++ b/zephix-frontend/src/components/shell/Sidebar.tsx
@@ -15,6 +15,10 @@ import { useAuth } from "@/state/AuthContext";
 import { isPlatformAdmin } from "@/utils/access";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { useProjects } from "@/features/projects/hooks";
+import { useFavorites, useRemoveFavorite } from "@/features/favorites/hooks";
+import type { Favorite } from "@/features/favorites/api";
+import { useQuery } from "@tanstack/react-query";
+import { listPublishedDashboards } from "@/features/dashboards/api";
 
 /* ────────────────────────────────────────────
    Sidebar — locked UX contract (Pass 1)
@@ -104,6 +108,20 @@ export function Sidebar() {
   const { data: projects } = useProjects(activeWorkspaceId, { enabled: !!activeWorkspaceId });
   const hasProjects = (projects?.length ?? 0) > 0;
 
+  // Real favorites data
+  const { data: favorites } = useFavorites();
+  const removeFavorite = useRemoveFavorite();
+  const hasFavorites = (favorites?.length ?? 0) > 0;
+
+  // Published dashboards = "Shared" content (only real sharing model that exists)
+  const { data: publishedDashboards } = useQuery({
+    queryKey: ['published-dashboards', activeWorkspaceId],
+    queryFn: () => listPublishedDashboards(activeWorkspaceId!),
+    enabled: !!activeWorkspaceId,
+    staleTime: 30_000,
+  });
+  const hasSharedItems = (publishedDashboards?.length ?? 0) > 0;
+
   // Section collapse state
   const [myTasksOpen, setMyTasksOpen] = useState(true);
   const [favoritesOpen, setFavoritesOpen] = useState(true);
@@ -187,7 +205,7 @@ export function Sidebar() {
 
         <div className="my-2 border-t border-slate-200/80" />
 
-        {/* ── Favorites ── (plus and three-dot deferred to Pass 2) */}
+        {/* ── Favorites ── real data from /favorites API */}
         <SectionHeader
           label="Favorites"
           expanded={favoritesOpen}
@@ -195,12 +213,37 @@ export function Sidebar() {
           testId="section-favorites"
         />
         {favoritesOpen && (
-          <div className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-3 text-sm text-slate-500">
-            No favorites yet.
-            <div className="mt-1 text-xs text-slate-400">
-              Add items you want quick access to after workspaces, dashboards, or projects exist.
+          hasFavorites ? (
+            <div className="ml-2 space-y-0.5" data-testid="favorites-list">
+              {favorites!.map((fav) => (
+                <FavoriteItem
+                  key={fav.id}
+                  favorite={fav}
+                  onRemove={() =>
+                    removeFavorite.mutate({
+                      itemType: fav.itemType,
+                      itemId: fav.itemId,
+                    })
+                  }
+                  onNavigate={() => {
+                    if (fav.itemType === 'workspace') navigate(`/workspaces/${fav.itemId}`);
+                    else if (fav.itemType === 'project') navigate(`/projects/${fav.itemId}`);
+                    else if (fav.itemType === 'dashboard') navigate(`/dashboards/${fav.itemId}`);
+                  }}
+                />
+              ))}
             </div>
-          </div>
+          ) : (
+            <div
+              className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-3 text-sm text-slate-500"
+              data-testid="favorites-empty"
+            >
+              No favorites yet.
+              <div className="mt-1 text-xs text-slate-400">
+                Add items you want quick access to after workspaces, dashboards, or projects exist.
+              </div>
+            </div>
+          )
         )}
 
         <div className="my-2 border-t border-slate-200/80" />
@@ -273,27 +316,38 @@ export function Sidebar() {
                     testId="section-shared"
                   />
                   {sharedOpen && (
-                    <div className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-2.5 text-xs text-slate-500">
-                      Nothing shared with you yet.
-                      <div className="mt-1 text-xs text-slate-400">
-                        Shared dashboards, projects, and docs will appear here.
+                    hasSharedItems ? (
+                      <div className="ml-2 space-y-0.5" data-testid="shared-list">
+                        {publishedDashboards!.map((d) => (
+                          <button
+                            key={d.id}
+                            type="button"
+                            onClick={() => navigate(`/dashboards/${d.id}`)}
+                            className="block w-full truncate rounded-lg px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50 transition"
+                            data-testid={`shared-item-${d.id}`}
+                          >
+                            <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
+                              Dashboard
+                            </span>
+                            {d.name}
+                          </button>
+                        ))}
                       </div>
-                    </div>
+                    ) : (
+                      <div
+                        className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-2.5 text-xs text-slate-500"
+                        data-testid="shared-empty"
+                      >
+                        Nothing shared with you yet.
+                        <div className="mt-1 text-xs text-slate-400">
+                          Published dashboards will appear here.
+                        </div>
+                      </div>
+                    )
                   )}
                 </div>
 
-                {/* Members — admin/member only */}
-                <NavLink
-                  data-testid="ws-nav-members"
-                  to={`/workspaces/${activeWorkspaceId}/members`}
-                  className={({ isActive }) =>
-                    `block rounded-lg px-3 py-1.5 text-sm transition ${
-                      isActive ? "bg-slate-100 font-medium" : "hover:bg-slate-50"
-                    }`
-                  }
-                >
-                  Members
-                </NavLink>
+                {/* Members: removed from left rail for this shell stage. Access via workspace page. */}
               </div>
             )}
 
@@ -326,5 +380,52 @@ export function Sidebar() {
         onCreated={handleWorkspaceCreated}
       />
     </aside>
+  );
+}
+
+/* ── Favorite item row ── */
+const ITEM_TYPE_LABELS: Record<string, string> = {
+  workspace: 'Workspace',
+  project: 'Project',
+  dashboard: 'Dashboard',
+};
+
+function FavoriteItem({
+  favorite,
+  onRemove,
+  onNavigate,
+}: {
+  favorite: Favorite;
+  onRemove: () => void;
+  onNavigate: () => void;
+}) {
+  return (
+    <div
+      className="group/fav flex items-center justify-between rounded-lg px-3 py-1.5 text-sm hover:bg-slate-50 transition cursor-pointer"
+      data-testid={`favorite-item-${favorite.id}`}
+    >
+      <button
+        type="button"
+        onClick={onNavigate}
+        className="flex-1 truncate text-left text-slate-700"
+      >
+        <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
+          {ITEM_TYPE_LABELS[favorite.itemType] ?? favorite.itemType}
+        </span>
+        {favorite.itemId.slice(0, 8)}…
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="ml-1 rounded p-0.5 text-slate-400 opacity-0 group-hover/fav:opacity-100 hover:bg-slate-200 hover:text-red-500 transition"
+        aria-label="Remove from favorites"
+        data-testid={`favorite-remove-${favorite.id}`}
+      >
+        <span className="text-xs">✕</span>
+      </button>
+    </div>
   );
 }

--- a/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
+++ b/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
@@ -48,11 +48,30 @@ vi.mock('@/features/projects/hooks', () => ({
   useProjects: vi.fn(),
 }));
 
+vi.mock('@/features/favorites/hooks', () => ({
+  useFavorites: vi.fn(),
+  useRemoveFavorite: vi.fn(() => ({ mutate: vi.fn() })),
+}));
+
+vi.mock('@/features/dashboards/api', () => ({
+  listPublishedDashboards: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  };
+});
+
 import { useAuth } from '@/state/AuthContext';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { useProjects } from '@/features/projects/hooks';
+import { useFavorites } from '@/features/favorites/hooks';
 
 const mockUseProjects = useProjects as ReturnType<typeof vi.fn>;
+const mockUseFavorites = useFavorites as ReturnType<typeof vi.fn>;
 
 const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
 const mockUseWorkspaceStore = useWorkspaceStore as ReturnType<typeof vi.fn>;
@@ -72,8 +91,9 @@ const VIEWER_USER = { id: '3', platformRole: 'VIEWER', role: 'viewer', email: 'v
 describe('Pass 1 — Shell locked UX contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no projects
+    // Default: no projects, no favorites
     mockUseProjects.mockReturnValue({ data: [], isLoading: false });
+    mockUseFavorites.mockReturnValue({ data: [], isLoading: false });
   });
 
   describe('Logo and Inbox', () => {
@@ -282,7 +302,7 @@ describe('Pass 1 — Shell locked UX contract', () => {
     });
   });
 
-  describe('Favorites (Pass 1.1: no management controls)', () => {
+  describe('Favorites (Pass 2: real data)', () => {
     it('Favorites section is visible', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
@@ -291,28 +311,43 @@ describe('Pass 1 — Shell locked UX contract', () => {
       expect(screen.getByTestId('section-favorites')).toBeInTheDocument();
     });
 
-    it('Favorites shows honest empty state', () => {
+    it('shows honest empty state when no favorites exist', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseFavorites.mockReturnValue({ data: [], isLoading: false });
       renderSidebar();
 
+      expect(screen.getByTestId('favorites-empty')).toBeInTheDocument();
       expect(screen.getByText('No favorites yet.')).toBeInTheDocument();
     });
 
-    it('Favorites plus is NOT present (deferred to Pass 2)', () => {
+    it('shows favorited items when favorites exist', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseFavorites.mockReturnValue({
+        data: [
+          { id: 'f1', itemType: 'workspace', itemId: 'ws-1', displayOrder: 0, createdAt: '' },
+          { id: 'f2', itemType: 'dashboard', itemId: 'dash-1', displayOrder: 1, createdAt: '' },
+        ],
+        isLoading: false,
+      });
       renderSidebar();
 
-      expect(screen.queryByTestId('section-favorites-plus')).not.toBeInTheDocument();
+      expect(screen.getByTestId('favorites-list')).toBeInTheDocument();
+      expect(screen.getByTestId('favorite-item-f1')).toBeInTheDocument();
+      expect(screen.getByTestId('favorite-item-f2')).toBeInTheDocument();
     });
 
-    it('Favorites three-dot is NOT present (deferred to Pass 2)', () => {
+    it('shows remove button on hover for each favorite', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseFavorites.mockReturnValue({
+        data: [{ id: 'f1', itemType: 'project', itemId: 'p-1', displayOrder: 0, createdAt: '' }],
+        isLoading: false,
+      });
       renderSidebar();
 
-      expect(screen.queryByTestId('section-favorites-more')).not.toBeInTheDocument();
+      expect(screen.getByTestId('favorite-remove-f1')).toBeInTheDocument();
     });
   });
 
@@ -333,6 +368,17 @@ describe('Pass 1 — Shell locked UX contract', () => {
       renderSidebar();
 
       expect(screen.queryByTestId('section-dashboards-more')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Members removal (Pass 2)', () => {
+    it('Members link is NOT in the left rail', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
+      expect(screen.queryByTestId('ws-nav-members')).not.toBeInTheDocument();
+      expect(screen.queryByText('Members')).not.toBeInTheDocument();
     });
   });
 

--- a/zephix-frontend/src/features/favorites/api.ts
+++ b/zephix-frontend/src/features/favorites/api.ts
@@ -1,0 +1,36 @@
+import { request } from '@/lib/api';
+
+export type FavoriteItemType = 'workspace' | 'project' | 'dashboard';
+
+export interface Favorite {
+  id: string;
+  userId: string;
+  organizationId: string;
+  itemType: FavoriteItemType;
+  itemId: string;
+  displayOrder: number;
+  createdAt: string;
+}
+
+export async function listFavorites(): Promise<Favorite[]> {
+  const data = await request.get<{ favorites: Favorite[] }>('/favorites');
+  return data.favorites;
+}
+
+export async function addFavorite(
+  itemType: FavoriteItemType,
+  itemId: string,
+): Promise<Favorite> {
+  const data = await request.post<{ favorite: Favorite }>('/favorites', {
+    itemType,
+    itemId,
+  });
+  return data.favorite;
+}
+
+export async function removeFavorite(
+  itemType: FavoriteItemType,
+  itemId: string,
+): Promise<void> {
+  await request.delete(`/favorites?itemType=${itemType}&itemId=${itemId}`);
+}

--- a/zephix-frontend/src/features/favorites/hooks.ts
+++ b/zephix-frontend/src/features/favorites/hooks.ts
@@ -1,0 +1,46 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/state/AuthContext';
+import {
+  listFavorites,
+  addFavorite,
+  removeFavorite,
+  type Favorite,
+  type FavoriteItemType,
+} from './api';
+
+const FAVORITES_KEY = ['favorites'] as const;
+
+export function useFavorites() {
+  const { user } = useAuth();
+
+  return useQuery<Favorite[]>({
+    queryKey: FAVORITES_KEY,
+    queryFn: listFavorites,
+    enabled: !!user?.id,
+    staleTime: 30_000,
+  });
+}
+
+export function useAddFavorite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ itemType, itemId }: { itemType: FavoriteItemType; itemId: string }) =>
+      addFavorite(itemType, itemId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: FAVORITES_KEY });
+    },
+  });
+}
+
+export function useRemoveFavorite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ itemType, itemId }: { itemType: FavoriteItemType; itemId: string }) =>
+      removeFavorite(itemType, itemId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: FAVORITES_KEY });
+    },
+  });
+}

--- a/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
+++ b/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
@@ -126,6 +126,23 @@ export function SidebarWorkspaces() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [plusMenuOpen]);
 
+  // Hide the entire workspace selector when no workspaces exist
+  // The Sidebar owns the empty-state messaging for that case
+  if (availableWorkspaces.length === 0 && !authLoading) {
+    return (
+      <div data-testid="sidebar-workspaces">
+        {/* Workspace Create Modal kept available for admin */}
+        {canCreateWorkspace && (
+          <WorkspaceCreateModal
+            open={open}
+            onClose={() => setOpen(false)}
+            onCreated={() => { refresh(); }}
+          />
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="px-2 mb-2" data-testid="sidebar-workspaces">
       {/* Workspace Dropdown and Plus Button */}
@@ -148,22 +165,17 @@ export function SidebarWorkspaces() {
               currentWorkspace
                 ? 'bg-gray-50 border-gray-300 hover:bg-gray-100'
                 : 'bg-white border-gray-300 hover:bg-gray-50'
-            } ${availableWorkspaces.length > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+            } cursor-pointer`}
             data-testid="workspace-selector"
-            disabled={availableWorkspaces.length === 0 && !canCreateWorkspace}
           >
             <span className="text-sm font-medium truncate flex-1 text-left">
               {currentWorkspace
                 ? currentWorkspace.name
-                : availableWorkspaces.length > 0
-                  ? 'Select workspace'
-                  : 'Select workspace'}
+                : 'Select workspace'}
             </span>
-            {canCreateWorkspace && availableWorkspaces.length > 0 && (
-              <ChevronDown
-                className={`h-4 w-4 text-gray-500 transition-transform flex-shrink-0 ${dropdownOpen ? 'rotate-180' : ''}`}
-              />
-            )}
+            <ChevronDown
+              className={`h-4 w-4 text-gray-500 transition-transform flex-shrink-0 ${dropdownOpen ? 'rotate-180' : ''}`}
+            />
           </button>
 
         {/* STEP 2: Dropdown menu - compact selector only, never renders full workspace list */}
@@ -304,12 +316,6 @@ export function SidebarWorkspaces() {
         />
       )}
 
-      {/* Non-admin message */}
-      {!canCreateWorkspace && availableWorkspaces.length === 0 && (
-        <div className="mt-2 px-3 py-2 text-xs text-gray-500 text-center">
-          Contact an admin to get assigned to a workspace
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Favorites backend**: New `favorites` table, entity, service, controller (GET/POST/DELETE /favorites). Supports workspace, project, dashboard item types.
- **Favorites frontend**: API client + React Query hooks + sidebar integration showing real favorited items with remove-on-hover
- **Shared section**: Now shows real published dashboards via `listPublishedDashboards()` instead of static placeholder
- **Members removed**: No longer appears in left rail (locked shell correction)
- **Workspace selector**: Hidden when no workspaces exist — honest empty state only
- **39 tests passing**, TypeScript clean (frontend + backend), Vite build clean

## Test plan

- [ ] Run migration 060 on staging DB
- [ ] `GET /favorites` returns empty array for new user
- [ ] `POST /favorites` with `{ itemType: "workspace", itemId: "<id>" }` creates favorite
- [ ] `DELETE /favorites?itemType=workspace&itemId=<id>` removes favorite
- [ ] Sidebar shows favorited items from real API
- [ ] Sidebar shows remove button on hover for each favorite
- [ ] Sidebar shows honest empty state when no favorites
- [ ] Shared section shows published dashboards if any exist
- [ ] Members link NOT visible in left rail
- [ ] Workspace selector hidden when no workspaces exist
- [ ] No regression to Inbox landing, logo, profile menu, Create Workspace, Invite Members

🤖 Generated with [Claude Code](https://claude.com/claude-code)