### PR TITLE
fix(admin-console): MVP-2.1 — enterprise invite dialog + profile popup + users table fix

### DIFF
--- a/zephix-frontend/src/components/shell/UserProfileDropdown.tsx
+++ b/zephix-frontend/src/components/shell/UserProfileDropdown.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { track } from "@/lib/telemetry";
 import { platformRoleFromUser, PLATFORM_ROLE } from "@/utils/roles";
+import { InviteMembersDialog } from "@/features/administration/components/InviteMembersDialog";
 
 const HELP_URL = "https://docs.zephix.io";
 
@@ -24,6 +25,7 @@ export function UserProfileDropdown({ align = "left" }: { align?: Align }) {
   const { clearActiveWorkspace } = useWorkspaceStore();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -138,12 +140,19 @@ export function UserProfileDropdown({ align = "left" }: { align?: Align }) {
               testId="menu-preferences"
             />
 
-            {/* Invite Members — admin only */}
+            {/* Invite Members — admin only. Opens dialog directly on
+                current page instead of navigating to Admin Console.
+                MVP-2.1: operator feedback that navigation-to-admin is
+                jarring when you just want to send an invite. */}
             {isAdmin && (
               <MenuItem
                 icon={<UserPlus className="h-4 w-4" />}
                 label="Invite Members"
-                onClick={() => go("invite_members", "/administration/users")}
+                onClick={() => {
+                  setOpen(false); // close the dropdown first
+                  setInviteOpen(true);
+                  track("user.menu.action", { action: "invite_members" });
+                }}
                 testId="menu-invite-members"
               />
             )}
@@ -198,6 +207,14 @@ export function UserProfileDropdown({ align = "left" }: { align?: Align }) {
           </div>
         </div>
       )}
+
+      {/* MVP-2.1: Invite dialog rendered outside the dropdown so it stays
+          open after the dropdown closes. The dialog uses Modal which has
+          its own fixed-position backdrop and z-50 stacking. */}
+      <InviteMembersDialog
+        isOpen={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+      />
     </div>
   );
 }

