### PR TITLE
fix(shell): Pass 3.1 — truthfulness corrections for favorites, Add Card, dashboard directory

### DIFF
--- a/zephix-backend/src/modules/favorites/favorites.module.ts
+++ b/zephix-backend/src/modules/favorites/favorites.module.ts
@@ -3,9 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Favorite } from './entities/favorite.entity';
 import { FavoritesController } from './favorites.controller';
 import { FavoritesService } from './favorites.service';
+import { Workspace } from '../workspaces/entities/workspace.entity';
+import { Project } from '../projects/entities/project.entity';
+import { Dashboard } from '../dashboards/entities/dashboard.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Favorite])],
+  imports: [TypeOrmModule.forFeature([Favorite, Workspace, Project, Dashboard])],
   controllers: [FavoritesController],
   providers: [FavoritesService],
   exports: [FavoritesService],

--- a/zephix-backend/src/modules/favorites/favorites.service.ts
+++ b/zephix-backend/src/modules/favorites/favorites.service.ts
@@ -1,20 +1,85 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { Favorite, FavoriteItemType } from './entities/favorite.entity';
+import { Workspace } from '../workspaces/entities/workspace.entity';
+import { Project } from '../projects/entities/project.entity';
+import { Dashboard } from '../dashboards/entities/dashboard.entity';
+
+export interface EnrichedFavorite {
+  id: string;
+  userId: string;
+  organizationId: string;
+  itemType: FavoriteItemType;
+  itemId: string;
+  displayName: string;
+  displayOrder: number;
+  createdAt: Date;
+}
 
 @Injectable()
 export class FavoritesService {
   constructor(
     @InjectRepository(Favorite)
     private readonly favoritesRepo: Repository<Favorite>,
+    @InjectRepository(Workspace)
+    private readonly workspaceRepo: Repository<Workspace>,
+    @InjectRepository(Project)
+    private readonly projectRepo: Repository<Project>,
+    @InjectRepository(Dashboard)
+    private readonly dashboardRepo: Repository<Dashboard>,
   ) {}
 
-  async listFavorites(userId: string, organizationId: string): Promise<Favorite[]> {
-    return this.favoritesRepo.find({
+  async listFavorites(userId: string, organizationId: string): Promise<EnrichedFavorite[]> {
+    const favorites = await this.favoritesRepo.find({
       where: { userId, organizationId },
       order: { displayOrder: 'ASC', createdAt: 'DESC' },
     });
+
+    if (favorites.length === 0) return [];
+
+    // Group item IDs by type for batch resolution
+    const workspaceIds = favorites.filter(f => f.itemType === 'workspace').map(f => f.itemId);
+    const projectIds = favorites.filter(f => f.itemType === 'project').map(f => f.itemId);
+    const dashboardIds = favorites.filter(f => f.itemType === 'dashboard').map(f => f.itemId);
+
+    // Batch-resolve names
+    const nameMap = new Map<string, string>();
+
+    if (workspaceIds.length > 0) {
+      const workspaces = await this.workspaceRepo.find({
+        where: { id: In(workspaceIds) },
+        select: ['id', 'name'],
+      });
+      workspaces.forEach(w => nameMap.set(w.id, w.name));
+    }
+
+    if (projectIds.length > 0) {
+      const projects = await this.projectRepo.find({
+        where: { id: In(projectIds) },
+        select: ['id', 'name'],
+      });
+      projects.forEach(p => nameMap.set(p.id, p.name));
+    }
+
+    if (dashboardIds.length > 0) {
+      const dashboards = await this.dashboardRepo.find({
+        where: { id: In(dashboardIds) },
+        select: ['id', 'name'],
+      });
+      dashboards.forEach(d => nameMap.set(d.id, d.name));
+    }
+
+    return favorites.map(f => ({
+      id: f.id,
+      userId: f.userId,
+      organizationId: f.organizationId,
+      itemType: f.itemType,
+      itemId: f.itemId,
+      displayName: nameMap.get(f.itemId) ?? 'Unknown item',
+      displayOrder: f.displayOrder,
+      createdAt: f.createdAt,
+    }));
   }
 
   async addFavorite(
@@ -23,7 +88,6 @@ export class FavoritesService {
     itemType: FavoriteItemType,
     itemId: string,
   ): Promise<Favorite> {
-    // Upsert: if already favorited, return existing
     const existing = await this.favoritesRepo.findOne({
       where: { userId, itemType, itemId },
     });

--- a/zephix-frontend/src/App.tsx
+++ b/zephix-frontend/src/App.tsx
@@ -209,7 +209,7 @@ export default function App() {
               <Route path="/admin/*" element={<RequireAdminInline><Navigate to="/administration" replace /></RequireAdminInline>} />
               <Route path="/org-dashboard" element={<RequireAdminInline><OrgDashboardPage /></RequireAdminInline>} />
 
-              {/* Pass 3: Dashboards directory — Org Admin standalone surface (no workspace required) */}
+              {/* Pass 3: Dashboards directory — Org Admin only. Still workspace-dependent for listing/creation. */}
               <Route path="/dashboards" element={<RequireAdminInline><DashboardsIndex /></RequireAdminInline>} />
 
               {/* ── Workspace-scoped routes (redirect to /inbox if none selected) ── */}

--- a/zephix-frontend/src/components/shell/Sidebar.tsx
+++ b/zephix-frontend/src/components/shell/Sidebar.tsx
@@ -401,7 +401,7 @@ function FavoriteItem({
         <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
           {ITEM_TYPE_LABELS[favorite.itemType] ?? favorite.itemType}
         </span>
-        {favorite.itemId.slice(0, 8)}…
+        {favorite.displayName}
       </button>
       <button
         type="button"

--- a/zephix-frontend/src/components/shell/Sidebar.tsx
+++ b/zephix-frontend/src/components/shell/Sidebar.tsx
@@ -1,11 +1,12 @@
-import { useState, useRef, useEffect } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import {
   ChevronDown,
   MoreHorizontal,
   Plus,
   Inbox,
 } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 
 import { SidebarWorkspaces } from "@/features/workspaces/SidebarWorkspaces";
 import { WorkspaceCreateModal } from "@/features/workspaces/WorkspaceCreateModal";
@@ -13,12 +14,13 @@ import { useWorkspaceStore } from "@/state/workspace.store";
 import { track } from "@/lib/telemetry";
 import { useAuth } from "@/state/AuthContext";
 import { isPlatformAdmin } from "@/utils/access";
+import { isPaidUser } from "@/utils/roles";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { useProjects } from "@/features/projects/hooks";
 import { useFavorites, useRemoveFavorite } from "@/features/favorites/hooks";
 import type { Favorite } from "@/features/favorites/api";
-import { useQuery } from "@tanstack/react-query";
 import { listPublishedDashboards } from "@/features/dashboards/api";
+import { useOrgHomeState } from "@/features/organizations/useOrgHomeState";
 
 /* ────────────────────────────────────────────
    Sidebar — locked UX contract (Pass 1)
@@ -31,6 +33,67 @@ function InboxBadge() {
     <span className="px-1.5 py-0.5 bg-red-600 text-white text-[10px] font-semibold rounded-full leading-none">
       {unreadCount > 99 ? "99+" : unreadCount}
     </span>
+  );
+}
+
+const myTasksChildNav = (isActive: boolean) =>
+  `block rounded-md px-2 py-1.5 text-sm font-medium transition ${
+    isActive ? "bg-slate-100 text-slate-900" : "text-slate-800 hover:bg-slate-50"
+  }`;
+
+/** My Tasks sub-destinations: real links only for paid roles; honest static row for guests. */
+function MyTasksChildren({ paid }: { paid: boolean }) {
+  const { pathname, search } = useLocation();
+  const filter = new URLSearchParams(search).get("filter");
+  const onMyWork = pathname === "/my-work";
+  const assignedActive = onMyWork && (filter === null || filter === "" || filter === "all");
+  const urgentActive = onMyWork && filter === "urgent";
+
+  return (
+    <div className="ml-4 border-l border-slate-200 pl-3 space-y-0.5" data-testid="my-tasks-children">
+      {paid ? (
+        <>
+          <Link
+            data-testid="my-tasks-assigned"
+            to="/my-work"
+            className={myTasksChildNav(assignedActive)}
+          >
+            Assigned to Me
+          </Link>
+          <Link
+            data-testid="my-tasks-urgent"
+            to="/my-work?filter=urgent"
+            className={myTasksChildNav(urgentActive)}
+          >
+            Today and Overdue
+          </Link>
+        </>
+      ) : (
+        <>
+          <div
+            className="rounded-md px-2 py-1.5 text-sm text-slate-500 select-none"
+            data-testid="my-tasks-assigned-static"
+          >
+            Assigned to Me
+          </div>
+          <div
+            className="rounded-md px-2 py-1.5 text-sm text-slate-500 select-none"
+            data-testid="my-tasks-urgent-static"
+          >
+            Today and Overdue
+          </div>
+        </>
+      )}
+      <div
+        className="rounded-md px-2 py-1.5 text-sm text-slate-500 select-none"
+        data-testid="my-tasks-personal-static"
+      >
+        Personal
+        <p className="mt-0.5 text-xs font-normal text-slate-400 leading-snug">
+          Not available yet — private task lists are planned.
+        </p>
+      </div>
+    </div>
   );
 }
 
@@ -59,12 +122,12 @@ function SectionHeader({
       <button
         type="button"
         onClick={onToggle}
-        className="flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.12em] text-slate-400 hover:text-slate-600 transition"
+        className="flex items-center gap-1.5 text-[11px] font-extrabold uppercase tracking-wide text-slate-900 hover:text-slate-950 transition"
         aria-expanded={expanded}
         data-testid={`${testId}-chevron`}
       >
         <ChevronDown
-          className={`h-3 w-3 transition-transform ${expanded ? "" : "-rotate-90"}`}
+          className={`h-3.5 w-3.5 shrink-0 text-slate-700 transition-transform ${expanded ? "" : "-rotate-90"}`}
         />
         {label}
       </button>
@@ -102,6 +165,7 @@ export function Sidebar() {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { activeWorkspaceId, setActiveWorkspace } = useWorkspaceStore();
+  const { workspaceCount, isLoading: orgWorkspaceLoading } = useOrgHomeState();
   const isAdmin = isPlatformAdmin(user);
 
   // Real project existence check — Projects link hidden until at least one exists
@@ -171,10 +235,10 @@ export function Sidebar() {
           data-testid="nav-inbox"
           to="/inbox"
           className={({ isActive }) =>
-            `flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition ${
+            `flex items-center justify-between rounded-lg px-3 py-2 text-sm font-semibold transition ${
               isActive
-                ? "bg-blue-50 text-blue-700"
-                : "text-slate-700 hover:bg-slate-50"
+                ? "bg-blue-50 text-blue-800"
+                : "text-slate-900 hover:bg-slate-50"
             }`
           }
         >
@@ -194,12 +258,7 @@ export function Sidebar() {
             testId="section-my-tasks"
           />
           {myTasksOpen && (
-            <div className="ml-4 border-l border-slate-200 pl-3 space-y-0.5" data-testid="my-tasks-children">
-              <div className="px-2 py-1 text-xs italic text-slate-400 select-none">Assigned to Me</div>
-              <div className="px-2 py-1 text-xs italic text-slate-400 select-none">Today and Overdue</div>
-              <div className="px-2 py-1 text-xs italic text-slate-400 select-none">Personal</div>
-              <div className="px-2 pt-1 text-[10px] text-slate-300">Available when tasks exist</div>
-            </div>
+            <MyTasksChildren paid={isPaidUser(user)} />
           )}
         </div>
 
@@ -275,8 +334,8 @@ export function Sidebar() {
                   data-testid="ws-nav-projects"
                   to="/projects"
                   className={({ isActive }) =>
-                    `block rounded-lg px-3 py-1.5 text-sm transition ${
-                      isActive ? "bg-slate-100 font-medium" : "hover:bg-slate-50"
+                    `block rounded-lg px-3 py-1.5 text-sm font-medium transition ${
+                      isActive ? "bg-slate-100 text-slate-900" : "text-slate-800 hover:bg-slate-50"
                     }`
                   }
                 >
@@ -285,25 +344,52 @@ export function Sidebar() {
               </div>
             )}
 
-            {/* No workspace empty state */}
-            {!activeWorkspaceId && (
-              <div className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 px-3 py-3 text-sm text-slate-500">
-                No workspaces yet.
-                <div className="mt-1 text-xs text-slate-400">
-                  Create your first workspace to start organizing projects, dashboards, and shared items.
+            {/* Honest workspace context: first workspace vs pick from list (org count is source of truth) */}
+            {!activeWorkspaceId &&
+              (orgWorkspaceLoading ? (
+                <div
+                  className="mx-2 rounded-lg border border-slate-200/80 bg-slate-50/40 px-3 py-2.5 text-xs text-slate-500"
+                  data-testid="workspaces-empty-loading"
+                >
+                  Loading workspace info…
                 </div>
-                {isAdmin && (
-                  <button
-                    type="button"
-                    onClick={handleCreateWorkspace}
-                    className="mt-3 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-blue-700 transition"
-                    data-testid="empty-create-workspace"
-                  >
-                    Create Workspace
-                  </button>
-                )}
-              </div>
-            )}
+              ) : workspaceCount === 0 ? (
+                <div
+                  className="mx-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/80 px-3 py-3"
+                  data-testid="workspaces-empty-first"
+                >
+                  <p className="text-sm font-semibold text-slate-900">Create your first workspace</p>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-500">
+                    Your organization does not have a workspace yet. Add one to organize projects,
+                    dashboards, and team work — nothing is created until you do.
+                  </p>
+                  {isAdmin ? (
+                    <button
+                      type="button"
+                      onClick={handleCreateWorkspace}
+                      className="mt-3 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-blue-700 transition"
+                      data-testid="empty-create-workspace"
+                    >
+                      Create workspace
+                    </button>
+                  ) : (
+                    <p className="mt-2 text-xs text-slate-400">
+                      Ask an organization admin to create the first workspace.
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div
+                  className="mx-2 rounded-lg border border-slate-200/90 bg-white px-3 py-3 shadow-sm"
+                  data-testid="workspaces-select-prompt"
+                >
+                  <p className="text-sm font-semibold text-slate-900">Choose a workspace</p>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-500">
+                    Use the workspace row above to select which workspace you are working in. Your
+                    API lists more than one workspace — no default is applied until you choose.
+                  </p>
+                </div>
+              ))}
           </div>
         )}
 
@@ -348,10 +434,10 @@ export function Sidebar() {
                     key={d.id}
                     type="button"
                     onClick={() => navigate(`/dashboards/${d.id}`)}
-                    className="block w-full truncate rounded-lg px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50 transition"
+                    className="block w-full truncate rounded-lg px-3 py-1.5 text-left text-sm font-medium text-slate-800 hover:bg-slate-50 transition"
                     data-testid={`shared-item-${d.id}`}
                   >
-                    <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mr-1.5">
                       Dashboard
                     </span>
                     {d.name}
@@ -396,9 +482,9 @@ function FavoriteItem({
       <button
         type="button"
         onClick={onNavigate}
-        className="flex-1 truncate text-left text-slate-700"
+        className="flex-1 truncate text-left text-slate-800 font-medium"
       >
-        <span className="text-[10px] uppercase tracking-wider text-slate-400 mr-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mr-1.5">
           {ITEM_TYPE_LABELS[favorite.itemType] ?? favorite.itemType}
         </span>
         {favorite.displayName}

--- a/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
+++ b/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
@@ -57,6 +57,10 @@ vi.mock('@/features/dashboards/api', () => ({
   listPublishedDashboards: vi.fn(() => Promise.resolve([])),
 }));
 
+vi.mock('@/features/organizations/useOrgHomeState', () => ({
+  useOrgHomeState: vi.fn(() => ({ workspaceCount: 0, isLoading: false })),
+}));
+
 vi.mock('@tanstack/react-query', async () => {
   const actual = await vi.importActual('@tanstack/react-query');
   return {
@@ -69,12 +73,14 @@ import { useAuth } from '@/state/AuthContext';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { useProjects } from '@/features/projects/hooks';
 import { useFavorites } from '@/features/favorites/hooks';
+import { useOrgHomeState } from '@/features/organizations/useOrgHomeState';
 
 const mockUseProjects = useProjects as ReturnType<typeof vi.fn>;
 const mockUseFavorites = useFavorites as ReturnType<typeof vi.fn>;
 
 const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
 const mockUseWorkspaceStore = useWorkspaceStore as ReturnType<typeof vi.fn>;
+const mockUseOrgHomeState = useOrgHomeState as ReturnType<typeof vi.fn>;
 
 function renderSidebar(initialPath = '/inbox') {
   return render(
@@ -91,9 +97,10 @@ const VIEWER_USER = { id: '3', platformRole: 'VIEWER', role: 'viewer', email: 'v
 describe('Pass 1 — Shell locked UX contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no projects, no favorites
+    // Default: no projects, no favorites, org reports zero workspaces
     mockUseProjects.mockReturnValue({ data: [], isLoading: false });
     mockUseFavorites.mockReturnValue({ data: [], isLoading: false });
+    mockUseOrgHomeState.mockReturnValue({ workspaceCount: 0, isLoading: false });
   });
 
   describe('Logo and Inbox', () => {
@@ -157,35 +164,38 @@ describe('Pass 1 — Shell locked UX contract', () => {
       expect(screen.getByTestId('section-my-tasks-chevron')).toBeInTheDocument();
     });
 
-    it('My Tasks child items are visible as non-click explanatory text', () => {
-      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
-      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
-      renderSidebar();
+    it('My Tasks shows real destinations for paid users (Admin and Member)', () => {
+      for (const user of [ADMIN_USER, MEMBER_USER]) {
+        mockUseAuth.mockReturnValue({ user });
+        mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+        const { unmount } = renderSidebar();
 
-      expect(screen.getByText('Assigned to Me')).toBeInTheDocument();
-      expect(screen.getByText('Today and Overdue')).toBeInTheDocument();
-      expect(screen.getByText('Personal')).toBeInTheDocument();
+        expect(screen.getByTestId('my-tasks-assigned').getAttribute('href')).toBe('/my-work');
+        expect(screen.getByTestId('my-tasks-urgent').getAttribute('href')).toBe(
+          '/my-work?filter=urgent',
+        );
+        unmount();
+      }
     });
 
-    it('My Tasks child items are not clickable buttons or links', () => {
+    it('My Tasks Personal is not a link and explains future availability', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
       renderSidebar();
 
+      expect(screen.getByTestId('my-tasks-personal-static')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /^Personal$/i })).not.toBeInTheDocument();
+    });
+
+    it('My Tasks uses static rows for guest (Viewer) instead of links', () => {
+      mockUseAuth.mockReturnValue({ user: VIEWER_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      renderSidebar();
+
+      expect(screen.getByTestId('my-tasks-assigned-static')).toBeInTheDocument();
+      expect(screen.getByTestId('my-tasks-urgent-static')).toBeInTheDocument();
       const container = screen.getByTestId('my-tasks-children');
-      // No buttons or anchor tags inside the children
-      expect(container.querySelectorAll('button')).toHaveLength(0);
       expect(container.querySelectorAll('a')).toHaveLength(0);
-    });
-
-    it('My Tasks child items are styled as italic explanatory text', () => {
-      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
-      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
-      renderSidebar();
-
-      const assignedItem = screen.getByText('Assigned to Me');
-      expect(assignedItem.className).toContain('italic');
-      expect(assignedItem.className).toContain('text-slate-400');
     });
   });
 
@@ -206,20 +216,53 @@ describe('Pass 1 — Shell locked UX contract', () => {
       expect(screen.queryByTestId('section-workspaces-plus')).not.toBeInTheDocument();
     });
 
-    it('shows empty state when no workspace selected', () => {
+    it('shows first-workspace empty state when org has no workspaces', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseOrgHomeState.mockReturnValue({ workspaceCount: 0, isLoading: false });
       renderSidebar();
 
-      expect(screen.getByText('No workspaces yet.')).toBeInTheDocument();
+      expect(screen.getByTestId('workspaces-empty-first')).toBeInTheDocument();
+      expect(screen.getByText(/Create your first workspace/i)).toBeInTheDocument();
     });
 
-    it('shows Create Workspace button in empty state for admin', () => {
+    it('shows choose-workspace prompt when org has workspaces but none selected', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseOrgHomeState.mockReturnValue({ workspaceCount: 2, isLoading: false });
+      renderSidebar();
+
+      expect(screen.getByTestId('workspaces-select-prompt')).toBeInTheDocument();
+      expect(screen.getByText(/Choose a workspace/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('empty-create-workspace')).not.toBeInTheDocument();
+    });
+
+    it('shows loading line while org workspace count is loading', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseOrgHomeState.mockReturnValue({ workspaceCount: 0, isLoading: true });
+      renderSidebar();
+
+      expect(screen.getByTestId('workspaces-empty-loading')).toBeInTheDocument();
+    });
+
+    it('shows Create Workspace button in first-workspace empty state for admin', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseOrgHomeState.mockReturnValue({ workspaceCount: 0, isLoading: false });
       renderSidebar();
 
       expect(screen.getByTestId('empty-create-workspace')).toBeInTheDocument();
+    });
+
+    it('member with no workspaces sees admin note, not Create Workspace', () => {
+      mockUseAuth.mockReturnValue({ user: MEMBER_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseOrgHomeState.mockReturnValue({ workspaceCount: 0, isLoading: false });
+      renderSidebar();
+
+      expect(screen.getByText(/Ask an organization admin/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('empty-create-workspace')).not.toBeInTheDocument();
     });
   });
 

--- a/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
+++ b/zephix-frontend/src/components/shell/__tests__/Sidebar.test.tsx
@@ -350,13 +350,13 @@ describe('Pass 1 — Shell locked UX contract', () => {
       expect(screen.getByText('No favorites yet.')).toBeInTheDocument();
     });
 
-    it('shows favorited items when favorites exist', () => {
+    it('shows favorited items with real display names', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
       mockUseFavorites.mockReturnValue({
         data: [
-          { id: 'f1', itemType: 'workspace', itemId: 'ws-1', displayOrder: 0, createdAt: '' },
-          { id: 'f2', itemType: 'dashboard', itemId: 'dash-1', displayOrder: 1, createdAt: '' },
+          { id: 'f1', itemType: 'workspace', itemId: 'ws-1', displayName: 'Engineering Hub', displayOrder: 0, createdAt: '' },
+          { id: 'f2', itemType: 'dashboard', itemId: 'dash-1', displayName: 'KPI Overview', displayOrder: 1, createdAt: '' },
         ],
         isLoading: false,
       });
@@ -365,13 +365,33 @@ describe('Pass 1 — Shell locked UX contract', () => {
       expect(screen.getByTestId('favorites-list')).toBeInTheDocument();
       expect(screen.getByTestId('favorite-item-f1')).toBeInTheDocument();
       expect(screen.getByTestId('favorite-item-f2')).toBeInTheDocument();
+      // Must show real names, not UUID fragments
+      expect(screen.getByText('Engineering Hub')).toBeInTheDocument();
+      expect(screen.getByText('KPI Overview')).toBeInTheDocument();
+    });
+
+    it('does not render UUID fragments for favorites', () => {
+      mockUseAuth.mockReturnValue({ user: ADMIN_USER });
+      mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
+      mockUseFavorites.mockReturnValue({
+        data: [
+          { id: 'f1', itemType: 'workspace', itemId: 'a1b2c3d4-5678-9abc-def0-123456789abc', displayName: 'My Workspace', displayOrder: 0, createdAt: '' },
+        ],
+        isLoading: false,
+      });
+      renderSidebar();
+
+      // Should not show the UUID fragment
+      expect(screen.queryByText(/a1b2c3d4/)).not.toBeInTheDocument();
+      // Should show the real name
+      expect(screen.getByText('My Workspace')).toBeInTheDocument();
     });
 
     it('shows remove button on hover for each favorite', () => {
       mockUseAuth.mockReturnValue({ user: ADMIN_USER });
       mockUseWorkspaceStore.mockReturnValue({ activeWorkspaceId: null, setActiveWorkspace: vi.fn() });
       mockUseFavorites.mockReturnValue({
-        data: [{ id: 'f1', itemType: 'project', itemId: 'p-1', displayOrder: 0, createdAt: '' }],
+        data: [{ id: 'f1', itemType: 'project', itemId: 'p-1', displayName: 'Sprint Dashboard', displayOrder: 0, createdAt: '' }],
         isLoading: false,
       });
       renderSidebar();

--- a/zephix-frontend/src/features/favorites/api.ts
+++ b/zephix-frontend/src/features/favorites/api.ts
@@ -8,6 +8,7 @@ export interface Favorite {
   organizationId: string;
   itemType: FavoriteItemType;
   itemId: string;
+  displayName: string;
   displayOrder: number;
   createdAt: string;
 }

--- a/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
+++ b/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronDown, Plus } from 'lucide-react';
-import { toast } from 'sonner';
+
+import { listWorkspaces } from './api';
+import type { Workspace } from './api';
+import { WorkspaceCreateModal } from './WorkspaceCreateModal';
 
 import { useAuth } from '@/state/AuthContext';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { telemetry } from '@/lib/telemetry';
-import { listWorkspaces } from './api';
-import type { Workspace } from './api';
-import { WorkspaceCreateModal } from './WorkspaceCreateModal';
 import { isAdminRole } from '@/types/roles';
 import { isPlatformViewer } from '@/utils/access';
 
@@ -22,30 +22,27 @@ export function SidebarWorkspaces() {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  // Phase 4: Only org owner or org admin can create workspaces
   const canCreateWorkspace = isAdminRole(user?.role);
 
-  // Close dropdown when clicking outside
   useEffect(() => {
-    if (!dropdownOpen || !canCreateWorkspace) return;
+    if (!dropdownOpen) return;
 
     const handleClickOutside = (event: MouseEvent) => {
+      const t = event.target as Node;
       if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node) &&
-        buttonRef.current &&
-        !buttonRef.current.contains(event.target as Node)
+        dropdownRef.current?.contains(t) ||
+        buttonRef.current?.contains(t)
       ) {
-        setDropdownOpen(false);
+        return;
       }
+      setDropdownOpen(false);
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [dropdownOpen, canCreateWorkspace]);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [dropdownOpen]);
 
   async function refresh() {
-    // Guard: Don't fire requests until auth state is READY
     if (authLoading || !user) {
       return;
     }
@@ -54,12 +51,11 @@ export function SidebarWorkspaces() {
       setWorkspaces(Array.isArray(data) ? data : []);
     } catch (error) {
       console.error('Failed to load workspaces:', error);
-      setWorkspaces([]); // Set empty array on error
+      setWorkspaces([]);
     }
   }
 
   useEffect(() => {
-    // Guard: Wait for auth to be ready
     if (authLoading) {
       return;
     }
@@ -72,66 +68,86 @@ export function SidebarWorkspaces() {
 
   function handleWorkspaceSelect(id: string) {
     if (!id) return;
-    // Single source of truth: set activeWorkspaceId in AuthContext
     setActiveWorkspace(id);
-    // Always navigate to workspace home
     navigate(`/workspaces/${id}/home`, { replace: true });
+    setDropdownOpen(false);
+    setPlusMenuOpen(false);
   }
 
   const currentWorkspace = workspaces.find(w => w.id === activeWorkspaceId);
   const availableWorkspaces = workspaces.filter(w => !w.deletedAt);
 
-  // STEP 4: Auto-select FIRST workspace ONCE after login if none selected
-  // Use ref to ensure this only happens once, not on every render
+  /**
+   * Only auto-select when the API returns exactly one workspace (unambiguous real context).
+   * Do not auto-select when multiple workspaces exist — the user must pick (no implied default).
+   */
   const hasInitializedRef = useRef(false);
   useEffect(() => {
-    // Only auto-select if:
-    // 1. Auth is ready
-    // 2. User exists
-    // 3. Workspaces are loaded
-    // 4. No workspace is currently selected
-    // 5. We haven't already initialized
     if (
       !authLoading &&
       user &&
-      availableWorkspaces.length > 0 &&
+      availableWorkspaces.length === 1 &&
       !activeWorkspaceId &&
       !hasInitializedRef.current
     ) {
       hasInitializedRef.current = true;
-      const firstWorkspace = availableWorkspaces[0];
-      if (firstWorkspace) {
-        // Set workspace context without navigating — inbox-first landing stays on /inbox
-        setActiveWorkspace(firstWorkspace.id);
-        telemetry.track('workspace.selected', { workspaceId: firstWorkspace.id });
+      const only = availableWorkspaces[0];
+      if (only) {
+        setActiveWorkspace(only.id);
+        telemetry.track('workspace.selected', { workspaceId: only.id, reason: 'single_workspace' });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [availableWorkspaces.length, activeWorkspaceId, authLoading, user]);
 
   const [plusMenuOpen, setPlusMenuOpen] = useState(false);
+  const plusButtonRef = useRef<HTMLButtonElement>(null);
   const plusMenuRef = useRef<HTMLDivElement>(null);
 
-  // Close plus menu when clicking outside
   useEffect(() => {
     if (!plusMenuOpen) return;
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (plusMenuRef.current && !plusMenuRef.current.contains(event.target as Node)) {
-        setPlusMenuOpen(false);
+      const t = event.target as Node;
+      if (plusMenuRef.current?.contains(t) || plusButtonRef.current?.contains(t)) {
+        return;
       }
+      setPlusMenuOpen(false);
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [plusMenuOpen]);
 
-  // Hide the entire workspace selector when no workspaces exist
-  // The Sidebar owns the empty-state messaging for that case
+  const showWorkspacePicker =
+    availableWorkspaces.length > 1 ||
+    (availableWorkspaces.length === 1 && canCreateWorkspace);
+
+  const toggleWorkspacePicker = () => {
+    if (!showWorkspacePicker) return;
+    setPlusMenuOpen(false);
+    setDropdownOpen((v) => !v);
+  };
+
+  const handleWorkspaceRowClick = () => {
+    if (availableWorkspaces.length === 0) return;
+
+    if (availableWorkspaces.length === 1 && !currentWorkspace) {
+      handleWorkspaceSelect(availableWorkspaces[0].id);
+      return;
+    }
+
+    if (availableWorkspaces.length === 1 && currentWorkspace) {
+      if (canCreateWorkspace) toggleWorkspacePicker();
+      return;
+    }
+
+    toggleWorkspacePicker();
+  };
+
   if (availableWorkspaces.length === 0 && !authLoading) {
     return (
       <div data-testid="sidebar-workspaces">
-        {/* Workspace Create Modal kept available for admin */}
         {canCreateWorkspace && (
           <WorkspaceCreateModal
             open={open}
@@ -144,168 +160,140 @@ export function SidebarWorkspaces() {
   }
 
   return (
-    <div className="px-2 mb-2" data-testid="sidebar-workspaces">
-      {/* Workspace Dropdown and Plus Button */}
-      <div className="flex items-center gap-2">
-        <div className="relative flex-1">
+    <div className="mb-2" data-testid="sidebar-workspaces">
+      <div className="flex items-stretch gap-1.5">
+        <div className="relative min-w-0 flex-1">
           <button
             ref={buttonRef}
-            onClick={() => {
-              if (availableWorkspaces.length > 0 && !currentWorkspace) {
-                if (availableWorkspaces.length === 1) {
-                  handleWorkspaceSelect(availableWorkspaces[0].id);
-                } else {
-                  setDropdownOpen(!dropdownOpen);
-                }
-              } else if (canCreateWorkspace) {
-                setDropdownOpen(!dropdownOpen);
-              }
-            }}
-            className={`w-full flex items-center justify-between px-3 py-2.5 rounded border text-sm ${
-              currentWorkspace
-                ? 'bg-gray-50 border-gray-300 hover:bg-gray-100'
-                : 'bg-white border-gray-300 hover:bg-gray-50'
-            } cursor-pointer`}
+            type="button"
+            onClick={handleWorkspaceRowClick}
+            className={`flex w-full items-center gap-2 rounded-lg border-l-[3px] border-slate-200 bg-transparent pl-2 pr-2.5 py-2 text-left text-sm font-semibold text-slate-900 transition ${
+              dropdownOpen
+                ? 'border-blue-500/80 bg-slate-100'
+                : 'hover:border-slate-300 hover:bg-slate-50'
+            } ${
+              availableWorkspaces.length === 1 && !!currentWorkspace && !canCreateWorkspace
+                ? 'cursor-default hover:bg-transparent hover:border-slate-200'
+                : ''
+            }`}
             data-testid="workspace-selector"
+            aria-expanded={dropdownOpen}
+            aria-haspopup={showWorkspacePicker ? 'listbox' : undefined}
           >
-            <span className="text-sm font-medium truncate flex-1 text-left">
+            <span className="min-w-0 flex-1 truncate">
               {currentWorkspace
                 ? currentWorkspace.name
                 : 'Select workspace'}
             </span>
-            <ChevronDown
-              className={`h-4 w-4 text-gray-500 transition-transform flex-shrink-0 ${dropdownOpen ? 'rotate-180' : ''}`}
-            />
+            {showWorkspacePicker && (
+              <ChevronDown
+                className={`h-4 w-4 shrink-0 text-slate-500 transition-transform ${
+                  dropdownOpen ? 'rotate-180' : ''
+                }`}
+              />
+            )}
           </button>
 
-        {/* STEP 2: Dropdown menu - compact selector only, never renders full workspace list */}
-        {/* STEP 4: Dropdown is for SWITCHING, not browsing - only shows list of workspace names */}
-        {canCreateWorkspace && dropdownOpen && (
-          <div
-            ref={dropdownRef}
-            className="absolute left-0 right-0 mt-1 bg-white border border-gray-300 rounded-lg shadow-lg z-50 max-h-64 overflow-auto"
-            data-testid="workspace-dropdown-menu"
-          >
-            <div className="py-1">
-              {/* STEP 2: Compact list - just names, no full workspace cards */}
-              {availableWorkspaces.map(ws => (
+          {dropdownOpen && showWorkspacePicker && (
+            <div
+              ref={dropdownRef}
+              role="listbox"
+              className="absolute left-0 right-0 top-full z-[100] mt-1 max-h-56 overflow-auto rounded-lg border border-slate-200 bg-white py-1 shadow-md"
+              data-testid="workspace-dropdown-menu"
+            >
+              {availableWorkspaces.map((ws) => (
                 <button
                   key={ws.id}
+                  type="button"
+                  role="option"
+                  aria-selected={ws.id === activeWorkspaceId}
                   onClick={() => handleWorkspaceSelect(ws.id)}
-                  className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 transition-colors ${
-                    ws.id === activeWorkspaceId ? 'bg-blue-50 font-medium text-blue-700' : ''
+                  className={`flex w-full px-3 py-2 text-left text-sm font-medium transition-colors hover:bg-slate-50 ${
+                    ws.id === activeWorkspaceId ? 'bg-blue-50 text-blue-800' : 'text-slate-800'
                   }`}
                   data-testid={`workspace-option-${ws.id}`}
                 >
                   {ws.name}
                 </button>
               ))}
-              {availableWorkspaces.length === 0 && (
-                <div className="px-3 py-2 text-sm text-gray-500">
-                  No workspaces yet
-                </div>
+              {canCreateWorkspace && (
+                <>
+                  <div className="my-1 border-t border-slate-100" />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDropdownOpen(false);
+                      setOpen(true);
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium text-blue-700 hover:bg-slate-50"
+                    data-testid="workspace-add-new"
+                  >
+                    <Plus className="h-4 w-4 shrink-0" />
+                    Add new workspace
+                  </button>
+                </>
               )}
-              <div className="border-t border-gray-200 my-1"></div>
+              <div className="my-1 border-t border-slate-100" />
               <button
-                onClick={() => {
-                  setDropdownOpen(false);
-                  setOpen(true);
-                }}
-                className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center gap-2 text-blue-600 font-medium"
-                data-testid="workspace-add-new"
-              >
-                <Plus className="h-4 w-4" />
-                <span>Add new workspace</span>
-              </button>
-              {/* STEP 2: Link to /workspaces for full workspace list page */}
-              <div className="border-t border-gray-200 my-1"></div>
-              <button
+                type="button"
                 onClick={() => {
                   setDropdownOpen(false);
                   navigate('/workspaces');
                 }}
-                className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 text-gray-600"
+                className="w-full px-3 py-2 text-left text-sm text-slate-600 hover:bg-slate-50"
                 data-testid="workspace-browse-all"
               >
-                Browse all workspaces...
+                Browse all workspaces…
               </button>
             </div>
-          </div>
-        )}
+          )}
         </div>
 
-        {/* Plus Button — hidden for viewers (read-only users cannot create) */}
         {activeWorkspaceId && !isPlatformViewer(user) && (
-          <div className="relative" ref={plusMenuRef}>
+          <div className="relative flex shrink-0 items-center">
             <button
-              onClick={() => setPlusMenuOpen(!plusMenuOpen)}
-              className="flex items-center justify-center w-10 h-10 rounded border border-gray-300 bg-white hover:bg-gray-50 transition-colors"
+              ref={plusButtonRef}
+              type="button"
+              onClick={() => {
+                setDropdownOpen(false);
+                setPlusMenuOpen((v) => !v);
+              }}
+              className={`flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 ${
+                plusMenuOpen ? 'bg-slate-100' : ''
+              }`}
               data-testid="workspace-plus-button"
+              aria-expanded={plusMenuOpen}
+              aria-haspopup="menu"
+              aria-label="Create in workspace"
             >
-              <Plus className="h-4 w-4 text-gray-600" />
+              <Plus className="h-4 w-4" />
             </button>
 
-            {/* Plus Menu Dropdown */}
             {plusMenuOpen && (
-              <div className="absolute left-0 mt-1 bg-white border border-gray-300 rounded-lg shadow-lg z-50 min-w-[180px]">
-                <div className="py-1">
-                  <button
-                    onClick={() => {
-                      setPlusMenuOpen(false);
-                      navigate('/templates');
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 transition-colors"
-                  >
-                    New project
-                  </button>
-                  <button
-                    onClick={async () => {
-                      setPlusMenuOpen(false);
-                      if (!activeWorkspaceId) {
-                        toast.error("Please select a workspace first");
-                        return;
-                      }
-                      try {
-                        const { createDoc } = await import("@/features/docs/api");
-                        const docId = await createDoc(activeWorkspaceId, "Untitled");
-                        navigate(`/docs/${docId}`, { replace: true });
-                        toast.success("Doc created");
-                      } catch (e: any) {
-                        toast.error(e?.message || "Failed to create doc");
-                      }
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 transition-colors"
-                  >
-                    Doc
-                  </button>
-                  <button
-                    onClick={async () => {
-                      setPlusMenuOpen(false);
-                      if (!activeWorkspaceId) {
-                        toast.error("Please select a workspace first");
-                        return;
-                      }
-                      try {
-                        const { createForm } = await import("@/features/forms/api");
-                        const formId = await createForm(activeWorkspaceId, "Untitled");
-                        navigate(`/forms/${formId}/edit`, { replace: true });
-                        toast.success("Form created");
-                      } catch (e: any) {
-                        toast.error(e?.message || "Failed to create form");
-                      }
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 transition-colors"
-                  >
-                    Form
-                  </button>
-                </div>
+              <div
+                ref={plusMenuRef}
+                role="menu"
+                className="absolute right-0 top-full z-[100] mt-1 min-w-[11rem] max-w-[min(100vw-2rem,16rem)] rounded-lg border border-slate-200 bg-white py-1 shadow-md"
+              >
+                {/* Only routes that navigate to existing app surfaces (no silent create stubs). */}
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setPlusMenuOpen(false);
+                    navigate('/templates');
+                  }}
+                  className="w-full px-3 py-2 text-left text-sm font-medium text-slate-800 hover:bg-slate-50"
+                  data-testid="workspace-plus-new-project"
+                >
+                  New project
+                </button>
               </div>
             )}
           </div>
         )}
       </div>
 
-      {/* Workspace Create Modal - Org admin/owner only */}
       {canCreateWorkspace && (
         <WorkspaceCreateModal
           open={open}
@@ -315,7 +303,6 @@ export function SidebarWorkspaces() {
           }}
         />
       )}
-
     </div>
   );
 }

--- a/zephix-frontend/src/pages/InboxPage.tsx
+++ b/zephix-frontend/src/pages/InboxPage.tsx
@@ -1,5 +1,15 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import {
+  Bell,
+  Inbox,
+  ListChecks,
+  CheckCircle2,
+  AtSign,
+  AlarmClock,
+  Users,
+} from "lucide-react";
+
 import { request } from "@/lib/api";
 import { useUIStore } from "@/stores/uiStore";
 import { useAuth } from "@/state/AuthContext";
@@ -9,7 +19,6 @@ import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { isPlatformAdmin } from "@/utils/access";
 import { WorkspaceCreateModal } from "@/features/workspaces/WorkspaceCreateModal";
 import { track } from "@/lib/telemetry";
-import { Bell, Inbox } from "lucide-react";
 
 interface Notification {
   id: string;
@@ -27,6 +36,49 @@ interface NotificationListResponse {
   nextCursor: string | null;
 }
 
+const INBOX_MODULES: {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof ListChecks;
+}[] = [
+  {
+    id: "assignments",
+    title: "Assignments",
+    description:
+      "Work routed to you across projects will surface here as the assignment model matures.",
+    icon: ListChecks,
+  },
+  {
+    id: "approvals",
+    title: "Approvals",
+    description:
+      "Pending approvals and sign-offs will appear when governance workflows are connected.",
+    icon: CheckCircle2,
+  },
+  {
+    id: "mentions",
+    title: "Mentions",
+    description:
+      "@mentions and directed comments will be grouped here; notification feed below already captures many events.",
+    icon: AtSign,
+  },
+  {
+    id: "reminders",
+    title: "Reminders",
+    description:
+      "Scheduled reminders and nudges will show in this lane once enabled for your org.",
+    icon: AlarmClock,
+  },
+  {
+    id: "activity",
+    title: "Shared activity",
+    description:
+      "Cross-workspace highlights and shared artifacts will aggregate here over time.",
+    icon: Users,
+  },
+];
+
 export default function InboxPage() {
   const nav = useNavigate();
   const { user } = useAuth();
@@ -43,9 +95,10 @@ export default function InboxPage() {
   const [hasMore, setHasMore] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
 
+  const showSetupBanner = !orgLoading && workspaceCount === 0;
+
   useEffect(() => {
     track("inbox_viewed", {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -119,198 +172,203 @@ export default function InboxPage() {
 
   const filteredNotifications =
     tab === "unread" ? notifications.filter((n) => !n.read) : notifications;
-  const hasNotifications = filteredNotifications.length > 0;
-  const showEmptyLanding = !orgLoading && workspaceCount === 0 && !hasNotifications;
 
   return (
-    <div className="mx-auto max-w-4xl p-6 space-y-6" data-testid="inbox-page">
-      {/* ── Empty landing: no workspaces, no notifications ── */}
-      {showEmptyLanding && (
-        <>
-          <section
-            className="rounded-2xl border border-slate-200/80 bg-white p-8 shadow-sm"
-            data-testid="inbox-welcome"
-          >
-            <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
-              Welcome to Zephix
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-              Inbox is your landing page. It stays simple on day one, then becomes the
-              place for assignments, approvals, mentions, reminders, and shared activity.
-            </p>
-            <div className="mt-6 flex flex-wrap gap-3">
-              {isAdmin && (
-                <button
-                  type="button"
-                  onClick={() => setShowCreateModal(true)}
-                  className="rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition"
-                  data-testid="inbox-create-workspace"
-                >
-                  Create Workspace
-                </button>
-              )}
-              {isAdmin && (
-                <button
-                  type="button"
-                  onClick={() => nav("/administration/users")}
-                  className="rounded-xl border border-slate-200 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition"
-                  data-testid="inbox-invite-members"
-                >
-                  Invite Members
-                </button>
-              )}
-            </div>
-          </section>
+    <div className="mx-auto max-w-4xl space-y-6 p-6" data-testid="inbox-page">
+      <header className="space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Inbox className="h-6 w-6 text-slate-500" />
+          <h1 className="text-xl font-bold tracking-tight text-slate-900">Inbox</h1>
+          {unreadCount > 0 && (
+            <span className="rounded-full bg-red-600 px-2 py-0.5 text-xs font-semibold text-white">
+              {unreadCount > 99 ? "99+" : unreadCount} unread
+            </span>
+          )}
+        </div>
+        <p className="max-w-2xl text-sm leading-relaxed text-slate-600">
+          Operational feed for notifications plus dedicated lanes for assignments, approvals,
+          mentions, reminders, and shared activity as each module goes live.
+        </p>
+      </header>
 
-          {/* Getting started guidance */}
-          <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm">
-            <h2 className="text-base font-semibold text-slate-900">Getting Started</h2>
-            <div className="mt-4 space-y-3">
-              <GettingStartedStep
-                number="1"
-                title="Create your first workspace"
-                text="Set up the container where projects, dashboards, docs, and shared items will live."
-              />
-              <GettingStartedStep
-                number="2"
-                title="Invite members"
-                text="Use the invite workflow from the profile menu to bring your team in."
-              />
-              <GettingStartedStep
-                number="3"
-                title="Create your first project"
-                text="Start from a template after your workspace exists."
-              />
-              <GettingStartedStep
-                number="4"
-                title="Use dashboards when source data exists"
-                text="Dashboards live under Workspaces. They become useful once projects and tasks provide data."
-              />
-            </div>
-          </section>
-        </>
-      )}
-
-      {/* ── Notification feed ── */}
-      {!showEmptyLanding && (
-        <section
-          className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm"
-          data-testid="inbox-feed"
-        >
-          <div className="border-b border-slate-200/80 bg-slate-50/50 px-6 py-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <Inbox className="h-5 w-5 text-slate-500" />
-                <h1 className="text-base font-semibold text-slate-900">Inbox</h1>
-                {unreadCount > 0 && (
-                  <span className="rounded-full bg-red-600 px-2 py-0.5 text-xs font-medium text-white">
-                    {unreadCount}
-                  </span>
-                )}
-              </div>
-              {tab === "all" && notifications.some((n) => !n.read) && (
-                <button
-                  onClick={handleMarkAllAsRead}
-                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100 transition"
-                >
-                  Mark all as read
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Tabs */}
-          <div className="flex gap-1 border-b border-slate-200/80 px-6">
-            <button
-              onClick={() => setTab("all")}
-              className={`px-3 py-2.5 text-sm font-medium transition ${
-                tab === "all"
-                  ? "border-b-2 border-blue-600 text-blue-600"
-                  : "text-slate-500 hover:text-slate-700"
-              }`}
+      <section
+        aria-label="Inbox modules"
+        className="grid gap-3 sm:grid-cols-2"
+        data-testid="inbox-modules"
+      >
+        {INBOX_MODULES.map((m) => {
+          const Icon = m.icon;
+          return (
+            <article
+              key={m.id}
+              className="rounded-xl border border-slate-200/90 bg-white p-4 shadow-sm"
+              data-testid={`inbox-module-${m.id}`}
             >
-              All
-            </button>
-            <button
-              onClick={() => setTab("unread")}
-              className={`px-3 py-2.5 text-sm font-medium transition ${
-                tab === "unread"
-                  ? "border-b-2 border-blue-600 text-blue-600"
-                  : "text-slate-500 hover:text-slate-700"
-              }`}
-            >
-              Unread{unreadCount > 0 ? ` (${unreadCount})` : ""}
-            </button>
-          </div>
-
-          {/* Notification list */}
-          <div className="divide-y divide-slate-100">
-            {loading && notifications.length === 0 ? (
-              <div className="py-12 text-center text-sm text-slate-500">Loading...</div>
-            ) : filteredNotifications.length === 0 ? (
-              <div className="px-6 py-12 text-center">
-                <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-400">
-                  <Bell className="h-6 w-6" />
+              <div className="flex items-start gap-3">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600">
+                  <Icon className="h-4 w-4" aria-hidden />
                 </div>
-                <h3 className="mt-4 text-sm font-semibold text-slate-900">
-                  {tab === "unread"
-                    ? "No unread notifications"
-                    : "Nothing in your inbox yet"}
-                </h3>
-                <p className="mx-auto mt-1 max-w-md text-sm text-slate-500">
-                  {tab === "unread"
-                    ? "You're all caught up."
-                    : "Approvals, mentions, assignments, and reminders will appear here once workspaces and projects are active."}
-                </p>
+                <div className="min-w-0">
+                  <h2 className="text-sm font-semibold text-slate-900">{m.title}</h2>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-500">{m.description}</p>
+                  <p className="mt-2 text-xs font-medium text-slate-400">Nothing to show yet</p>
+                </div>
               </div>
-            ) : (
-              filteredNotifications.map((notification) => (
-                <div
-                  key={notification.id}
-                  className={`flex items-start justify-between gap-4 px-6 py-4 ${
-                    !notification.read ? "bg-blue-50/40" : ""
-                  }`}
-                >
-                  <div className="min-w-0 flex-1">
-                    <p
-                      className={`text-sm ${
-                        !notification.read
-                          ? "font-semibold text-slate-900"
-                          : "text-slate-700"
-                      }`}
-                    >
-                      {notification.title}
-                    </p>
-                    {notification.body && (
-                      <p className="mt-0.5 text-sm text-slate-500">{notification.body}</p>
-                    )}
-                    <p className="mt-1 text-xs text-slate-400">
-                      {new Date(notification.createdAt).toLocaleString()}
-                    </p>
-                  </div>
-                  {!notification.read && (
-                    <button
-                      onClick={() => handleMarkAsRead(notification.id)}
-                      className="shrink-0 rounded-lg px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100 transition"
-                    >
-                      Mark read
-                    </button>
-                  )}
-                </div>
-              ))
+            </article>
+          );
+        })}
+      </section>
+
+      <section
+        className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm"
+        data-testid="inbox-feed"
+      >
+        <div className="border-b border-slate-200/80 bg-slate-50/50 px-6 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-semibold text-slate-900">Notifications</h2>
+              {unreadCount > 0 && (
+                <span className="rounded-full bg-red-600 px-2 py-0.5 text-xs font-medium text-white">
+                  {unreadCount}
+                </span>
+              )}
+            </div>
+            {tab === "all" && notifications.some((n) => !n.read) && (
+              <button
+                type="button"
+                onClick={handleMarkAllAsRead}
+                className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100 transition"
+              >
+                Mark all as read
+              </button>
             )}
           </div>
+        </div>
 
-          {hasMore && (
-            <div className="border-t border-slate-100 px-6 py-3 text-center">
-              <button
-                onClick={() => {
-                  if (nextCursor && !loading) loadNotifications(nextCursor);
-                }}
-                disabled={loading}
-                className="rounded-lg px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 disabled:opacity-50 transition"
+        <div className="flex gap-1 border-b border-slate-200/80 px-6">
+          <button
+            type="button"
+            onClick={() => setTab("all")}
+            className={`px-3 py-2.5 text-sm font-medium transition ${
+              tab === "all"
+                ? "border-b-2 border-blue-600 text-blue-600"
+                : "text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("unread")}
+            className={`px-3 py-2.5 text-sm font-medium transition ${
+              tab === "unread"
+                ? "border-b-2 border-blue-600 text-blue-600"
+                : "text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            Unread{unreadCount > 0 ? ` (${unreadCount})` : ""}
+          </button>
+        </div>
+
+        <div className="divide-y divide-slate-100">
+          {loading && notifications.length === 0 ? (
+            <div className="py-12 text-center text-sm text-slate-500">Loading…</div>
+          ) : filteredNotifications.length === 0 ? (
+            <div className="px-6 py-12 text-center">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-400">
+                <Bell className="h-6 w-6" />
+              </div>
+              <h3 className="mt-4 text-sm font-semibold text-slate-900">
+                {tab === "unread" ? "No unread notifications" : "No notifications yet"}
+              </h3>
+              <p className="mx-auto mt-1 max-w-md text-sm text-slate-500">
+                {tab === "unread"
+                  ? "You're all caught up."
+                  : "When teammates mention you, assign work, or trigger approvals, entries will appear here."}
+              </p>
+            </div>
+          ) : (
+            filteredNotifications.map((notification) => (
+              <div
+                key={notification.id}
+                className={`flex items-start justify-between gap-4 px-6 py-4 ${
+                  !notification.read ? "bg-blue-50/40" : ""
+                }`}
               >
-                {loading ? "Loading..." : "Load more"}
+                <div className="min-w-0 flex-1">
+                  <p
+                    className={`text-sm ${
+                      !notification.read
+                        ? "font-semibold text-slate-900"
+                        : "text-slate-700"
+                    }`}
+                  >
+                    {notification.title}
+                  </p>
+                  {notification.body && (
+                    <p className="mt-0.5 text-sm text-slate-500">{notification.body}</p>
+                  )}
+                  <p className="mt-1 text-xs text-slate-400">
+                    {new Date(notification.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                {!notification.read && (
+                  <button
+                    type="button"
+                    onClick={() => handleMarkAsRead(notification.id)}
+                    className="shrink-0 rounded-lg px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100 transition"
+                  >
+                    Mark read
+                  </button>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        {hasMore && (
+          <div className="border-t border-slate-100 px-6 py-3 text-center">
+            <button
+              type="button"
+              onClick={() => {
+                if (nextCursor && !loading) loadNotifications(nextCursor);
+              }}
+              disabled={loading}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 disabled:opacity-50 transition"
+            >
+              {loading ? "Loading…" : "Load more"}
+            </button>
+          </div>
+        )}
+      </section>
+
+      {showSetupBanner && (
+        <section
+          className="rounded-xl border border-slate-200/90 bg-slate-50/80 px-4 py-3 text-sm text-slate-800"
+          data-testid="inbox-setup-banner"
+        >
+          <p className="font-semibold text-slate-900">No workspace yet</p>
+          <p className="mt-1 text-xs leading-relaxed text-slate-500">
+            Create your first workspace to unlock projects and workspace-scoped notifications. This
+            banner is secondary — modules and notifications above are your operational Inbox.
+          </p>
+          {isAdmin && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => setShowCreateModal(true)}
+                className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-blue-700 transition"
+                data-testid="inbox-create-workspace"
+              >
+                Create workspace
+              </button>
+              <button
+                type="button"
+                onClick={() => nav("/administration/users")}
+                className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 transition"
+                data-testid="inbox-invite-members"
+              >
+                Invite members
               </button>
             </div>
           )}
@@ -322,28 +380,6 @@ export default function InboxPage() {
         onClose={() => setShowCreateModal(false)}
         onCreated={handleWorkspaceCreated}
       />
-    </div>
-  );
-}
-
-function GettingStartedStep({
-  number,
-  title,
-  text,
-}: {
-  number: string;
-  title: string;
-  text: string;
-}) {
-  return (
-    <div className="flex gap-3 rounded-xl border border-slate-200 bg-slate-50/50 p-4">
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-teal-500 text-xs font-semibold text-white shadow-sm">
-        {number}
-      </div>
-      <div>
-        <div className="text-sm font-semibold text-slate-800">{title}</div>
-        <div className="mt-0.5 text-sm leading-relaxed text-slate-500">{text}</div>
-      </div>
     </div>
   );
 }

--- a/zephix-frontend/src/pages/__tests__/InboxPage.shell.test.tsx
+++ b/zephix-frontend/src/pages/__tests__/InboxPage.shell.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Shell: Inbox operational surface (modules + feed), not welcome-only.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import InboxPage from '../InboxPage';
+
+vi.mock('@/lib/api', () => ({
+  request: {
+    get: vi.fn().mockResolvedValue({ notifications: [], nextCursor: null }),
+    post: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('@/stores/uiStore', () => ({
+  useUIStore: vi.fn(() => ({ addToast: vi.fn() })),
+}));
+
+vi.mock('@/state/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ user: { id: '1', platformRole: 'ADMIN', role: 'admin' } })),
+}));
+
+vi.mock('@/state/workspace.store', () => ({
+  useWorkspaceStore: vi.fn(() => ({ setActiveWorkspace: vi.fn() })),
+}));
+
+vi.mock('@/features/organizations/useOrgHomeState', () => ({
+  useOrgHomeState: vi.fn(() => ({ workspaceCount: 0, isLoading: false })),
+}));
+
+vi.mock('@/hooks/useUnreadNotifications', () => ({
+  useUnreadNotifications: vi.fn(() => ({ unreadCount: 0, refresh: vi.fn() })),
+}));
+
+vi.mock('@/utils/access', () => ({
+  isPlatformAdmin: vi.fn(() => true),
+}));
+
+vi.mock('@/features/workspaces/WorkspaceCreateModal', () => ({
+  WorkspaceCreateModal: () => null,
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn(),
+}));
+
+function renderInbox() {
+  return render(
+    <MemoryRouter>
+      <InboxPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('InboxPage shell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders operational module grid, not welcome-only content', async () => {
+    renderInbox();
+    expect(await screen.findByTestId('inbox-modules')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-module-assignments')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-feed')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^Welcome to Zephix$/i })).not.toBeInTheDocument();
+  });
+});

--- a/zephix-frontend/src/views/dashboards/View.tsx
+++ b/zephix-frontend/src/views/dashboards/View.tsx
@@ -1,8 +1,11 @@
 // Phase 4.3: Dashboard View with Global Filters and Widget Grid
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate, useLocation, Link, useSearchParams } from "react-router-dom";
-import { RefreshCw, Share2, Edit, Calendar, LogIn } from "lucide-react";
+import { RefreshCw, Share2, Edit, Calendar, LogIn, Plus } from "lucide-react";
 import { fetchDashboard, fetchDashboardPublic } from "@/features/dashboards/api";
+import { AddCardModal } from "@/features/dashboards/AddCardModal";
+import { createWidget } from "@/features/dashboards/widget-registry";
+import type { WidgetType } from "@/features/dashboards/types";
 import { useAuth } from "@/state/AuthContext";
 import { queryWidgets } from "@/features/widgets/api";
 import FiltersBar from "@/features/dashboards/FiltersBar";
@@ -32,6 +35,7 @@ export default function DashboardView() {
   const [error, setError] = useState<string | null>(null);
   const [workspaceError, setWorkspaceError] = useState(false);
   const [kpiCache, setKpiCache] = useState<Map<string, { value: number; timestamp: number }>>(new Map());
+  const [addCardOpen, setAddCardOpen] = useState(false);
 
   // Global filters state
   const urlFilters = useMemo(() => parseFiltersFromUrl(location.search), [location.search]);
@@ -339,11 +343,23 @@ export default function DashboardView() {
             </button>
           )}
 
+          {/* Add Card Button - Hidden in share mode */}
+          {!isShareMode && (
+            <button
+              onClick={() => setAddCardOpen(true)}
+              className="inline-flex items-center px-3 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-200 rounded-md hover:bg-slate-50"
+              data-testid="dashboard-add-card"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Add Card
+            </button>
+          )}
+
           {/* Edit Button - Hidden in share mode */}
           {!isShareMode && (
             <Link
               to={`/dashboards/${id}/edit`}
-              className="inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md hover:bg-indigo-700"
+              className="inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700"
               data-testid="dashboard-edit"
             >
               <Edit className="w-4 h-4 mr-2" />
@@ -441,6 +457,39 @@ export default function DashboardView() {
           onClose={() => setShareOpen(false)}
         />
       )}
+
+      <AddCardModal
+        open={addCardOpen}
+        onClose={() => setAddCardOpen(false)}
+        onSelect={async (widgetType: WidgetType) => {
+          if (!id) return;
+          try {
+            const widget = createWidget(widgetType);
+            const { patchDashboard } = await import("@/features/dashboards/api");
+            const current = dashboard as DashboardEntity;
+            const existingWidgets = current?.widgets ?? [];
+            await patchDashboard(id, {
+              widgets: [...existingWidgets.map(w => ({
+                widgetKey: w.type,
+                title: w.title,
+                config: w.config,
+                layout: w.layout,
+              })), {
+                widgetKey: widget.type,
+                title: widget.title,
+                config: widget.config,
+                layout: widget.layout,
+              }],
+            });
+            // Refresh dashboard to show new widget
+            const fresh = await fetchDashboard(id);
+            setDashboard(fresh);
+            track("dashboard.card_added", { widgetType, dashboardId: id });
+          } catch (err: any) {
+            console.error("Failed to add card:", err);
+          }
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes four truthfulness gaps from Pass 3:

- **Favorites show real names**: Backend enriches favorites with `displayName` resolved from workspace/project/dashboard tables. No more UUID fragments in sidebar.
- **Add Card is live**: `AddCardModal` wired into `DashboardView` with real "Add Card" button. Selecting a card type creates a widget via `patchDashboard` and refreshes.
- **Dashboard directory honesty**: Route comment corrected — no longer claims "standalone" when it's workspace-dependent.
- **Backend verified**: TypeScript clean, migration SQL verified structurally, entity-migration alignment confirmed. Migration NOT yet run on staging DB.

## Test plan

- [ ] Run migration 060 on staging DB
- [ ] `GET /favorites` returns items with `displayName` field
- [ ] Sidebar favorites show real workspace/project/dashboard names
- [ ] No UUID fragments visible in favorites
- [ ] Open a dashboard at `/dashboards/:id` — "Add Card" button visible
- [ ] Click "Add Card" — modal opens with Zephix categories
- [ ] Select a card type — widget created and dashboard refreshes
- [ ] Close modal works cleanly
- [ ] `/dashboards` shows honest workspace-required message when no workspace selected
- [ ] No regression to Inbox, shell, Shared, profile menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)