### PR TITLE
feat(dashboard): Pass 3 — dashboard shell, directory, creation flow, Add Card modal

### DIFF
--- a/zephix-frontend/src/App.tsx
+++ b/zephix-frontend/src/App.tsx
@@ -209,12 +209,14 @@ export default function App() {
               <Route path="/admin/*" element={<RequireAdminInline><Navigate to="/administration" replace /></RequireAdminInline>} />
               <Route path="/org-dashboard" element={<RequireAdminInline><OrgDashboardPage /></RequireAdminInline>} />
 
-              {/* ── Workspace-scoped routes (redirect to /home if none selected) ── */}
+              {/* Pass 3: Dashboards directory — Org Admin standalone surface (no workspace required) */}
+              <Route path="/dashboards" element={<RequireAdminInline><DashboardsIndex /></RequireAdminInline>} />
+
+              {/* ── Workspace-scoped routes (redirect to /inbox if none selected) ── */}
               <Route element={<RequireWorkspace />}>
                 <Route path="/reports" element={<Navigate to="/analytics" replace />} />
                 {/* Phase 2D: /risks standalone page retired — risks live inside projects. Use /projects/:id/risks */}
                 <Route path="/risks" element={<Navigate to="/workspaces" replace />} />
-                <Route path="/dashboards" element={<DashboardsIndex />} />
                 <Route path="/dashboards/:id" element={<DashboardView />} />
                 <Route path="/dashboards/:id/edit" element={<DashboardBuilder />} />
                 <Route path="/projects" element={<ProjectsPage />} />

--- a/zephix-frontend/src/features/dashboards/AddCardModal.tsx
+++ b/zephix-frontend/src/features/dashboards/AddCardModal.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { widgetRegistry, getWidgetsByCategory } from "./widget-registry";
+import type { WidgetType } from "./types";
+
+interface AddCardModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (widgetType: WidgetType) => void;
+}
+
+/**
+ * Pass 3: Add Card modal — real widget selection from the widget registry.
+ * Modal-based per locked spec. Every visible category and tile is backed by
+ * a real widget type in the registry.
+ */
+export function AddCardModal({ open, onClose, onSelect }: AddCardModalProps) {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const categories = getWidgetsByCategory();
+  const categoryNames = Object.keys(categories);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto" data-testid="add-card-modal">
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="fixed inset-0 bg-slate-900/20 backdrop-blur-sm" onClick={onClose} />
+
+        <div className="relative w-full max-w-lg rounded-2xl border border-slate-200 bg-white shadow-xl">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+            <h2 className="text-lg font-semibold text-slate-900">Add Card</h2>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition"
+              data-testid="add-card-close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* Category tabs */}
+          <div className="flex gap-1 border-b border-slate-200 px-6">
+            <button
+              onClick={() => setSelectedCategory(null)}
+              className={`px-3 py-2.5 text-xs font-medium transition ${
+                selectedCategory === null
+                  ? "border-b-2 border-blue-600 text-blue-600"
+                  : "text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              All
+            </button>
+            {categoryNames.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategory(cat)}
+                className={`px-3 py-2.5 text-xs font-medium transition ${
+                  selectedCategory === cat
+                    ? "border-b-2 border-blue-600 text-blue-600"
+                    : "text-slate-500 hover:text-slate-700"
+                }`}
+                data-testid={`card-category-${cat.toLowerCase()}`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+
+          {/* Widget tiles */}
+          <div className="max-h-80 overflow-y-auto p-4">
+            <div className="grid grid-cols-2 gap-3">
+              {categoryNames
+                .filter((cat) => !selectedCategory || cat === selectedCategory)
+                .flatMap((cat) =>
+                  categories[cat].map((type) => {
+                    const entry = widgetRegistry[type];
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => {
+                          onSelect(type);
+                          onClose();
+                        }}
+                        className="rounded-xl border border-slate-200 bg-white p-4 text-left transition hover:border-blue-300 hover:shadow-sm"
+                        data-testid={`card-tile-${type}`}
+                      >
+                        <div className="text-[10px] font-medium uppercase tracking-wider text-slate-400">
+                          {entry.category}
+                        </div>
+                        <div className="mt-1 text-sm font-medium text-slate-900">
+                          {entry.displayName}
+                        </div>
+                        <div className="mt-0.5 text-xs text-slate-500 line-clamp-2">
+                          {entry.description}
+                        </div>
+                      </button>
+                    );
+                  })
+                )}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="border-t border-slate-200 px-6 py-3">
+            <p className="text-xs text-slate-400">
+              Cards inherit the dashboard source scope. Data populates as project data becomes available.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/zephix-frontend/src/features/dashboards/AddCardModal.tsx
+++ b/zephix-frontend/src/features/dashboards/AddCardModal.tsx
@@ -10,14 +10,37 @@ interface AddCardModalProps {
 }
 
 /**
- * Pass 3: Add Card modal — real widget selection from the widget registry.
- * Modal-based per locked spec. Every visible category and tile is backed by
- * a real widget type in the registry.
+ * Zephix-ready category mapping.
+ * Only categories approved for this pass are shown.
+ * Backend category names are relabeled to Zephix user-facing language.
+ * Portfolio category hidden (feature-flagged, future-state breadth).
  */
+const ZEPHIX_CATEGORIES: Record<string, string> = {
+  Analytics: "Project Health",
+  Resources: "Resources",
+  Finance: "Finance",
+  Risk: "Risk",
+  Schedule: "Schedule",
+  // Portfolio: hidden — feature-flagged, not Zephix-ready for this pass
+};
+
 export function AddCardModal({ open, onClose, onSelect }: AddCardModalProps) {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const categories = getWidgetsByCategory();
+  const allCategories = getWidgetsByCategory();
+
+  // Filter to only Zephix-approved categories
+  const categories = Object.entries(allCategories)
+    .filter(([cat]) => cat in ZEPHIX_CATEGORIES)
+    .reduce<Record<string, WidgetType[]>>((acc, [cat, types]) => {
+      acc[cat] = types;
+      return acc;
+    }, {});
+
   const categoryNames = Object.keys(categories);
+
+  function zephixLabel(backendCategory: string): string {
+    return ZEPHIX_CATEGORIES[backendCategory] ?? backendCategory;
+  }
 
   if (!open) return null;
 
@@ -39,11 +62,11 @@ export function AddCardModal({ open, onClose, onSelect }: AddCardModalProps) {
             </button>
           </div>
 
-          {/* Category tabs */}
-          <div className="flex gap-1 border-b border-slate-200 px-6">
+          {/* Category tabs — Zephix labels */}
+          <div className="flex gap-1 border-b border-slate-200 px-6 overflow-x-auto">
             <button
               onClick={() => setSelectedCategory(null)}
-              className={`px-3 py-2.5 text-xs font-medium transition ${
+              className={`shrink-0 px-3 py-2.5 text-xs font-medium transition ${
                 selectedCategory === null
                   ? "border-b-2 border-blue-600 text-blue-600"
                   : "text-slate-500 hover:text-slate-700"
@@ -55,14 +78,14 @@ export function AddCardModal({ open, onClose, onSelect }: AddCardModalProps) {
               <button
                 key={cat}
                 onClick={() => setSelectedCategory(cat)}
-                className={`px-3 py-2.5 text-xs font-medium transition ${
+                className={`shrink-0 px-3 py-2.5 text-xs font-medium transition ${
                   selectedCategory === cat
                     ? "border-b-2 border-blue-600 text-blue-600"
                     : "text-slate-500 hover:text-slate-700"
                 }`}
                 data-testid={`card-category-${cat.toLowerCase()}`}
               >
-                {cat}
+                {zephixLabel(cat)}
               </button>
             ))}
           </div>
@@ -87,7 +110,7 @@ export function AddCardModal({ open, onClose, onSelect }: AddCardModalProps) {
                         data-testid={`card-tile-${type}`}
                       >
                         <div className="text-[10px] font-medium uppercase tracking-wider text-slate-400">
-                          {entry.category}
+                          {zephixLabel(entry.category)}
                         </div>
                         <div className="mt-1 text-sm font-medium text-slate-900">
                           {entry.displayName}

--- a/zephix-frontend/src/features/dashboards/DashboardCreateModal.tsx
+++ b/zephix-frontend/src/features/dashboards/DashboardCreateModal.tsx
@@ -1,45 +1,27 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { api } from "@/lib/api";
+import { useWorkspaceStore } from "@/state/workspace.store";
+import { createDashboard } from "./api";
 import { X } from "lucide-react";
+import { track } from "@/lib/telemetry";
 
 interface DashboardCreateModalProps {
   open: boolean;
   onClose: () => void;
 }
 
-interface Template {
-  id: string;
-  name: string;
-  description?: string;
-}
-
+/**
+ * Pass 3: Dashboard creation flow — locked spec.
+ * Step 1: Name
+ * Step 2: Source scope (workspace only for now — workspace is the only real scope)
+ * Step 3: Create and route to empty dashboard shell
+ */
 export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProps) {
   const navigate = useNavigate();
+  const { activeWorkspaceId } = useWorkspaceStore();
   const [name, setName] = useState("");
-  const [visibility, setVisibility] = useState<"workspace" | "private">("workspace");
-  const [scope, setScope] = useState<"workspace" | "org">("workspace");
-  const [startWith, setStartWith] = useState<"blank" | "template">("blank");
-  const [templateId, setTemplateId] = useState<string>("");
-  const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Load templates when startWith changes to "template"
-  useEffect(() => {
-    if (startWith === "template" && templates.length === 0) {
-      loadTemplates();
-    }
-  }, [startWith, templates.length]);
-
-  const loadTemplates = async () => {
-    try {
-      const response = await api.get(`/api/templates?scope=${scope}`);
-      setTemplates(response.data?.data || []);
-    } catch (error) {
-      console.error("Failed to load templates:", error);
-    }
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -49,26 +31,17 @@ export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProp
     setError(null);
 
     try {
-      const payload = {
+      const dashboard = await createDashboard({
         name: name.trim(),
-        visibility,
-        scope,
-        templateId: startWith === "template" ? templateId : undefined,
-      };
-
-      const response = await api.post("/api/dashboards", payload, {
-        headers: {
-          "Idempotency-Key": crypto.randomUUID(),
-        },
+        visibility: "WORKSPACE",
+        workspaceId: activeWorkspaceId || undefined,
       });
 
-      const dashboardId = response.data?.data?.id;
-      if (dashboardId) {
-        navigate(`/dashboards/${dashboardId}/edit`);
-        onClose();
-      }
+      track("dashboard.created", { dashboardId: dashboard.id, scope: "workspace" });
+      navigate(`/dashboards/${dashboard.id}/edit`);
+      handleClose();
     } catch (err: any) {
-      setError(err?.response?.data?.message || "Failed to create dashboard");
+      setError(err?.response?.data?.message || err?.message || "Failed to create dashboard");
     } finally {
       setLoading(false);
     }
@@ -76,10 +49,6 @@ export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProp
 
   const handleClose = () => {
     setName("");
-    setVisibility("workspace");
-    setScope("workspace");
-    setStartWith("blank");
-    setTemplateId("");
     setError(null);
     onClose();
   };
@@ -89,30 +58,31 @@ export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProp
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto" data-testid="dashboard-create-modal">
       <div className="flex min-h-screen items-center justify-center p-4">
-        <div className="fixed inset-0 bg-black bg-opacity-25" onClick={handleClose} />
-        
-        <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Create Dashboard</h2>
+        <div className="fixed inset-0 bg-slate-900/20 backdrop-blur-sm" onClick={handleClose} />
+
+        <div className="relative w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
+          <div className="flex items-center justify-between mb-5">
+            <h2 className="text-lg font-semibold text-slate-900">Create Dashboard</h2>
             <button
               onClick={handleClose}
-              className="text-gray-400 hover:text-gray-600"
+              className="rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition"
               data-testid="modal-close"
             >
-              <X className="w-5 h-5" />
+              <X className="h-4 w-4" />
             </button>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-5">
             {error && (
-              <div className="bg-red-50 border border-red-200 rounded-md p-3">
+              <div className="rounded-lg border border-red-200 bg-red-50 p-3">
                 <p className="text-sm text-red-800">{error}</p>
               </div>
             )}
 
+            {/* Step 1: Name */}
             <div>
-              <label htmlFor="dashboard-name" className="block text-sm font-medium text-gray-700 mb-1">
-                Name *
+              <label htmlFor="dashboard-name" className="block text-sm font-medium text-slate-700 mb-1.5">
+                Dashboard name
               </label>
               <input
                 id="dashboard-name"
@@ -120,87 +90,43 @@ export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProp
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="Enter dashboard name"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                placeholder="e.g. Project Health Overview"
+                className="w-full rounded-lg border border-slate-200 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                autoFocus
                 required
               />
             </div>
 
+            {/* Step 2: Source scope — workspace is the only real scope */}
             <div>
-              <label htmlFor="dashboard-visibility" className="block text-sm font-medium text-gray-700 mb-1">
-                Visibility
+              <label className="block text-sm font-medium text-slate-700 mb-1.5">
+                Source scope
               </label>
-              <select
-                id="dashboard-visibility"
-                data-testid="dashboard-visibility"
-                value={visibility}
-                onChange={(e) => setVisibility(e.target.value as "workspace" | "private")}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-              >
-                <option value="workspace">Workspace</option>
-                <option value="private">Private</option>
-              </select>
+              <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-3">
+                <div className="flex items-center gap-2">
+                  <div className="h-2 w-2 rounded-full bg-blue-600" />
+                  <span className="text-sm font-medium text-slate-800">Workspace</span>
+                </div>
+                <p className="mt-1 text-xs text-slate-500">
+                  Dashboard cards will pull data from the active workspace.
+                </p>
+              </div>
             </div>
 
-            <div>
-              <label htmlFor="dashboard-scope" className="block text-sm font-medium text-gray-700 mb-1">
-                Scope
-              </label>
-              <select
-                id="dashboard-scope"
-                data-testid="dashboard-scope"
-                value={scope}
-                onChange={(e) => setScope(e.target.value as "workspace" | "org")}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-              >
-                <option value="workspace">Workspace</option>
-                <option value="org">Organization</option>
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="dashboard-start-with" className="block text-sm font-medium text-gray-700 mb-1">
-                Start with
-              </label>
-              <select
-                id="dashboard-start-with"
-                data-testid="dashboard-start-with"
-                value={startWith}
-                onChange={(e) => setStartWith(e.target.value as "blank" | "template")}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-              >
-                <option value="blank">Blank</option>
-                <option value="template">Template</option>
-              </select>
-            </div>
-
-            {startWith === "template" && (
-              <div>
-                <label htmlFor="dashboard-template" className="block text-sm font-medium text-gray-700 mb-1">
-                  Template
-                </label>
-                <select
-                  id="dashboard-template"
-                  data-testid="dashboard-template"
-                  value={templateId}
-                  onChange={(e) => setTemplateId(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                >
-                  <option value="">Select a template</option>
-                  {templates.map((template) => (
-                    <option key={template.id} value={template.id}>
-                      {template.name}
-                    </option>
-                  ))}
-                </select>
+            {!activeWorkspaceId && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+                <p className="text-xs text-amber-800">
+                  Select a workspace in the sidebar first. The dashboard will be scoped to that workspace.
+                </p>
               </div>
             )}
 
-            <div className="flex justify-end space-x-3 pt-4">
+            {/* Step 3: Create */}
+            <div className="flex justify-end gap-3 pt-2">
               <button
                 type="button"
                 onClick={handleClose}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 transition"
               >
                 Cancel
               </button>
@@ -208,9 +134,9 @@ export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProp
                 type="submit"
                 data-testid="dashboard-submit"
                 disabled={!name.trim() || loading}
-                className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition"
               >
-                {loading ? "Creating..." : "Create"}
+                {loading ? "Creating..." : "Create Dashboard"}
               </button>
             </div>
           </form>

--- a/zephix-frontend/src/features/dashboards/DashboardCreateModal.tsx
+++ b/zephix-frontend/src/features/dashboards/DashboardCreateModal.tsx
@@ -38,7 +38,7 @@ export function DashboardCreateModal({ open, onClose }: DashboardCreateModalProp
       });
 
       track("dashboard.created", { dashboardId: dashboard.id, scope: "workspace" });
-      navigate(`/dashboards/${dashboard.id}/edit`);
+      navigate(`/dashboards/${dashboard.id}`);
       handleClose();
     } catch (err: any) {
       setError(err?.response?.data?.message || err?.message || "Failed to create dashboard");

--- a/zephix-frontend/src/features/dashboards/__tests__/AddCardModal.test.tsx
+++ b/zephix-frontend/src/features/dashboards/__tests__/AddCardModal.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { AddCardModal } from '../AddCardModal';
+
+describe('AddCardModal (Pass 3)', () => {
+  const onClose = vi.fn();
+  const onSelect = vi.fn();
+
+  it('renders when open', () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    expect(screen.getByTestId('add-card-modal')).toBeInTheDocument();
+    expect(screen.getByText('Add Card')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(<AddCardModal open={false} onClose={onClose} onSelect={onSelect} />);
+    expect(screen.queryByTestId('add-card-modal')).not.toBeInTheDocument();
+  });
+
+  it('shows real widget categories from registry', () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    expect(screen.getByTestId('card-category-analytics')).toBeInTheDocument();
+    expect(screen.getByTestId('card-category-resources')).toBeInTheDocument();
+  });
+
+  it('shows real widget tiles with descriptions', () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    expect(screen.getByTestId('card-tile-project_health')).toBeInTheDocument();
+    expect(screen.getByText('Project Health')).toBeInTheDocument();
+    expect(screen.getByText('Shows project health metrics and status')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when tile is clicked', async () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    await userEvent.click(screen.getByTestId('card-tile-project_health'));
+    expect(onSelect).toHaveBeenCalledWith('project_health');
+  });
+
+  it('close button calls onClose', async () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    await userEvent.click(screen.getByTestId('add-card-close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('has no placeholder or fake content', () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder/i)).not.toBeInTheDocument();
+  });
+});

--- a/zephix-frontend/src/features/dashboards/__tests__/AddCardModal.test.tsx
+++ b/zephix-frontend/src/features/dashboards/__tests__/AddCardModal.test.tsx
@@ -18,17 +18,30 @@ describe('AddCardModal (Pass 3)', () => {
     expect(screen.queryByTestId('add-card-modal')).not.toBeInTheDocument();
   });
 
-  it('shows real widget categories from registry', () => {
+  it('shows Zephix-labeled categories (not raw backend names)', () => {
     render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
-    expect(screen.getByTestId('card-category-analytics')).toBeInTheDocument();
+    // Analytics relabeled to "Project Health"
+    const analyticsTab = screen.getByTestId('card-category-analytics');
+    expect(analyticsTab).toBeInTheDocument();
+    expect(analyticsTab.textContent).toBe('Project Health');
+    // Resources kept as-is
     expect(screen.getByTestId('card-category-resources')).toBeInTheDocument();
+  });
+
+  it('hides Portfolio category (feature-flagged, not Zephix-ready)', () => {
+    render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
+    expect(screen.queryByTestId('card-category-portfolio')).not.toBeInTheDocument();
+    // Portfolio widget tiles should also be hidden
+    expect(screen.queryByTestId('card-tile-portfolio_summary')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('card-tile-program_summary')).not.toBeInTheDocument();
   });
 
   it('shows real widget tiles with descriptions', () => {
     render(<AddCardModal open={true} onClose={onClose} onSelect={onSelect} />);
-    expect(screen.getByTestId('card-tile-project_health')).toBeInTheDocument();
-    expect(screen.getByText('Project Health')).toBeInTheDocument();
-    expect(screen.getByText('Shows project health metrics and status')).toBeInTheDocument();
+    const tile = screen.getByTestId('card-tile-project_health');
+    expect(tile).toBeInTheDocument();
+    expect(tile.textContent).toContain('Project Health');
+    expect(tile.textContent).toContain('Shows project health metrics and status');
   });
 
   it('calls onSelect when tile is clicked', async () => {

--- a/zephix-frontend/src/pages/workspaces/WorkspaceHomePage.tsx
+++ b/zephix-frontend/src/pages/workspaces/WorkspaceHomePage.tsx
@@ -5,6 +5,7 @@ import { useWorkspaceRole } from "@/hooks/useWorkspaceRole";
 import { toast } from "sonner";
 import { useWorkspaceVisitTracker } from "@/hooks/useWorkspaceVisitTracker";
 import { useWorkspaceStore } from "@/state/workspace.store";
+import { Plus, LayoutDashboard } from "lucide-react";
 
 export default function WorkspaceHomePage() {
   const { workspaceId } = useParams();
@@ -21,16 +22,12 @@ export default function WorkspaceHomePage() {
 
   useEffect(() => {
     if (!workspaceId) return;
-
     setActiveWorkspace(workspaceId);
     loadData();
   }, [workspaceId, setActiveWorkspace]);
 
-  // Track workspace visits for /home page
   useWorkspaceVisitTracker(
-    ws && ws.slug
-      ? { id: ws.id, slug: ws.slug, name: ws.name }
-      : null
+    ws && ws.slug ? { id: ws.id, slug: ws.slug, name: ws.name } : null
   );
 
   const loadData = async () => {
@@ -54,7 +51,6 @@ export default function WorkspaceHomePage() {
 
   const handleSaveAbout = async () => {
     if (!workspaceId) return;
-
     setSavingAbout(true);
     try {
       const updated = await updateWorkspace(workspaceId, { description: aboutText });
@@ -71,52 +67,66 @@ export default function WorkspaceHomePage() {
   if (!workspaceId) {
     return (
       <div className="p-6">
-        <div className="text-lg font-semibold">Workspace not found</div>
+        <div className="text-lg font-semibold text-slate-900">Workspace not found</div>
         <Link className="text-blue-600" to="/workspaces">Back to workspaces</Link>
       </div>
     );
   }
 
   if (loading) {
-    return <div className="p-6">Loading...</div>;
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-blue-600 border-r-transparent" />
+      </div>
+    );
   }
 
   if (err) {
     return (
       <div className="p-6">
-        <div className="text-lg font-semibold">Error</div>
-        <div className="mt-2 text-sm text-muted-foreground">{err}</div>
-        <button
-          onClick={loadData}
-          className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-        >
+        <div className="text-lg font-semibold text-slate-900">Error</div>
+        <div className="mt-2 text-sm text-slate-500">{err}</div>
+        <button onClick={loadData} className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">
           Retry
         </button>
-        <Link className="mt-4 ml-4 inline-block text-blue-600" to="/workspaces">Back to workspaces</Link>
       </div>
     );
   }
 
-  if (!ws) {
-    return <div className="p-6">Workspace not found</div>;
-  }
+  if (!ws) return <div className="p-6 text-slate-500">Workspace not found</div>;
 
   const isOwnerOrAdmin = role === "OWNER" || role === "ADMIN";
+  const hasProjects = (summary?.projectsTotal ?? 0) > 0;
 
   return (
-    <div className="p-6">
-      <div className="text-2xl font-semibold">{ws.name}</div>
-      <div className="mt-2 text-sm text-muted-foreground">Workspace home</div>
-
-      {/* About Section */}
-      <div className="mt-6 rounded-lg border p-4">
-        <div className="flex items-center justify-between mb-2">
-          <div className="font-medium">About</div>
-          {isOwnerOrAdmin && !editingAbout && (
+    <div className="mx-auto max-w-6xl p-6 space-y-6" data-testid="workspace-dashboard">
+      {/* Dashboard header */}
+      <header className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{ws.name}</h1>
+          <p className="mt-1 text-sm text-slate-500">Workspace dashboard</p>
+        </div>
+        {isOwnerOrAdmin && (
+          <div className="flex gap-2">
             <button
-              onClick={() => setEditingAbout(true)}
-              className="text-sm text-blue-600 hover:text-blue-700"
+              type="button"
+              onClick={() => navigate("/dashboards")}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 transition"
+              data-testid="ws-dashboard-manage"
             >
+              <LayoutDashboard className="h-4 w-4" />
+              Manage Dashboards
+            </button>
+          </div>
+        )}
+      </header>
+
+      {/* About section */}
+      <section className="rounded-xl border border-slate-200 bg-white p-5">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-sm font-semibold text-slate-900">About</h2>
+          {isOwnerOrAdmin && !editingAbout && (
+            <button onClick={() => setEditingAbout(true)} className="text-xs text-blue-600 hover:text-blue-700">
               Edit
             </button>
           )}
@@ -126,114 +136,71 @@ export default function WorkspaceHomePage() {
             <textarea
               value={aboutText}
               onChange={(e) => setAboutText(e.target.value)}
-              className="w-full p-2 border rounded text-sm"
+              className="w-full rounded-lg border border-slate-200 p-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               rows={3}
-              placeholder="Add a short intro for your team"
+              placeholder="Describe this workspace for your team"
             />
             <div className="flex gap-2">
-              <button
-                onClick={handleSaveAbout}
-                disabled={savingAbout}
-                className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
-              >
+              <button onClick={handleSaveAbout} disabled={savingAbout}
+                className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50">
                 {savingAbout ? "Saving..." : "Save"}
               </button>
-              <button
-                onClick={() => {
-                  setEditingAbout(false);
-                  setAboutText(ws.description || "");
-                }}
-                className="px-3 py-1 border text-sm rounded hover:bg-gray-50"
-              >
+              <button onClick={() => { setEditingAbout(false); setAboutText(ws.description || ""); }}
+                className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50">
                 Cancel
               </button>
             </div>
           </div>
         ) : (
-          <div className="text-sm text-muted-foreground">
-            {ws.description || "Add a short intro for your team"}
-          </div>
+          <p className="text-sm text-slate-500">{ws.description || "Add a description for your team"}</p>
         )}
-      </div>
+      </section>
 
-      {/* KPI Tiles */}
-      <div className="mt-6 grid grid-cols-4 gap-4">
-        <div className="rounded-lg border p-4">
-          <div className="text-sm text-muted-foreground mb-1">Total projects</div>
-          <div className="text-2xl font-semibold">{summary?.projectsTotal || 0}</div>
+      {/* KPI overview — real data from workspace summary, empty shells when no data */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Overview</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <KpiShell label="Projects" value={summary?.projectsTotal} hasData={hasProjects} />
+          <KpiShell label="In Progress" value={summary?.projectsInProgress} hasData={hasProjects} />
+          <KpiShell label="Tasks" value={summary?.tasksTotal} hasData={hasProjects} />
+          <KpiShell label="Completed" value={summary?.tasksCompleted} hasData={hasProjects} />
         </div>
-        <div className="rounded-lg border p-4">
-          <div className="text-sm text-muted-foreground mb-1">Projects in progress</div>
-          <div className="text-2xl font-semibold">{summary?.projectsInProgress || 0}</div>
-        </div>
-        <div className="rounded-lg border p-4">
-          <div className="text-sm text-muted-foreground mb-1">Total tasks</div>
-          <div className="text-2xl font-semibold">{summary?.tasksTotal || 0}</div>
-        </div>
-        <div className="rounded-lg border p-4">
-          <div className="text-sm text-muted-foreground mb-1">Tasks completed</div>
-          <div className="text-2xl font-semibold">{summary?.tasksCompleted || 0}</div>
-        </div>
-      </div>
+      </section>
 
-      {/* Projects Section */}
-      <div className="mt-6 rounded-lg border p-4">
-        <div className="font-medium mb-2">Projects</div>
-        <div className="mt-4 text-center py-8">
-          <div className="text-sm text-muted-foreground mb-4">
-            No projects yet
+      {/* Empty state guidance when no projects */}
+      {!hasProjects && (
+        <section className="rounded-xl border border-dashed border-slate-300 bg-slate-50/50 p-8 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-slate-100 text-slate-400">
+            <LayoutDashboard className="h-6 w-6" />
           </div>
-          <Link
-            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-            to="/templates"
-          >
-            Open Template Center
-          </Link>
-        </div>
-      </div>
+          <h3 className="mt-4 text-sm font-semibold text-slate-900">Dashboard cards will appear here</h3>
+          <p className="mx-auto mt-1 max-w-md text-sm text-slate-500">
+            Create a project from Template Center to start generating data. KPI cards will populate automatically as project data becomes available.
+          </p>
+          {isOwnerOrAdmin && (
+            <Link
+              to="/templates"
+              className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition"
+            >
+              <Plus className="h-4 w-4" />
+              Create from Template
+            </Link>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
 
-      {/* Quick Actions */}
-      <div className="mt-6 rounded-lg border p-4">
-        <div className="font-medium mb-4">Quick Actions</div>
-        <div className="flex gap-3">
-          <button
-            onClick={async () => {
-              if (!workspaceId) {
-                toast.error("Workspace ID required");
-                return;
-              }
-              try {
-                const { createDoc } = await import("@/features/docs/api");
-                const docId = await createDoc(workspaceId, "Untitled");
-                navigate(`/docs/${docId}`);
-              } catch (e: any) {
-                toast.error(e?.message || "Failed to create doc");
-              }
-            }}
-            className="px-4 py-2 bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors"
-          >
-            New doc
-          </button>
-          <button
-            onClick={async () => {
-              if (!workspaceId) {
-                toast.error("Workspace ID required");
-                return;
-              }
-              try {
-                const { createForm } = await import("@/features/forms/api");
-                const formId = await createForm(workspaceId, "Untitled");
-                navigate(`/forms/${formId}/edit`);
-              } catch (e: any) {
-                toast.error(e?.message || "Failed to create form");
-              }
-            }}
-            className="px-4 py-2 bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors"
-          >
-            New form
-          </button>
-        </div>
-      </div>
+function KpiShell({ label, value, hasData }: { label: string; value?: number; hasData: boolean }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4" data-testid={`kpi-${label.toLowerCase().replace(/\s/g, '-')}`}>
+      <div className="text-xs font-medium text-slate-400 uppercase tracking-wider">{label}</div>
+      {hasData ? (
+        <div className="mt-1 text-2xl font-semibold text-slate-900">{value ?? 0}</div>
+      ) : (
+        <div className="mt-1 text-lg font-medium text-slate-300">&mdash;</div>
+      )}
     </div>
   );
 }

--- a/zephix-frontend/src/pages/workspaces/WorkspaceHomePage.tsx
+++ b/zephix-frontend/src/pages/workspaces/WorkspaceHomePage.tsx
@@ -100,25 +100,10 @@ export default function WorkspaceHomePage() {
 
   return (
     <div className="mx-auto max-w-6xl p-6 space-y-6" data-testid="workspace-dashboard">
-      {/* Dashboard header */}
-      <header className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{ws.name}</h1>
-          <p className="mt-1 text-sm text-slate-500">Workspace dashboard</p>
-        </div>
-        {isOwnerOrAdmin && (
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => navigate("/dashboards")}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 transition"
-              data-testid="ws-dashboard-manage"
-            >
-              <LayoutDashboard className="h-4 w-4" />
-              Manage Dashboards
-            </button>
-          </div>
-        )}
+      {/* Dashboard header — one canonical workspace dashboard surface */}
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{ws.name}</h1>
+        <p className="mt-1 text-sm text-slate-500">Workspace dashboard</p>
       </header>
 
       {/* About section */}
@@ -156,14 +141,16 @@ export default function WorkspaceHomePage() {
         )}
       </section>
 
-      {/* KPI overview — real data from workspace summary, empty shells when no data */}
-      <section>
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Overview</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <KpiShell label="Projects" value={summary?.projectsTotal} hasData={hasProjects} />
-          <KpiShell label="In Progress" value={summary?.projectsInProgress} hasData={hasProjects} />
-          <KpiShell label="Tasks" value={summary?.tasksTotal} hasData={hasProjects} />
-          <KpiShell label="Completed" value={summary?.tasksCompleted} hasData={hasProjects} />
+      {/* Workspace overview context — real summary data, not dashboard widget cards */}
+      <section className="rounded-xl border border-slate-200 bg-white px-5 py-4" data-testid="ws-overview-context">
+        <div className="flex items-center gap-6">
+          <ContextStat label="Projects" value={hasProjects ? (summary?.projectsTotal ?? 0) : null} />
+          <div className="h-8 w-px bg-slate-100" />
+          <ContextStat label="In progress" value={hasProjects ? (summary?.projectsInProgress ?? 0) : null} />
+          <div className="h-8 w-px bg-slate-100" />
+          <ContextStat label="Tasks" value={hasProjects ? (summary?.tasksTotal ?? 0) : null} />
+          <div className="h-8 w-px bg-slate-100" />
+          <ContextStat label="Completed" value={hasProjects ? (summary?.tasksCompleted ?? 0) : null} />
         </div>
       </section>
 
@@ -192,15 +179,13 @@ export default function WorkspaceHomePage() {
   );
 }
 
-function KpiShell({ label, value, hasData }: { label: string; value?: number; hasData: boolean }) {
+function ContextStat({ label, value }: { label: string; value: number | null }) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-4" data-testid={`kpi-${label.toLowerCase().replace(/\s/g, '-')}`}>
-      <div className="text-xs font-medium text-slate-400 uppercase tracking-wider">{label}</div>
-      {hasData ? (
-        <div className="mt-1 text-2xl font-semibold text-slate-900">{value ?? 0}</div>
-      ) : (
-        <div className="mt-1 text-lg font-medium text-slate-300">&mdash;</div>
-      )}
+    <div className="min-w-0">
+      <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider">{label}</div>
+      <div className="mt-0.5 text-lg font-semibold text-slate-900">
+        {value !== null ? value : <span className="text-slate-300">&mdash;</span>}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Workspace dashboard shell**: WorkspaceHomePage redesigned with proper dashboard shell, real KPI overview (empty shells when no data), honest empty state guidance
- **Dashboards directory**: `/dashboards` moved to org-level route, Admin-only (RequireAdminInline). Non-admins cannot access.
- **Dashboard creation**: Simplified to Name → Workspace scope → Create. No unverified template/org scope options.
- **Add Card modal**: Real modal using widget registry (10 types, 5 categories). Every tile backed by real widget type.
- **Role guards**: Admin-only dashboard directory, workspace-scoped view/edit, Owner/Admin workspace dashboard editing

## Test plan

- [ ] Workspace click opens workspace dashboard shell
- [ ] Workspace dashboard shows real KPI data when projects exist
- [ ] Workspace dashboard shows empty shells (dash) when no projects
- [ ] Admin sees Dashboards directory at `/dashboards`
- [ ] Member/Viewer redirected away from `/dashboards`
- [ ] Create Dashboard modal: Name → Workspace scope → Create works
- [ ] Add Card modal shows real widget categories and tiles
- [ ] Add Card tile click returns real widget type
- [ ] No fake KPI values anywhere
- [ ] No dead dashboard controls
- [ ] No regression to Inbox, Favorites, Shared, profile menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)