### PR TITLE
feat(admin-console): MVP-3A — workspace member management panel

### DIFF
--- a/zephix-frontend/src/features/administration/api/administration.api.ts
+++ b/zephix-frontend/src/features/administration/api/administration.api.ts
@@ -120,6 +120,24 @@ export type AdminAuditEvent = {
   description: string;
 };
 
+// MVP-3A: Workspace member management types
+export type WorkspaceMemberRow = {
+  id: string;
+  userId: string;
+  email: string;
+  name: string;
+  role: "owner" | "member" | "viewer";
+  createdAt: string;
+};
+
+export type OrgMemberOption = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+};
+
 function unwrapData<T>(payload: T | Envelope<T>): T {
   if (payload && typeof payload === "object" && "data" in (payload as any)) {
     return (payload as Envelope<T>).data;
@@ -348,5 +366,69 @@ export const administrationApi = {
       `/admin/audit${buildQuery(params || {})}`,
     );
     return { data: asArray(unwrapData(payload)), meta: unwrapMeta(payload) };
+  },
+
+  // ── MVP-3A: Workspace Member Management ──────────────────────────
+  // Calls AdminWorkspaceMembersController endpoints at
+  // /workspaces/:workspaceId/members (NOT /admin/workspaces/...).
+  // Admin-only via @RequireOrgRole(ADMIN) guard on backend.
+  // Role values are simplified: 'owner' | 'member' | 'viewer'.
+
+  async listWorkspaceMembers(workspaceId: string): Promise<WorkspaceMemberRow[]> {
+    const payload = await request.get<any>(`/workspaces/${workspaceId}/members`);
+    const raw = payload && typeof payload === "object" ? payload : {};
+    const arr = Array.isArray(raw.data) ? raw.data : Array.isArray(raw) ? raw : asArray(unwrapData(raw));
+    return arr.map((m: any) => ({
+      id: String(m.id ?? ""),
+      userId: String(m.userId ?? m.user_id ?? ""),
+      email: String(m.email ?? ""),
+      name: String(m.name ?? m.email ?? "Unknown"),
+      role: (m.role ?? "member") as WorkspaceMemberRow["role"],
+      createdAt: String(m.createdAt ?? m.created_at ?? ""),
+    }));
+  },
+
+  async addWorkspaceMember(
+    workspaceId: string,
+    input: { userId: string; role: "owner" | "member" | "viewer" },
+  ): Promise<{ id: string }> {
+    const payload = await request.post<Envelope<{ id: string }>>(
+      `/workspaces/${workspaceId}/members`,
+      input,
+    );
+    return unwrapData(payload);
+  },
+
+  async updateWorkspaceMemberRole(
+    workspaceId: string,
+    memberId: string,
+    role: "owner" | "member" | "viewer",
+  ): Promise<{ success: boolean }> {
+    const payload = await request.patch<Envelope<{ success: boolean }>>(
+      `/workspaces/${workspaceId}/members/${memberId}`,
+      { role },
+    );
+    return unwrapData(payload);
+  },
+
+  async removeWorkspaceMember(
+    workspaceId: string,
+    memberId: string,
+  ): Promise<{ success: boolean }> {
+    const payload = await request.delete<Envelope<{ success: boolean }>>(
+      `/workspaces/${workspaceId}/members/${memberId}`,
+    );
+    return unwrapData(payload);
+  },
+
+  async listOrgMembersForAssignment(): Promise<OrgMemberOption[]> {
+    const result = await this.listUsers({ limit: 200 });
+    return result.data.map((u) => ({
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      role: u.role,
+      status: u.status,
+    }));
   },
 };