--- a/zephix-frontend/src/features/administration/api/administration.api.ts
+++ b/zephix-frontend/src/features/administration/api/administration.api.ts
@@ -247,10 +247,37 @@ export const administrationApi = {
     role?: string;
     status?: string;
   }): Promise<{ data: AdminDirectoryUser[]; meta: PageMeta | null }> {
-    const payload = await request.get<Envelope<AdminDirectoryUser[]>>(
-      `/admin/users${buildQuery(params || {})}`,
-    );
-    return { data: asArray(unwrapData(payload)), meta: unwrapMeta(payload) };
+    // MVP-2.1 fix: The backend GET /admin/users returns
+    // { users: [{id, email, firstName, lastName, role, status, ...}], pagination: {...} }
+    // NOT { data: [...] }. The response interceptor passes it through as-is
+    // because there's no outer `data` key. We need to:
+    //   1. Extract the `users` array from the raw response
+    //   2. Transform each user to the AdminDirectoryUser shape (combine
+    //      firstName+lastName into `name`, add empty `workspaceAccess`)
+    //   3. Extract pagination into the PageMeta format
+    const raw = await request.get<any>(`/admin/users${buildQuery(params || {})}`);
+    const rawPayload = raw && typeof raw === "object" ? raw : {};
+    const usersArr: any[] = Array.isArray(rawPayload.users)
+      ? rawPayload.users
+      : Array.isArray(rawPayload) // fallback if interceptor unwrapped differently
+        ? rawPayload
+        : asArray(unwrapData(rawPayload));
+
+    const data: AdminDirectoryUser[] = usersArr.map((u: any) => ({
+      id: String(u.id ?? ""),
+      name: [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.email || "Unknown",
+      email: u.email ?? "",
+      role: (u.role ?? "member").toLowerCase() as AdminDirectoryUser["role"],
+      status: (u.status ?? "active") as AdminDirectoryUser["status"],
+      workspaceAccess: Array.isArray(u.workspaceAccess) ? u.workspaceAccess : [],
+    }));
+
+    const pag = rawPayload.pagination;
+    const meta: PageMeta | null = pag
+      ? { page: pag.page ?? 1, limit: pag.limit ?? 20, total: pag.total ?? data.length }
+      : null;
+
+    return { data, meta };
   },
 
   async changeUserRole(

--- a/zephix-frontend/src/features/administration/components/InviteMembersDialog.tsx
+++ b/zephix-frontend/src/features/administration/components/InviteMembersDialog.tsx
@@ -1,60 +1,90 @@
 /**
- * InviteMembersDialog — Admin Console MVP-2.
+ * InviteMembersDialog — Admin Console MVP-2.1 (designer-grade redesign).
  *
- * Compact popup dialog for inviting new people to the organization.
- * Replaces the `window.prompt("Enter admin email")` in the Users page
- * and the Overview Quick Actions.
+ * Enterprise-quality invite dialog inspired by Linear's chip input,
+ * Notion's role clarity, ClickUp's functional depth. Replaces the
+ * MVP-2 basic textarea+radio implementation.
  *
- * Per Admin Console Architecture Spec v1 §5.2.1:
- * - Email textarea (comma/newline separated)
- * - Role radio selector (Admin / Member / Viewer with descriptions)
- * - Optional workspace assignment (hidden when zero workspaces)
- * - Domain restriction note
- * - Two-phase UI: form → per-email results display
+ * Uses the existing Modal component (no Dialog/Popover available in
+ * the component library). All interactive elements use Zephix brand
+ * purple via the existing `bg-primary` / `text-primary` tokens.
  *
- * Uses the existing Modal component from `components/ui/overlay/Modal`.
- * Calls existing `administrationApi.inviteUsers()` — no backend changes.
+ * Features:
+ * - Chip-based email input (tokenized, paste-friendly, Enter/comma
+ *   to add, Backspace to remove, inline validation)
+ * - Rich role selector dropdown with icon, name, description,
+ *   permission tags, and 'Recommended' badge
+ * - Conditional workspace assignment (hidden when zero workspaces)
+ * - Two-phase UI: form → per-email results with "Invite more" loop
+ * - Email count badge on submit button
+ *
+ * Per Admin Console Architecture Spec v1 §5.2.1 + UX/UI designer spec.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   CheckCircle,
+  ChevronDown,
+  Eye,
   Info,
   Loader2,
+  Mail,
+  Shield,
+  User,
+  X,
   XCircle,
 } from "lucide-react";
 import { Modal } from "@/components/ui/overlay/Modal";
+import { Button } from "@/components/ui/button/Button";
 import {
   administrationApi,
   type WorkspaceSnapshotRow,
 } from "@/features/administration/api/administration.api";
 
+/* ── Types + config ─────────────────────────────────────────────── */
+
 interface InviteMembersDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: () => void;
+  /** Context label shown in header (e.g. workspace name). */
+  contextLabel?: string;
 }
 
-type RoleOption = {
-  value: "Admin" | "Member" | "Viewer";
-  label: string;
-  description: string;
-};
+type RoleId = "Admin" | "Member" | "Viewer";
 
-const ROLE_OPTIONS: RoleOption[] = [
+const ROLES: ReadonlyArray<{
+  id: RoleId;
+  name: string;
+  description: string;
+  icon: typeof Shield;
+  permissions: string[];
+  recommended?: boolean;
+  colorClass: string;
+}> = [
   {
-    value: "Admin",
-    label: "Admin",
+    id: "Admin",
+    name: "Admin",
     description: "Full platform control — workspaces, people, billing, settings",
+    icon: Shield,
+    permissions: ["All permissions"],
+    colorClass: "text-amber-500",
   },
   {
-    value: "Member",
-    label: "Member",
+    id: "Member",
+    name: "Member",
     description: "Operational access within assigned workspaces",
+    icon: User,
+    permissions: ["Create", "Edit", "Comment"],
+    recommended: true,
+    colorClass: "text-violet-600",
   },
   {
-    value: "Viewer",
-    label: "Viewer",
+    id: "Viewer",
+    name: "Viewer",
     description: "Read-only access to shared items",
+    icon: Eye,
+    permissions: ["View only"],
+    colorClass: "text-gray-500",
   },
 ];
 
@@ -64,27 +94,38 @@ type InviteResult = {
   message?: string;
 };
 
+/* ── Component ──────────────────────────────────────────────────── */
+
 export function InviteMembersDialog({
   isOpen,
   onClose,
   onSuccess,
+  contextLabel,
 }: InviteMembersDialogProps) {
-  const [emails, setEmails] = useState("");
-  const [role, setRole] = useState<"Admin" | "Member" | "Viewer">("Member");
+  // ── Core state ──
+  const [emailChips, setEmailChips] = useState<string[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const [selectedRole, setSelectedRole] = useState<RoleId>("Member");
   const [selectedWorkspaceIds, setSelectedWorkspaceIds] = useState<string[]>([]);
   const [workspaces, setWorkspaces] = useState<WorkspaceSnapshotRow[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [results, setResults] = useState<InviteResult[] | null>(null);
-  const [errors, setErrors] = useState<string[]>([]);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [roleDropdownOpen, setRoleDropdownOpen] = useState(false);
 
-  // Reset on open + load workspaces.
+  const inputRef = useRef<HTMLInputElement>(null);
+  const roleDropdownRef = useRef<HTMLDivElement>(null);
+
+  // ── Reset on open + load workspaces ──
   useEffect(() => {
     if (isOpen) {
-      setEmails("");
-      setRole("Member");
+      setEmailChips([]);
+      setInputValue("");
+      setSelectedRole("Member");
       setSelectedWorkspaceIds([]);
       setResults(null);
-      setErrors([]);
+      setEmailError(null);
+      setRoleDropdownOpen(false);
       administrationApi
         .listWorkspaces()
         .then((ws) => setWorkspaces(ws.filter((w) => w.status === "ACTIVE")))
@@ -92,47 +133,89 @@ export function InviteMembersDialog({
     }
   }, [isOpen]);
 
+  // ── Close role dropdown on outside click ──
+  useEffect(() => {
+    if (!roleDropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        roleDropdownRef.current &&
+        !roleDropdownRef.current.contains(e.target as Node)
+      ) {
+        setRoleDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [roleDropdownOpen]);
+
+  // ── Email chip logic ──
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  function addEmail(raw: string) {
+    const cleaned = raw.trim().toLowerCase();
+    if (!cleaned) return;
+    if (!emailRegex.test(cleaned)) {
+      setEmailError(`"${cleaned}" is not a valid email`);
+      return;
+    }
+    if (emailChips.includes(cleaned)) {
+      setEmailError(`"${cleaned}" already added`);
+      return;
+    }
+    setEmailError(null);
+    setEmailChips((prev) => [...prev, cleaned]);
+  }
+
+  function removeEmail(email: string) {
+    setEmailChips((prev) => prev.filter((e) => e !== email));
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addEmail(inputValue);
+      setInputValue("");
+    }
+    if (e.key === "Backspace" && !inputValue && emailChips.length > 0) {
+      removeEmail(emailChips[emailChips.length - 1]);
+    }
+  }
+
+  function handlePaste(e: React.ClipboardEvent) {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData("text");
+    pasted
+      .split(/[,;\s\n]+/)
+      .filter(Boolean)
+      .forEach(addEmail);
+    setInputValue("");
+  }
+
+  // ── Submit ──
   async function handleSubmit() {
-    const parsed = emails
-      .split(/[,;\n]/)
-      .map((e) => e.trim())
-      .filter(Boolean);
-
-    // Basic email format check.
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const invalid = parsed.filter((e) => !emailRegex.test(e));
-    if (invalid.length > 0) {
-      setErrors(invalid.map((e) => `"${e}" is not a valid email`));
-      return;
-    }
-    if (parsed.length === 0) {
-      setErrors(["Enter at least one email address"]);
-      return;
-    }
-
-    setErrors([]);
+    if (emailChips.length === 0) return;
     setIsSubmitting(true);
 
     const workspaceAssignments =
       selectedWorkspaceIds.length > 0
         ? selectedWorkspaceIds.map((wsId) => ({
             workspaceId: wsId,
-            accessLevel: (role === "Viewer" ? "Viewer" : "Member") as
-              | "Member"
-              | "Viewer",
+            accessLevel: (selectedRole === "Viewer"
+              ? "Viewer"
+              : "Member") as "Member" | "Viewer",
           }))
         : undefined;
 
     try {
       const res = await administrationApi.inviteUsers({
-        emails: parsed,
-        platformRole: role,
+        emails: emailChips,
+        platformRole: selectedRole,
         workspaceAssignments,
       });
       setResults(res.results);
     } catch {
       setResults(
-        parsed.map((email) => ({
+        emailChips.map((email) => ({
           email,
           status: "error" as const,
           message: "Failed to send. Try again.",
@@ -141,6 +224,15 @@ export function InviteMembersDialog({
     } finally {
       setIsSubmitting(false);
     }
+  }
+
+  function resetForm() {
+    setEmailChips([]);
+    setInputValue("");
+    setSelectedRole("Member");
+    setSelectedWorkspaceIds([]);
+    setResults(null);
+    setEmailError(null);
   }
 
   function handleDone() {
@@ -154,174 +246,299 @@ export function InviteMembersDialog({
     );
   }
 
-  // ── Results phase ──
+  const activeRole = ROLES.find((r) => r.id === selectedRole)!;
+
+  // ══════════════════════════════════════════════════════════════════
+  // SUCCESS STATE
+  // ══════════════════════════════════════════════════════════════════
   if (results) {
+    const successCount = results.filter((r) => r.status === "success").length;
     return (
-      <Modal isOpen={isOpen} onClose={handleDone} title="Invitation Results" size="sm">
-        <div className="space-y-3">
-          {results.map((r) => (
-            <div
-              key={r.email}
-              className="flex items-start gap-2 text-sm"
-            >
-              {r.status === "success" ? (
-                <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-green-600" />
-              ) : (
-                <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
-              )}
-              <div className="min-w-0">
-                <span className="font-medium text-gray-900">{r.email}</span>
-                <span className="ml-1 text-gray-500">
-                  — {r.status === "success" ? "Invitation sent" : r.message || "Error"}
-                </span>
-              </div>
+      <Modal isOpen={isOpen} onClose={handleDone} size="sm" showCloseButton={false}>
+        <div className="space-y-5">
+          {/* Banner */}
+          <div className="rounded-xl bg-emerald-50 p-5 text-center">
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100">
+              <CheckCircle className="h-6 w-6 text-emerald-600" />
             </div>
-          ))}
-        </div>
-        <div className="mt-6 flex justify-end">
-          <button
-            type="button"
-            onClick={handleDone}
-            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-          >
-            Done
-          </button>
+            <h3 className="mb-1 text-base font-semibold text-gray-900">
+              Invites sent successfully
+            </h3>
+            <p className="text-sm text-gray-500">
+              {successCount} of {results.length} invitation
+              {results.length !== 1 ? "s" : ""} sent
+            </p>
+          </div>
+
+          {/* Per-email results */}
+          <div className="space-y-1.5">
+            {results.map((r, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2"
+              >
+                <span className="text-sm font-medium text-gray-700">
+                  {r.email}
+                </span>
+                {r.status === "success" ? (
+                  <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700">
+                    Sent
+                  </span>
+                ) : (
+                  <span
+                    className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700"
+                    title={r.message}
+                  >
+                    Failed
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3 pt-2">
+            <Button variant="outline" className="flex-1" onClick={resetForm}>
+              Invite more
+            </Button>
+            <Button variant="primary" className="flex-1" onClick={handleDone}>
+              Done
+            </Button>
+          </div>
         </div>
       </Modal>
     );
   }
 
-  // ── Form phase ──
+  // ══════════════════════════════════════════════════════════════════
+  // FORM STATE
+  // ══════════════════════════════════════════════════════════════════
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Invite People" size="sm">
-      <div className="space-y-5">
-        {/* Email addresses */}
+    <Modal isOpen={isOpen} onClose={onClose} size="sm" showCloseButton={false}>
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-violet-50">
+          <Mail className="h-5 w-5 text-violet-600" />
+        </div>
         <div>
-          <label
-            htmlFor="invite-emails"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
+          <h2 className="text-lg font-semibold tracking-tight text-gray-900">
+            Invite members
+          </h2>
+          {contextLabel && (
+            <p className="text-sm text-gray-500">to {contextLabel}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-5">
+        {/* ── Email chip input ── */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-gray-700">
             Email addresses
           </label>
-          <textarea
-            id="invite-emails"
-            rows={3}
-            value={emails}
-            onChange={(e) => {
-              setEmails(e.target.value);
-              setErrors([]);
-            }}
-            placeholder="Enter email addresses, separated by commas"
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-          />
-          <div className="mt-1 flex items-center gap-1.5 text-xs text-gray-500">
-            <Info className="h-3 w-3 shrink-0" />
-            <span>Invitations are restricted to your organization's email domain.</span>
-          </div>
-          {errors.length > 0 && (
-            <div className="mt-2 space-y-1">
-              {errors.map((err) => (
-                <p key={err} className="text-xs text-red-600">
-                  {err}
-                </p>
+          <div
+            className={`min-h-[80px] rounded-lg border bg-gray-50/50 p-2.5 transition-all focus-within:border-violet-500 focus-within:ring-2 focus-within:ring-violet-500/20 ${
+              emailError ? "border-red-300" : "border-gray-200"
+            }`}
+            onClick={() => inputRef.current?.focus()}
+          >
+            <div className="flex flex-wrap gap-1.5">
+              {emailChips.map((email) => (
+                <span
+                  key={email}
+                  className="inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white py-1 pl-2 pr-1 text-sm text-gray-700"
+                >
+                  {email}
+                  <button
+                    type="button"
+                    onClick={() => removeEmail(email)}
+                    className="rounded-full p-0.5 transition-colors hover:bg-gray-200"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
               ))}
+              <input
+                ref={inputRef}
+                value={inputValue}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  setEmailError(null);
+                }}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                onBlur={() => {
+                  if (inputValue.trim()) {
+                    addEmail(inputValue);
+                    setInputValue("");
+                  }
+                }}
+                placeholder={
+                  emailChips.length === 0
+                    ? "Enter email addresses, separated by commas"
+                    : ""
+                }
+                className="min-w-[140px] flex-1 bg-transparent py-1 text-sm outline-none placeholder:text-gray-400"
+              />
             </div>
+          </div>
+          {emailError ? (
+            <p className="text-xs text-red-500">{emailError}</p>
+          ) : (
+            <p className="flex items-center gap-1.5 text-xs text-gray-400">
+              <span className="inline-block h-1 w-1 rounded-full bg-gray-400" />
+              Press Enter or comma to add multiple emails
+            </p>
           )}
         </div>
 
-        {/* Role selector */}
-        <div>
-          <label className="mb-2 block text-sm font-medium text-gray-700">
-            Organization Role
+        {/* ── Role selector ── */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-gray-700">
+            Organization role
           </label>
-          <div className="space-y-2">
-            {ROLE_OPTIONS.map((opt) => {
-              const selected = role === opt.value;
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => setRole(opt.value)}
-                  className={`w-full rounded-lg border p-3 text-left transition-colors ${
-                    selected
-                      ? "border-indigo-600 bg-indigo-50 ring-1 ring-indigo-600"
-                      : "border-gray-200 bg-white hover:bg-gray-50"
+          <div className="relative" ref={roleDropdownRef}>
+            <button
+              type="button"
+              onClick={() => setRoleDropdownOpen((v) => !v)}
+              className="w-full rounded-lg border border-gray-200 bg-white p-3 text-left transition-colors hover:border-gray-300"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <activeRole.icon
+                    className={`h-4 w-4 ${activeRole.colorClass}`}
+                  />
+                  <div>
+                    <div className="text-sm font-medium text-gray-900">
+                      {activeRole.name}
+                    </div>
+                    <div className="max-w-[240px] truncate text-xs text-gray-500">
+                      {activeRole.description}
+                    </div>
+                  </div>
+                </div>
+                <ChevronDown
+                  className={`h-4 w-4 text-gray-400 transition-transform ${
+                    roleDropdownOpen ? "rotate-180" : ""
                   }`}
-                >
-                  <div className="flex items-center gap-2">
-                    <div
-                      className={`h-4 w-4 shrink-0 rounded-full border-2 ${
-                        selected
-                          ? "border-indigo-600 bg-indigo-600"
-                          : "border-gray-300"
-                      }`}
-                    >
-                      {selected && (
-                        <div className="flex h-full items-center justify-center">
-                          <div className="h-1.5 w-1.5 rounded-full bg-white" />
-                        </div>
+                />
+              </div>
+            </button>
+
+            {roleDropdownOpen && (
+              <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+                {ROLES.map((role, idx) => (
+                  <button
+                    key={role.id}
+                    type="button"
+                    onClick={() => {
+                      setSelectedRole(role.id);
+                      setRoleDropdownOpen(false);
+                    }}
+                    className={`w-full px-4 py-3 text-left transition-colors hover:bg-gray-50 ${
+                      idx !== ROLES.length - 1
+                        ? "border-b border-gray-100"
+                        : ""
+                    } ${selectedRole === role.id ? "bg-gray-50" : ""}`}
+                  >
+                    <div className="flex w-full items-center gap-2">
+                      <role.icon
+                        className={`h-4 w-4 ${role.colorClass}`}
+                      />
+                      <span className="text-sm font-medium text-gray-900">
+                        {role.name}
+                      </span>
+                      {role.recommended && (
+                        <span className="ml-auto rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-700">
+                          Recommended
+                        </span>
                       )}
                     </div>
-                    <span className="text-sm font-medium text-gray-900">
-                      {opt.label}
-                    </span>
-                  </div>
-                  <p className="mt-0.5 pl-6 text-xs text-gray-500">
-                    {opt.description}
-                  </p>
-                </button>
-              );
-            })}
+                    <p className="mt-1.5 pl-6 text-xs leading-relaxed text-gray-500">
+                      {role.description}
+                    </p>
+                    <div className="mt-2 flex gap-1.5 pl-6">
+                      {role.permissions.map((perm) => (
+                        <span
+                          key={perm}
+                          className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500"
+                        >
+                          {perm}
+                        </span>
+                      ))}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 
-        {/* Workspace assignment (conditional) */}
+        {/* ── Workspace assignment (conditional) ── */}
         {workspaces.length > 0 && (
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700">
               Add to workspaces{" "}
               <span className="font-normal text-gray-400">(optional)</span>
             </label>
-            <div className="max-h-36 space-y-1 overflow-y-auto rounded-md border border-gray-200 p-2">
+            <div className="max-h-[120px] divide-y divide-gray-100 overflow-y-auto rounded-lg border border-gray-200">
               {workspaces.map((ws) => (
                 <label
                   key={ws.workspaceId}
-                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                  className="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-gray-50"
                 >
                   <input
                     type="checkbox"
                     checked={selectedWorkspaceIds.includes(ws.workspaceId)}
                     onChange={() => toggleWorkspace(ws.workspaceId)}
-                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    className="h-4 w-4 rounded border-gray-300 text-violet-600 focus:ring-violet-500/20"
                   />
-                  {ws.workspaceName}
+                  <span className="text-sm text-gray-700">
+                    {ws.workspaceName}
+                  </span>
                 </label>
               ))}
             </div>
-            <p className="mt-1 text-xs text-gray-400">
+            <p className="text-xs text-gray-400">
               Members added to a workspace can see all projects within it.
             </p>
           </div>
         )}
 
-        {/* Buttons */}
-        <div className="flex justify-end gap-2 pt-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
+        {/* ── Domain note ── */}
+        <p className="flex items-center gap-1.5 text-xs text-gray-400">
+          <Info className="h-3 w-3 shrink-0" />
+          Invitations are restricted to your organization's email domain.
+        </p>
+
+        {/* ── Footer ── */}
+        <div className="flex items-center justify-end gap-2 border-t border-gray-100 pt-4">
+          <Button variant="outline" size="sm" onClick={onClose}>
             Cancel
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
             onClick={handleSubmit}
-            disabled={isSubmitting || emails.trim().length === 0}
-            className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={isSubmitting || emailChips.length === 0}
+            className="min-w-[120px] gap-2"
           >
-            {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
-            Send Invitations
-          </button>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Sending...
+              </>
+            ) : (
+              <>
+                Send invites
+                {emailChips.length > 0 && (
+                  <span className="text-xs opacity-70">
+                    ({emailChips.length})
+                  </span>
+                )}
+              </>
+            )}
+          </Button>
         </div>
       </div>
     </Modal>

--- a/zephix-frontend/src/features/administration/pages/AdministrationOverviewPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationOverviewPage.tsx
@@ -8,6 +8,7 @@ import {
   type GovernanceActivityEvent,
 } from "@/features/administration/api/administration.api";
 import { ConfirmActionDialog } from "../components/ConfirmActionDialog";
+import { InviteMembersDialog } from "../components/InviteMembersDialog";
 
 function formatDate(value: string): string {
   if (!value) return "Unknown time";
@@ -79,6 +80,7 @@ export default function AdministrationOverviewPage() {
   // MVP-2: window.prompt replaced with ConfirmActionDialog.
   const [rejectTarget, setRejectTarget] = useState<GovernanceDecision | null>(null);
   const [infoTarget, setInfoTarget] = useState<GovernanceDecision | null>(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
 
   const onReject = (decision: GovernanceDecision) => setRejectTarget(decision);
   const onRequestInfo = (decision: GovernanceDecision) => setInfoTarget(decision);
@@ -255,7 +257,7 @@ export default function AdministrationOverviewPage() {
         <h2 className="text-sm font-semibold text-gray-900">Quick Actions</h2>
         <div className="mt-3 flex flex-wrap gap-2">
           <Link to="/administration/workspaces" className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Create Workspace</Link>
-          <Link to="/administration/users" className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Invite People</Link>
+          <button type="button" onClick={() => setInviteOpen(true)} className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Invite People</button>
           <Link to="/administration/governance" className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Open Governance Policies</Link>
           <Link to="/administration/templates" className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">Open Templates</Link>
           <Link to="/administration/audit-log" className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">View Audit Log</Link>
@@ -280,6 +282,10 @@ export default function AdministrationOverviewPage() {
         inputRequired
         confirmLabel="Send Request"
         onConfirm={handleInfoConfirm}
+      />
+      <InviteMembersDialog
+        isOpen={inviteOpen}
+        onClose={() => setInviteOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Hotfix for MVP-2 staging issues — designer-informed redesign

### Issue 1: Profile dropdown "Invite Members" opened wrong surface
**Before:** Navigated to Admin Console Users page.
**After:** Opens InviteMembersDialog as popup overlay on current page. Dialog renders outside the dropdown wrapper so it stays open when dropdown closes.

### Issue 2: Users table showed "No users available"
**Root cause:** Backend `GET /admin/users` returns `{users: [...], pagination: {...}}` but the frontend expected `{data: [...]}` (the standard Envelope shape). The response interceptor passed the raw `{users, pagination}` object through, then `asArray()` returned `[]` because the object is not an array.
**Fix:** `administration.api.ts` `listUsers()` now reads `.users` from the raw response, transforms each user (combines `firstName+lastName` into `name`, adds empty `workspaceAccess[]`), and extracts `pagination` into `PageMeta` format. The admin who is logged in now appears in the table.

### Issue 3: Invite dialog redesigned to enterprise quality
**Before:** Basic textarea + radio cards. Generic indigo styling.
**After:** Designer-spec implementation per UX/UI research (Linear/Notion/ClickUp patterns):

- **Chip-based email input** — tokenized pills with X remove, paste-friendly (splits on comma/semicolon/newline/whitespace), Enter/comma to add, Backspace to remove last, inline validation with error messages
- **Rich role selector dropdown** — icon + name + description + permission tags for each role. "Recommended" badge on Member role. Custom dropdown (no Popover/Dialog in UI library — uses absolute-positioned div with outside-click close)
- **Conditional workspace assignment** — multi-select checkboxes, hidden when zero workspaces exist
- **Two-phase UI** — form with email count badge on submit → success state with centered checkmark, per-email Sent/Failed badges, "Invite more" button that resets the form
- **Zephix brand colors** — violet-600 (existing primary) throughout, not generic indigo or blue

### Issue 4: Overview Quick Actions "Invite People"
**Before:** `<Link to="/administration/users">` (navigated away).
**After:** Button that opens InviteMembersDialog as overlay.

### Verification
- `tsc --noEmit` (frontend): **0 errors**
- Administration tests: **5/5 passing**
- `grep window.prompt` in administration/: **0 live calls**
- Dead code check (features/admin/, pages/admin/): **clean**
- Files changed: **4** (UserProfileDropdown, administration.api, InviteMembersDialog, OverviewPage)

### Test plan
- [ ] Click avatar → "Invite Members" → dialog opens as overlay on current page
- [ ] Type comma-separated emails → chips appear with X remove
- [ ] Paste multiple emails → auto-splits and tokenizes
- [ ] Select Admin/Member/Viewer → dropdown shows icon + description + permission tags
- [ ] Click "Send invites" → see per-email results with Sent/Failed badges
- [ ] Click "Invite more" → form resets
- [ ] Navigate to `/administration/users` → users table shows the logged-in admin
- [ ] Overview Quick Actions → "Invite People" → opens dialog

### Deferred
- Copy invite link (requires backend link generation)
- Skip onboarding email checkbox
- Dark mode variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)