### PR TITLE
feat(admin-console): MVP-1 — full-page layout switch + back link + role rename

### DIFF
--- a/zephix-frontend/src/App.tsx
+++ b/zephix-frontend/src/App.tsx
@@ -191,20 +191,6 @@ export default function App() {
               <Route path="/settings/profile" element={<Navigate to="/settings" replace />} />
               {/* Phase 2A: Billing restricted to platform admin */}
               <Route path="/billing" element={<RequireAdminInline><BillingPage /></RequireAdminInline>} />
-              {/* Administration control plane - admin only */}
-              <Route path="/administration" element={<RequireAdminInline><AdministrationLayout /></RequireAdminInline>}>
-                <Route index element={<AdministrationOverviewPage />} />
-                <Route path="governance" element={<AdministrationGovernancePage />} />
-                <Route path="workspaces" element={<AdministrationWorkspacesPage />} />
-                <Route path="templates" element={<AdministrationTemplatesPage />} />
-                <Route path="users" element={<AdministrationUsersPage />} />
-                <Route path="audit-log" element={<AdministrationAuditLogPage />} />
-                <Route path="settings" element={<AdministrationSettingsPage />} />
-                <Route path="billing" element={<AdministrationBillingPage />} />
-              </Route>
-              {/* Legacy admin compatibility paths */}
-              <Route path="/admin" element={<RequireAdminInline><Navigate to="/administration" replace /></RequireAdminInline>} />
-              <Route path="/admin/*" element={<RequireAdminInline><Navigate to="/administration" replace /></RequireAdminInline>} />
               <Route path="/org-dashboard" element={<RequireAdminInline><OrgDashboardPage /></RequireAdminInline>} />
 
               {/* Pass 3: Dashboards directory — Org Admin only. Still workspace-dependent for listing/creation. */}
@@ -275,6 +261,37 @@ export default function App() {
               <Route path="/403" element={<Forbidden />} />
               <Route path="/404" element={<NotFound />} />
             </Route>
+
+            {/*
+             * Administration control plane — full-page layout (Admin Console MVP-1).
+             * Per Admin Console Architecture Spec v1 §4.1: when the user enters
+             * Administration, the main app sidebar disappears and the admin
+             * sidebar takes the full left panel. This route is a SIBLING of
+             * DashboardLayout (NOT nested inside it) so AdministrationLayout
+             * is the only layout in the tree, replacing the main app shell.
+             *
+             * Still inside ProtectedRoute so unauthenticated users are bounced
+             * to /login. Still gated by RequireAdminInline so only platform
+             * ADMIN users can reach it (matches the backend AdminGuard which
+             * also checks normalizePlatformRole(...) === ADMIN).
+             *
+             * Legacy /admin and /admin/* paths redirect to /administration.
+             * They live here as siblings (not under DashboardLayout) so the
+             * redirect target is reachable from the same shell-less context.
+             */}
+            <Route path="/administration" element={<RequireAdminInline><AdministrationLayout /></RequireAdminInline>}>
+              <Route index element={<AdministrationOverviewPage />} />
+              <Route path="governance" element={<AdministrationGovernancePage />} />
+              <Route path="workspaces" element={<AdministrationWorkspacesPage />} />
+              <Route path="templates" element={<AdministrationTemplatesPage />} />
+              <Route path="users" element={<AdministrationUsersPage />} />
+              <Route path="audit-log" element={<AdministrationAuditLogPage />} />
+              <Route path="settings" element={<AdministrationSettingsPage />} />
+              <Route path="billing" element={<AdministrationBillingPage />} />
+            </Route>
+            {/* Legacy admin compatibility paths — also outside DashboardLayout. */}
+            <Route path="/admin" element={<RequireAdminInline><Navigate to="/administration" replace /></RequireAdminInline>} />
+            <Route path="/admin/*" element={<RequireAdminInline><Navigate to="/administration" replace /></RequireAdminInline>} />
 
           </Route>
 

--- a/zephix-frontend/src/features/administration/api/administration.api.ts
+++ b/zephix-frontend/src/features/administration/api/administration.api.ts
@@ -277,8 +277,13 @@ export const administrationApi = {
 
   async inviteUsers(input: {
     emails: string[];
-    platformRole: "Admin" | "Member" | "Guest";
-    workspaceAssignments?: Array<{ workspaceId: string; accessLevel: "Member" | "Guest" }>;
+    // Admin Console MVP-1 — canonical platform role vocabulary per spec §3.3.
+    // Guest is renamed to Viewer everywhere in the administration feature.
+    // The backend `normalizePlatformRole` accepts both values during the
+    // transition; the migration to canonical DB values (§9.3) is deferred
+    // to a separate cleanup PR.
+    platformRole: "Admin" | "Member" | "Viewer";
+    workspaceAssignments?: Array<{ workspaceId: string; accessLevel: "Member" | "Viewer" }>;
   }): Promise<{ results: Array<{ email: string; status: "success" | "error"; message?: string }> }> {
     const payload = await request.post<
       Envelope<{ results: Array<{ email: string; status: "success" | "error"; message?: string }> }>

--- a/zephix-frontend/src/features/administration/layout/AdministrationLayout.tsx
+++ b/zephix-frontend/src/features/administration/layout/AdministrationLayout.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import { NavLink, Outlet } from "react-router-dom";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Link, NavLink, Outlet } from "react-router-dom";
+import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react";
 import { ADMINISTRATION_NAV_ITEMS } from "@/features/administration/constants";
 
 export default function AdministrationLayout() {
@@ -18,6 +18,25 @@ export default function AdministrationLayout() {
 
       <div className="hidden lg:flex h-full">
         <aside className={`${navWidth} shrink-0 border-r border-gray-200 bg-white transition-all`}>
+          {/*
+           * Admin Console MVP-1 — "Back to Zephix" exit affordance.
+           * Per Admin Console Architecture Spec v1 §4.1: every Admin Console
+           * page must offer a clear way back to the operational app. /inbox
+           * is the universal post-login landing per the same spec, so it's
+           * the safest target. When the sidebar is collapsed, only the
+           * ArrowLeft icon shows; when expanded, the icon + label show.
+           */}
+          <Link
+            to="/inbox"
+            data-testid="admin-back-to-zephix"
+            title={collapsed ? "Back to Zephix" : undefined}
+            className={`flex items-center gap-2 border-b border-gray-200 px-3 py-2 text-sm text-gray-500 transition-colors hover:text-gray-900 ${
+              collapsed ? "justify-center" : ""
+            }`}
+          >
+            <ArrowLeft className="h-4 w-4 shrink-0" />
+            {!collapsed ? <span>Back to Zephix</span> : null}
+          </Link>
           <div className="flex h-14 items-center justify-between border-b border-gray-200 px-3">
             {!collapsed ? (
               <div>


### PR DESCRIPTION
## Summary

MVP-1 of the Admin Console buildout per the [Architecture & Design Spec v1](docs/architecture/template-center-mvp-source-of-truth.md). First phase of bringing the Admin Console to spec.

This branch also carries one carry-over commit from prior work:
- \`6bebf7fa fix(frontend): apiClient CSRF token for cross-origin staging (Template Center)\` — operator's follow-up to PR #112's CSRF fix that extended the cache-clear to the second axios instance under \`lib/api/client.ts\`.

### MVP-1 Changes (this PR)

1. **Full-page layout switch** — lifted \`/administration/*\` and the legacy \`/admin\`, \`/admin/*\` redirects OUT of the \`<DashboardLayout />\` parent route in \`App.tsx\`. They are now siblings of DashboardLayout (still inside ProtectedRoute). When a user enters Administration, the main app sidebar (Inbox / My Work / Workspaces / Dashboards) disappears completely. Only the admin sidebar is visible. Matches the spec's Monday.com / Linear-style \"full-page context switch\" pattern.

2. **\"← Back to Zephix\" link** — added \`<Link to=\"/inbox\">\` at the top of the admin sidebar, above the \"Administration / Control plane\" header. Visible in both expanded and collapsed sidebar states. \`data-testid=\"admin-back-to-zephix\"\` for future test coverage.

3. **Guest → Viewer rename** — updated invite type union in \`features/administration/api/administration.api.ts\` from \`Admin | Member | Guest\` to \`Admin | Member | Viewer\` in BOTH the \`platformRole\` field AND the \`workspaceAssignments[].accessLevel\` field. Backend \`normalizePlatformRole\` already accepts both Guest and Viewer values during the transition; the DB-side role normalization migration (spec §9.3) is intentionally deferred to a separate cleanup PR after MVP per the verification report.

### Phase 0 Reconnaissance Findings (locked in for future MVP phases)

- **AdminGuard** (\`zephix-backend/src/admin/guards/admin.guard.ts\`): checks \`normalizePlatformRole(user.platformRole ?? user.role) === ADMIN\`
- **RequireAdminInline** (frontend, \`App.tsx:127\`): checks \`platformRoleFromUser(user) === 'ADMIN' || user.permissions?.isAdmin === true\`
- **They AGREE** on the canonical ADMIN check. The frontend has an extra legacy \`permissions.isAdmin\` escape hatch that the backend does NOT honor. Future RBAC cleanup should remove the FE-only escape hatch.
- **Invitations storage**: \`org_invites\` table (entity at \`zephix-backend/src/modules/auth/entities/org-invite.entity.ts\`), served by \`OrgInvitesService\`. The legacy \`invitations\` table referenced in spec §3.3/§9.3 does NOT exist on staging (only an entity file at \`organizations/entities/invitation.entity.ts\` that's wired to a different table). The spec needs a follow-up correction here.
- **ADMINISTRATION_NAV_ITEMS**: canonical 8-item list at \`features/administration/constants.ts\`, matches the spec exactly.

### Verification

- \`tsc --noEmit\` (frontend): **0 errors**
- \`tsc --noEmit\` (backend): **0 errors**
- Administration feature tests: **5/5 passing** (\`AdministrationPages.test.tsx\`)
- No files touched in dead admin code directories:
  - \`features/admin/\` (27 dead files) — untouched
  - \`pages/admin/\` (39 dead files) — untouched
  - Confirmed via \`git diff --name-only | grep -E '(features/admin/|pages/admin/)'\` returning empty
- Files changed: exactly 3 (App.tsx, AdministrationLayout.tsx, administration.api.ts)
- Stop conditions: none triggered

### Test plan (manual smoke)

After Railway auto-deploys this PR:

- [ ] Sign in to staging as a platform admin
- [ ] Navigate to \`/administration\` — should see ONLY the admin sidebar (no Inbox, My Work, Workspaces, Dashboards), with the 8 admin nav items + new \"← Back to Zephix\" link at the top
- [ ] Click \"← Back to Zephix\" — should navigate to \`/inbox\` and the main app shell should reappear
- [ ] Collapse the admin sidebar (chevron) — \"Back to Zephix\" should collapse to icon-only
- [ ] Try inviting a user as Viewer (formerly Guest) — should work end-to-end
- [ ] Visit \`/admin\` directly — should redirect to \`/administration\` and still render the new full-page layout

### Next phases (separate PRs per spec)

- **MVP-2**: Replace \`window.prompt()\` invite flow in \`AdministrationUsersPage.tsx\` with proper modal (spec §5.2.1)
- **MVP-3**: Workspace member management panel + create-workspace modal (spec §5.3)
- **MVP-4**: Settings page with Organization Profile + Security tabs (spec §5.5)
- **MVP-5**: Polish + Overview API error fix + Billing upgrade CTA + Quick Actions copy update

### Deferred (separate cleanup PRs)

- Role normalization migration (438 rows on staging) — runtime normalizers handle legacy values correctly, no urgency
- Dead admin code deletion (66 files in \`features/admin/\` + \`pages/admin/\`) — separate sweep PR after MVP ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)