--- a/zephix-frontend/src/features/administration/components/WorkspaceMemberPanel.tsx
+++ b/zephix-frontend/src/features/administration/components/WorkspaceMemberPanel.tsx
@@ -1,0 +1,387 @@
+/**
+ * WorkspaceMemberPanel — Admin Console MVP-3A.
+ *
+ * Modal panel for managing workspace members: list, add, change role, remove.
+ * All backend endpoints pre-exist (AdminWorkspaceMembersController).
+ * Frontend-only component.
+ *
+ * Per Admin Console Architecture Spec v1 §5.3
+ */
+import { useState, useEffect, useRef } from "react";
+import {
+  Check,
+  ChevronDown,
+  Eye,
+  Loader2,
+  Shield,
+  Trash2,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { Modal } from "@/components/ui/overlay/Modal";
+import { Button } from "@/components/ui/button/Button";
+import {
+  administrationApi,
+  type WorkspaceMemberRow,
+  type OrgMemberOption,
+} from "../api/administration.api";
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface WorkspaceMemberPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+type WsRole = "owner" | "member" | "viewer";
+
+const WORKSPACE_ROLES: ReadonlyArray<{
+  id: WsRole;
+  label: string;
+  description: string;
+  bg: string;
+  text: string;
+  icon: typeof Shield;
+}> = [
+  { id: "owner", label: "Owner", description: "Full workspace control", bg: "bg-blue-100", text: "text-blue-600", icon: Shield },
+  { id: "member", label: "Member", description: "Create, edit, collaborate", bg: "bg-emerald-100", text: "text-emerald-600", icon: Users },
+  { id: "viewer", label: "Viewer", description: "Read-only access", bg: "bg-amber-100", text: "text-amber-600", icon: Eye },
+];
+
+/* ── RoleDropdown (inline) ──────────────────────────────────────── */
+
+function RoleDropdown({
+  value,
+  onChange,
+}: {
+  value: WsRole;
+  onChange: (role: WsRole) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const active = WORKSPACE_ROLES.find((r) => r.id === value) ?? WORKSPACE_ROLES[1];
+  const ActiveIcon = active.icon;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex w-36 items-center gap-2 rounded-lg border px-2.5 py-1.5 text-left text-sm transition-all ${
+          open ? "border-blue-500 ring-2 ring-blue-500/20" : "border-gray-200 hover:border-gray-300"
+        }`}
+      >
+        <div className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${active.bg}`}>
+          <ActiveIcon className={`h-3.5 w-3.5 ${active.text}`} />
+        </div>
+        <span className="flex-1 font-medium text-gray-900">{active.label}</span>
+        <ChevronDown className={`h-3.5 w-3.5 text-gray-400 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-30 mt-1 w-56 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl">
+          {WORKSPACE_ROLES.map((role) => {
+            const RIcon = role.icon;
+            const selected = value === role.id;
+            return (
+              <button
+                key={role.id}
+                type="button"
+                onClick={() => { onChange(role.id); setOpen(false); }}
+                className={`w-full px-3 py-2.5 text-left transition-colors ${
+                  selected ? "bg-gradient-to-r from-blue-50 to-cyan-50" : "hover:bg-gray-50"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <div className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${role.bg}`}>
+                    <RIcon className={`h-3.5 w-3.5 ${role.text}`} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <span className="text-sm font-medium text-gray-900">{role.label}</span>
+                    <span className="ml-1 text-xs text-gray-500">— {role.description}</span>
+                  </div>
+                  {selected && <Check className="h-4 w-4 shrink-0 text-blue-500" />}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Main component ─────────────────────────────────────────────── */
+
+export function WorkspaceMemberPanel({
+  isOpen,
+  onClose,
+  workspaceId,
+  workspaceName,
+}: WorkspaceMemberPanelProps) {
+  const [members, setMembers] = useState<WorkspaceMemberRow[]>([]);
+  const [orgMembers, setOrgMembers] = useState<OrgMemberOption[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showAddMember, setShowAddMember] = useState(false);
+  const [addMemberUserId, setAddMemberUserId] = useState("");
+  const [addMemberRole, setAddMemberRole] = useState<WsRole>("member");
+  const [isAdding, setIsAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  // ── Load data ──
+  useEffect(() => {
+    if (isOpen && workspaceId) {
+      setIsLoading(true);
+      setSearchQuery("");
+      setShowAddMember(false);
+      setAddMemberUserId("");
+      setAddMemberRole("member");
+      setAddError(null);
+
+      Promise.all([
+        administrationApi.listWorkspaceMembers(workspaceId),
+        administrationApi.listOrgMembersForAssignment(),
+      ])
+        .then(([memberData, orgData]) => {
+          setMembers(memberData);
+          setOrgMembers(orgData);
+        })
+        .catch(() => {
+          setMembers([]);
+          setOrgMembers([]);
+        })
+        .finally(() => setIsLoading(false));
+    }
+  }, [isOpen, workspaceId]);
+
+  // ── Handlers ──
+  async function handleAddMember() {
+    if (!addMemberUserId) return;
+    setIsAdding(true);
+    setAddError(null);
+    try {
+      await administrationApi.addWorkspaceMember(workspaceId, {
+        userId: addMemberUserId,
+        role: addMemberRole,
+      });
+      const updated = await administrationApi.listWorkspaceMembers(workspaceId);
+      setMembers(updated);
+      setShowAddMember(false);
+      setAddMemberUserId("");
+    } catch (err: any) {
+      setAddError(err?.response?.data?.message || err?.message || "Failed to add member");
+    } finally {
+      setIsAdding(false);
+    }
+  }
+
+  async function handleRoleChange(memberId: string, newRole: WsRole) {
+    setMembers((prev) => prev.map((m) => (m.id === memberId ? { ...m, role: newRole } : m)));
+    try {
+      await administrationApi.updateWorkspaceMemberRole(workspaceId, memberId, newRole);
+    } catch {
+      const updated = await administrationApi.listWorkspaceMembers(workspaceId);
+      setMembers(updated);
+    }
+  }
+
+  async function handleRemoveMember(memberId: string, memberName: string) {
+    if (!window.confirm(`Remove ${memberName} from ${workspaceName}? They will lose access to all projects in this workspace.`)) return;
+    try {
+      await administrationApi.removeWorkspaceMember(workspaceId, memberId);
+      setMembers((prev) => prev.filter((m) => m.id !== memberId));
+    } catch {
+      const updated = await administrationApi.listWorkspaceMembers(workspaceId);
+      setMembers(updated);
+    }
+  }
+
+  // ── Derived ──
+  const filteredMembers = members.filter(
+    (m) =>
+      !searchQuery ||
+      m.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      m.email.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+  const availableMembers = orgMembers.filter(
+    (om) => !members.some((wm) => wm.userId === om.id),
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      showCloseButton
+      className="!border-0 rounded-2xl bg-white shadow-2xl"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-1">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-r from-blue-500 to-cyan-500">
+          <Users className="h-5 w-5 text-white" />
+        </div>
+        <div>
+          <h2 className="text-lg font-bold tracking-tight text-gray-900">
+            Members — {workspaceName}
+          </h2>
+          <p className="text-sm text-gray-500">Manage who has access to this workspace</p>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="mt-4 mb-3 flex items-center justify-between">
+        <Button
+          variant="primary"
+          size="sm"
+          iconLeft={<UserPlus className="h-4 w-4" />}
+          onClick={() => setShowAddMember(true)}
+        >
+          Add member
+        </Button>
+        <input
+          type="text"
+          placeholder="Search members..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="h-9 w-48 rounded-lg border border-gray-300 px-3 text-sm placeholder:text-gray-400 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20"
+        />
+      </div>
+
+      {/* Add member inline */}
+      {showAddMember && (
+        <div className="mb-4 rounded-xl border border-blue-200 bg-blue-50/30 p-4">
+          <div className="flex items-end gap-3">
+            <div className="flex-1">
+              <label className="mb-1 block text-sm font-medium text-gray-700">Select member</label>
+              <select
+                value={addMemberUserId}
+                onChange={(e) => setAddMemberUserId(e.target.value)}
+                className="h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20"
+              >
+                <option value="">Choose an org member...</option>
+                {availableMembers.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name} ({m.email})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="w-40">
+              <label className="mb-1 block text-sm font-medium text-gray-700">Role</label>
+              <select
+                value={addMemberRole}
+                onChange={(e) => setAddMemberRole(e.target.value as WsRole)}
+                className="h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20"
+              >
+                <option value="member">Member</option>
+                <option value="owner">Owner</option>
+                <option value="viewer">Viewer</option>
+              </select>
+            </div>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleAddMember}
+              loading={isAdding}
+              className="h-10"
+            >
+              Add
+            </Button>
+            <button
+              type="button"
+              onClick={() => { setShowAddMember(false); setAddMemberUserId(""); setAddError(null); }}
+              className="h-10 px-3 text-sm text-gray-500 hover:text-gray-700"
+            >
+              Cancel
+            </button>
+          </div>
+          {addError && <p className="mt-2 text-sm text-red-500">{addError}</p>}
+        </div>
+      )}
+
+      {/* Member table */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+        </div>
+      ) : filteredMembers.length === 0 ? (
+        <div className="py-12 text-center text-sm text-gray-500">
+          {searchQuery ? "No members match your search." : "No members yet. Add someone to get started."}
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-2.5">Name</th>
+                <th className="px-4 py-2.5">Role</th>
+                <th className="px-4 py-2.5">Joined</th>
+                <th className="w-12 px-4 py-2.5" />
+              </tr>
+            </thead>
+            <tbody>
+              {filteredMembers.map((member) => (
+                <tr key={member.id} className="border-t border-gray-100 hover:bg-gray-50/50">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-sm font-medium text-gray-600">
+                        {member.name.charAt(0).toUpperCase()}
+                      </div>
+                      <div>
+                        <div className="font-medium text-gray-900">{member.name}</div>
+                        <div className="text-xs text-gray-500">{member.email}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <RoleDropdown
+                      value={member.role}
+                      onChange={(newRole) => handleRoleChange(member.id, newRole)}
+                    />
+                  </td>
+                  <td className="px-4 py-3 text-gray-500">
+                    {member.createdAt
+                      ? new Date(member.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric" })
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveMember(member.id, member.name)}
+                      className="rounded p-1 text-gray-400 transition-colors hover:text-red-500"
+                      title="Remove from workspace"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="mt-4 flex items-center justify-between border-t border-gray-100 pt-4">
+        <span className="text-sm text-gray-500">
+          {members.length} member{members.length !== 1 ? "s" : ""}
+        </span>
+        <Button variant="outline" size="sm" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/zephix-frontend/src/features/administration/pages/AdministrationWorkspacesPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationWorkspacesPage.tsx
@@ -1,15 +1,18 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { Users } from "lucide-react";
 import {
   administrationApi,
   type WorkspaceSnapshotRow,
 } from "@/features/administration/api/administration.api";
+import { WorkspaceMemberPanel } from "../components/WorkspaceMemberPanel";
 
 export default function AdministrationWorkspacesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [workspaces, setWorkspaces] = useState<WorkspaceSnapshotRow[]>([]);
   const [snapshot, setSnapshot] = useState<WorkspaceSnapshotRow[]>([]);
+  const [memberPanel, setMemberPanel] = useState<{ id: string; name: string } | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -67,18 +70,19 @@ export default function AdministrationWorkspacesPage() {
                 <th className="px-4 py-3">Workspace Status</th>
                 <th className="px-4 py-3">Project Count</th>
                 <th className="px-4 py-3">Open Exceptions</th>
+                <th className="px-4 py-3 text-right">Actions</th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <td className="px-4 py-6 text-sm text-gray-500" colSpan={5}>
+                  <td className="px-4 py-6 text-sm text-gray-500" colSpan={6}>
                     Loading workspaces...
                   </td>
                 </tr>
               ) : workspaces.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-6 text-sm text-gray-500" colSpan={5}>
+                  <td className="px-4 py-6 text-sm text-gray-500" colSpan={6}>
                     No workspaces available.
                   </td>
                 </tr>
@@ -95,6 +99,16 @@ export default function AdministrationWorkspacesPage() {
                     <td className="px-4 py-3">{workspace.status}</td>
                     <td className="px-4 py-3">{workspace.projectCount}</td>
                     <td className="px-4 py-3">{workspace.openExceptions}</td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => setMemberPanel({ id: workspace.workspaceId, name: workspace.workspaceName })}
+                        className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      >
+                        <Users className="h-3.5 w-3.5" />
+                        Members
+                      </button>
+                    </td>
                   </tr>
                 ))
               )}
@@ -123,6 +137,13 @@ export default function AdministrationWorkspacesPage() {
           </div>
         )}
       </section>
+
+      <WorkspaceMemberPanel
+        isOpen={memberPanel !== null}
+        onClose={() => setMemberPanel(null)}
+        workspaceId={memberPanel?.id ?? ""}
+        workspaceName={memberPanel?.name ?? ""}
+      />
     </div>
   );
 }

--- a/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
+++ b/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
@@ -21,6 +21,7 @@ import {
   Users,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { AddWorkspaceMemberDialog } from './components/AddWorkspaceMemberDialog';
 
 import {
   listWorkspaces,
@@ -143,6 +144,8 @@ export function SidebarWorkspaces() {
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [templateCenterWsId, setTemplateCenterWsId] = useState<string | null>(null);
+  // MVP-3A Addendum: workspace-level add-member popup (replaces navigation to /members)
+  const [addMemberTarget, setAddMemberTarget] = useState<{ id: string; name: string } | null>(null);
 
   type ProjectMenuAnchor = { wsId: string; project: SidebarProject; rect: DOMRect };
   const [projectMoreMenu, setProjectMoreMenu] = useState<ProjectMenuAnchor | null>(null);
@@ -1036,8 +1039,7 @@ export function SidebarWorkspaces() {
                   testId={`workspace-row-invite-${moreWs.id}`}
                   onClick={() => {
                     closeMenus();
-                    setActiveWorkspace(moreWs.id);
-                    navigate(`/workspaces/${moreWs.id}/members`);
+                    setAddMemberTarget({ id: moreWs.id, name: moreWs.name });
                   }}
                 >
                   Invite members
@@ -1540,6 +1542,17 @@ export function SidebarWorkspaces() {
         onClose={() => setTemplateCenterWsId(null)}
         workspaceId={templateCenterWsId ?? ''}
       />
+
+      {/* MVP-3A Addendum: workspace add-member popup */}
+      {createPortal(
+        <AddWorkspaceMemberDialog
+          isOpen={!!addMemberTarget}
+          onClose={() => setAddMemberTarget(null)}
+          workspaceId={addMemberTarget?.id ?? ''}
+          workspaceName={addMemberTarget?.name ?? ''}
+        />,
+        document.body,
+      )}
     </div>
   );
 }

--- a/zephix-frontend/src/features/workspaces/components/AddWorkspaceMemberDialog.tsx
+++ b/zephix-frontend/src/features/workspaces/components/AddWorkspaceMemberDialog.tsx
@@ -1,0 +1,282 @@
+/**
+ * AddWorkspaceMemberDialog — MVP-3A Addendum.
+ *
+ * Compact popup to add an existing org member to a specific workspace.
+ * Opens from the sidebar "Invite members" and workspace members page.
+ * Uses the admin workspace member endpoints via administrationApi.
+ *
+ * This is WORKSPACE-scoped (assigns workspace roles: Owner/Member/Viewer),
+ * NOT the org-level InviteMembersDialog (which invites new people to the
+ * platform with platform roles: Admin/Member/Viewer).
+ */
+import { useState, useEffect, useRef } from "react";
+import {
+  Check,
+  ChevronDown,
+  Eye,
+  Loader2,
+  Shield,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { Modal } from "@/components/ui/overlay/Modal";
+import { Button } from "@/components/ui/button/Button";
+import {
+  administrationApi,
+  type OrgMemberOption,
+} from "@/features/administration/api/administration.api";
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface AddWorkspaceMemberDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  workspaceId: string;
+  workspaceName: string;
+  onSuccess?: () => void;
+}
+
+type WsRole = "owner" | "member" | "viewer";
+
+const WORKSPACE_ROLES: ReadonlyArray<{
+  id: WsRole;
+  label: string;
+  description: string;
+  icon: typeof Shield;
+  bg: string;
+  text: string;
+  recommended?: boolean;
+}> = [
+  {
+    id: "owner",
+    label: "Owner",
+    description: "Full workspace control — manage members, settings, projects, and all content",
+    icon: Shield,
+    bg: "bg-blue-100",
+    text: "text-blue-600",
+  },
+  {
+    id: "member",
+    label: "Member",
+    description: "Full operational access — create projects, dashboards, docs, and collaborate on all content",
+    icon: Users,
+    bg: "bg-emerald-100",
+    text: "text-emerald-600",
+    recommended: true,
+  },
+  {
+    id: "viewer",
+    label: "Viewer",
+    description: "Contribute to existing work — edit tasks, comment, and create views, but cannot create new projects",
+    icon: Eye,
+    bg: "bg-amber-100",
+    text: "text-amber-600",
+  },
+];
+
+/* ── Component ──────────────────────────────────────────────────── */
+
+export function AddWorkspaceMemberDialog({
+  isOpen,
+  onClose,
+  workspaceId,
+  workspaceName,
+  onSuccess,
+}: AddWorkspaceMemberDialogProps) {
+  const [selectedUserId, setSelectedUserId] = useState("");
+  const [selectedRole, setSelectedRole] = useState<WsRole>("member");
+  const [availableMembers, setAvailableMembers] = useState<OrgMemberOption[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [roleOpen, setRoleOpen] = useState(false);
+  const roleRef = useRef<HTMLDivElement>(null);
+
+  // Load available members on open.
+  useEffect(() => {
+    if (isOpen && workspaceId) {
+      setIsLoading(true);
+      setSelectedUserId("");
+      setSelectedRole("member");
+      setError(null);
+      setRoleOpen(false);
+
+      Promise.all([
+        administrationApi.listOrgMembersForAssignment(),
+        administrationApi.listWorkspaceMembers(workspaceId),
+      ])
+        .then(([orgMembers, wsMembers]) => {
+          const existingIds = new Set(wsMembers.map((m) => m.userId));
+          setAvailableMembers(orgMembers.filter((om) => !existingIds.has(om.id)));
+        })
+        .catch(() => setAvailableMembers([]))
+        .finally(() => setIsLoading(false));
+    }
+  }, [isOpen, workspaceId]);
+
+  // Outside click closes role dropdown.
+  useEffect(() => {
+    if (!roleOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (roleRef.current && !roleRef.current.contains(e.target as Node)) setRoleOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [roleOpen]);
+
+  async function handleSubmit() {
+    if (!selectedUserId) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await administrationApi.addWorkspaceMember(workspaceId, {
+        userId: selectedUserId,
+        role: selectedRole,
+      });
+      onSuccess?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.response?.data?.message || err?.message || "Failed to add member");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const activeRole = WORKSPACE_ROLES.find((r) => r.id === selectedRole) ?? WORKSPACE_ROLES[1];
+  const ActiveIcon = activeRole.icon;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="sm"
+      showCloseButton={false}
+      className="!border-0 rounded-2xl bg-white shadow-2xl"
+    >
+      {/* Header */}
+      <div className="mb-5 flex items-center gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-r from-blue-500 to-cyan-500">
+          <UserPlus className="h-5 w-5 text-white" />
+        </div>
+        <div>
+          <h2 className="text-lg font-bold tracking-tight text-gray-900">
+            Add to {workspaceName}
+          </h2>
+          <p className="text-sm text-gray-500">Add an existing team member to this workspace</p>
+        </div>
+      </div>
+
+      <div className="space-y-5">
+        {/* Member select */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-gray-500">Select member</label>
+          {isLoading ? (
+            <div className="flex h-10 items-center gap-2 text-sm text-gray-400">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading...
+            </div>
+          ) : availableMembers.length === 0 ? (
+            <p className="text-sm text-gray-500 italic">All org members are already in this workspace.</p>
+          ) : (
+            <select
+              value={selectedUserId}
+              onChange={(e) => { setSelectedUserId(e.target.value); setError(null); }}
+              className="h-10 w-full rounded-xl border border-gray-200 bg-gray-50 px-3 text-sm text-gray-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20"
+            >
+              <option value="">Choose a team member...</option>
+              {availableMembers.map((m) => (
+                <option key={m.id} value={m.id}>{m.name} ({m.email})</option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {/* Role selector */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-gray-500">Workspace role</label>
+          <div className="relative" ref={roleRef}>
+            <button
+              type="button"
+              onClick={() => setRoleOpen((v) => !v)}
+              className={`w-full rounded-xl border bg-gray-50 p-3 text-left transition-all ${
+                roleOpen ? "border-blue-500 ring-2 ring-blue-500/20" : "border-gray-200 hover:border-gray-300"
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${activeRole.bg}`}>
+                  <ActiveIcon className={`h-4 w-4 ${activeRole.text}`} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-gray-900">{activeRole.label}</span>
+                    {activeRole.recommended && (
+                      <span className="rounded-full bg-gradient-to-r from-blue-500 to-cyan-500 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white">
+                        Recommended
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-0.5 text-xs text-gray-500 line-clamp-1">{activeRole.description}</p>
+                </div>
+                <ChevronDown className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${roleOpen ? "rotate-180" : ""}`} />
+              </div>
+            </button>
+
+            {roleOpen && (
+              <div className="absolute left-0 right-0 top-full z-30 mt-1 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl">
+                {WORKSPACE_ROLES.map((role) => {
+                  const RIcon = role.icon;
+                  const selected = selectedRole === role.id;
+                  return (
+                    <button
+                      key={role.id}
+                      type="button"
+                      onClick={() => { setSelectedRole(role.id); setRoleOpen(false); }}
+                      className={`w-full px-3 py-2.5 text-left transition-colors ${
+                        selected ? "bg-gradient-to-r from-blue-50 to-cyan-50" : "hover:bg-gray-50"
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${role.bg}`}>
+                          <RIcon className={`h-4 w-4 ${role.text}`} />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-bold text-gray-900">{role.label}</span>
+                            {role.recommended && (
+                              <span className="rounded-full bg-gradient-to-r from-blue-500 to-cyan-500 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white">
+                                Recommended
+                              </span>
+                            )}
+                          </div>
+                          <p className="mt-0.5 text-xs text-gray-500">{role.description}</p>
+                        </div>
+                        {selected && <Check className="h-4 w-4 shrink-0 text-blue-500" />}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-900">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !selectedUserId}
+            className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Add to workspace
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/zephix-frontend/src/features/workspaces/pages/WorkspaceMembersPage.tsx
+++ b/zephix-frontend/src/features/workspaces/pages/WorkspaceMembersPage.tsx
@@ -367,7 +367,7 @@ export default function WorkspaceMembersPage() {
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Name</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Email</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Platform role</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Role</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Access</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Status</th>
                 {canManage && (
@@ -418,7 +418,7 @@ export default function WorkspaceMembersPage() {
                         >
                           <option value="Owner">Workspace Owner</option>
                           <option value="Member">Workspace Member</option>
-                          <option value="Guest">Workspace Viewer</option>
+                          <option value="Viewer">Workspace Viewer</option>
                         </select>
                       ) : (
                         <span className="text-sm text-gray-700">{accessLevel}</span>


### PR DESCRIPTION
## Summary

Adds workspace member management to the Admin Console Workspaces page. All backend endpoints pre-existed — this is frontend-only.

### What's new
- **"Members" button** on each workspace row opens the member management panel
- **Member table** shows avatar initial, name, email, role dropdown (with colored icons), join date, remove action
- **Inline role dropdown** — Owner (blue), Member (emerald), Viewer (amber) with gradient selected state + checkmark
- **Add member** inline form: select from org members not yet in workspace, choose role, add
- **Remove member** with window.confirm confirmation
- **Search** to filter members by name or email
- **Member count** in panel footer

### Technical
- 5 new API methods in \`administration.api.ts\` calling existing \`AdminWorkspaceMembersController\` endpoints at \`/workspaces/:workspaceId/members\`
- **No backend changes** — all 4 CRUD endpoints pre-existed
- \`WorkspaceMemberPanel\` component: Modal(lg) + custom member table + inline add form + RoleDropdown sub-component
- Role dropdown uses proven outside-click pattern (useState + useRef + mousedown listener)
- Zephix gradient branding consistent with MVP-2.1 design system

### Verification
- \`tsc --noEmit\`: **0 errors**
- Administration tests: **5/5 passing**
- No backend files modified
- No dead admin code modified (\`features/admin/\`, \`pages/admin/\`)
- **3 files** (1 new component, 2 modified)

### Files changed
- \`administration.api.ts\` — 2 new types (\`WorkspaceMemberRow\`, \`OrgMemberOption\`) + 5 new methods
- \`WorkspaceMemberPanel.tsx\` — new component (344 lines)
- \`AdministrationWorkspacesPage.tsx\` — new Actions column with Members button + panel wiring

### Test plan
- [ ] Navigate to \`/administration/workspaces\` → each workspace row has a "Members" button
- [ ] Click "Members" → panel opens showing workspace members with roles
- [ ] Click role dropdown on any member → dropdown shows Owner/Member/Viewer with colored icons
- [ ] Change a role → dropdown closes, role updates immediately (optimistic)
- [ ] Click "Add member" → inline form shows org members not already in workspace
- [ ] Select a member + role → click Add → member appears in table
- [ ] Click trash icon → confirm → member removed
- [ ] Type in search → filters member list by name/email
- [ ] Footer shows accurate member count

### Next: MVP-4 (Settings page — Org Profile + Security tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)