### PR TITLE
fix(shell): IA correction — Dashboards and Shared promoted to top-level

### DIFF
--- a/zephix-frontend/src/components/shell/Sidebar.tsx
+++ b/zephix-frontend/src/components/shell/Sidebar.tsx
@@ -268,86 +268,20 @@ export function Sidebar() {
               <SidebarWorkspaces />
             </div>
 
-            {/* Nested under Workspaces when a workspace is selected */}
-            {activeWorkspaceId && (
+            {/* Workspace-scoped children — only Projects for now */}
+            {activeWorkspaceId && hasProjects && (
               <div className="ml-2 space-y-0.5">
-                {/* Projects — only shown when at least one real project exists */}
-                {hasProjects && (
-                  <NavLink
-                    data-testid="ws-nav-projects"
-                    to="/projects"
-                    className={({ isActive }) =>
-                      `block rounded-lg px-3 py-1.5 text-sm transition ${
-                        isActive ? "bg-slate-100 font-medium" : "hover:bg-slate-50"
-                      }`
-                    }
-                  >
-                    Projects
-                  </NavLink>
-                )}
-
-                {/* ── Nested: Dashboards ── */}
-                <div className="mt-1">
-                  <SectionHeader
-                    label="Dashboards"
-                    expanded={dashboardsOpen}
-                    onToggle={() => setDashboardsOpen(!dashboardsOpen)}
-                    onPlus={() => navigate("/dashboards")}
-                    plusLabel="Open Dashboard Center"
-                    plusAlwaysVisible
-                    testId="section-dashboards"
-                  />
-                  {dashboardsOpen && (
-                    <div className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-2.5 text-xs text-slate-500">
-                      No dashboards yet.
-                      <div className="mt-1 text-xs text-slate-400">
-                        Create a dashboard after you have projects to pull data from.
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* ── Nested: Shared ── */}
-                <div className="mt-1">
-                  <SectionHeader
-                    label="Shared"
-                    expanded={sharedOpen}
-                    onToggle={() => setSharedOpen(!sharedOpen)}
-                    testId="section-shared"
-                  />
-                  {sharedOpen && (
-                    hasSharedItems ? (
-                      <div className="ml-2 space-y-0.5" data-testid="shared-list">
-                        {publishedDashboards!.map((d) => (
-                          <button
-                            key={d.id}
-                            type="button"
-                            onClick={() => navigate(`/dashboards/${d.id}`)}
-                            className="block w-full truncate rounded-lg px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50 transition"
-                            data-testid={`shared-item-${d.id}`}
-                          >
-                            <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
-                              Dashboard
-                            </span>
-                            {d.name}
-                          </button>
-                        ))}
-                      </div>
-                    ) : (
-                      <div
-                        className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-2.5 text-xs text-slate-500"
-                        data-testid="shared-empty"
-                      >
-                        Nothing shared with you yet.
-                        <div className="mt-1 text-xs text-slate-400">
-                          Published dashboards and future shared items will appear here.
-                        </div>
-                      </div>
-                    )
-                  )}
-                </div>
-
-                {/* Members: removed from left rail for this shell stage. Access via workspace page. */}
+                <NavLink
+                  data-testid="ws-nav-projects"
+                  to="/projects"
+                  className={({ isActive }) =>
+                    `block rounded-lg px-3 py-1.5 text-sm transition ${
+                      isActive ? "bg-slate-100 font-medium" : "hover:bg-slate-50"
+                    }`
+                  }
+                >
+                  Projects
+                </NavLink>
               </div>
             )}
 
@@ -371,6 +305,61 @@ export function Sidebar() {
               </div>
             )}
           </div>
+        )}
+
+        {/* ── Dashboards (top-level, always visible for Admin) ── */}
+        {isAdmin && (
+          <>
+            <div className="my-2 border-t border-slate-200/80" />
+            <SectionHeader
+              label="Dashboards"
+              expanded={dashboardsOpen}
+              onToggle={() => setDashboardsOpen(!dashboardsOpen)}
+              onPlus={() => navigate("/dashboards")}
+              plusLabel="Open Dashboard Center"
+              plusAlwaysVisible
+              testId="section-dashboards"
+            />
+            {dashboardsOpen && (
+              <div className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-2.5 text-xs text-slate-500">
+                No dashboards yet.
+                <div className="mt-1 text-xs text-slate-400">
+                  Create a dashboard after you have projects to pull data from.
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* ── Shared (top-level, visible only when real shared items exist) ── */}
+        {hasSharedItems && (
+          <>
+            <div className="my-2 border-t border-slate-200/80" />
+            <SectionHeader
+              label="Shared"
+              expanded={sharedOpen}
+              onToggle={() => setSharedOpen(!sharedOpen)}
+              testId="section-shared"
+            />
+            {sharedOpen && (
+              <div className="ml-2 space-y-0.5" data-testid="shared-list">
+                {publishedDashboards!.map((d) => (
+                  <button
+                    key={d.id}
+                    type="button"
+                    onClick={() => navigate(`/dashboards/${d.id}`)}
+                    className="block w-full truncate rounded-lg px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50 transition"
+                    data-testid={`shared-item-${d.id}`}
+                  >
+                    <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
+                      Dashboard
+                    </span>
+                    {d.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </>
         )}
       </nav>
 

--- a/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
+++ b/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
@@ -264,40 +264,69 @@ describe('Pass 1 — Shell locked UX contract', () => {
     });
   });
 
-  describe('Nested Dashboards and Shared under Workspaces', () => {
-    it('Dashboards section appears when workspace is selected', () => {
+  describe('Dashboards (top-level, IA correction)', () => {
+    it('Dashboards is a top-level section for Admin (always visible)', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
-      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
       renderSidebar();
 
       expect(screen.getByTestId('section-dashboards')).toBeInTheDocument();
     });
 
-    it('Dashboards plus is always visible when workspace selected', () => {
-      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
-      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });
-      renderSidebar();
-
-      const plus = screen.getByTestId('section-dashboards-plus');
-      expect(plus).toBeInTheDocument();
-      // plusAlwaysVisible means opacity-100 (not hidden behind hover)
-      expect(plus.className).toContain('opacity-100');
-    });
-
-    it('Shared section appears when workspace is selected', () => {
-      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
-      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });
-      renderSidebar();
-
-      expect(screen.getByTestId('section-shared')).toBeInTheDocument();
-    });
-
-    it('Dashboards and Shared do NOT appear without workspace', () => {
+    it('Dashboards is visible for Admin even without workspace selected', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
       renderSidebar();
 
+      expect(screen.getByTestId('section-dashboards')).toBeInTheDocument();
+    });
+
+    it('Dashboards plus is always visible for Admin', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
+      const plus = screen.getByTestId('section-dashboards-plus');
+      expect(plus).toBeInTheDocument();
+      expect(plus.className).toContain('opacity-100');
+    });
+
+    it('Dashboards is NOT visible for non-admin (Member)', () => {
+      mockUseAuth.mockReturnValue({ user: MEMBER_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
       expect(screen.queryByTestId('section-dashboards')).not.toBeInTheDocument();
+    });
+
+    it('Dashboards visible without workspace proves it is not nested under Workspaces', () => {
+      // If Dashboards were nested under Workspaces, it would only appear when
+      // activeWorkspaceId is set. The "visible without workspace" test above
+      // already proves Dashboards is a top-level independent section.
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
+      expect(screen.getByTestId('section-dashboards')).toBeInTheDocument();
+      // Workspaces expanded content should not exist (no workspace selected)
+      expect(screen.queryByTestId('ws-nav-projects')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Shared (top-level, visibility-based)', () => {
+    it('Shared does NOT appear when no shared items exist', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
+      expect(screen.queryByTestId('section-shared')).not.toBeInTheDocument();
+    });
+
+    it('Shared does NOT appear without workspace selected', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
       expect(screen.queryByTestId('section-shared')).not.toBeInTheDocument();
     });
   });
@@ -351,17 +380,15 @@ describe('Pass 1 — Shell locked UX contract', () => {
     });
   });
 
-  describe('Shared (Pass 1.1: no management controls)', () => {
-    it('Shared three-dot is NOT present (deferred to Pass 2)', () => {
+  describe('No management controls on Shared or Dashboards', () => {
+    it('Shared three-dot is NOT present', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });
       renderSidebar();
 
       expect(screen.queryByTestId('section-shared-more')).not.toBeInTheDocument();
     });
-  });
 
-  describe('Dashboards (Pass 1.1: three-dot removed)', () => {
     it('Dashboards three-dot is NOT present', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: 'ws-1', setActiveWorkspace: vi.fn() });


### PR DESCRIPTION
## Summary

- **Dashboards**: moved from nested under Workspaces to standalone top-level (always visible for Admin)
- **Shared**: moved from nested under Workspaces to standalone top-level (visible only when shared items exist)
- **Workspaces children**: only Projects (when real projects exist) — no nested Dashboards or Shared
- Left rail now matches locked Zephix IA: Inbox → My Tasks → Favorites → Workspaces → Dashboards → Shared

## Test plan

- [ ] Admin sees: Inbox, My Tasks, Favorites, Workspaces, Dashboards (always)
- [ ] Shared appears only when published dashboards exist
- [ ] Dashboards visible for Admin even without workspace selected
- [ ] Dashboards NOT visible for Member
- [ ] No Dashboards or Shared nested under Workspaces
- [ ] Workspace click still opens workspace dashboard
- [ ] No regression to Inbox landing, Favorites, Create Workspace, Invite Members

🤖 Generated with [Claude Code](https://claude.com/claude-code)