### PR TITLE
fix(admin-console): workspace permissions owner role + checkbox visual fix

### DIFF
--- a/zephix-backend/src/admin/admin.controller.ts
+++ b/zephix-backend/src/admin/admin.controller.ts
@@ -1154,10 +1154,10 @@ export class AdminController {
     try {
       const org = await this.organizationsService.findOne(organizationId);
       const stored = (org.settings as any)?.workspacePermissionDefaults || {};
-      return { data: { member: stored.member || {}, viewer: stored.viewer || {} } };
+      return { data: { owner: stored.owner || {}, member: stored.member || {}, viewer: stored.viewer || {} } };
     } catch (error) {
       this.logger.warn('Failed to load workspace permissions', { organizationId });
-      return { data: { member: {}, viewer: {} } };
+      return { data: { owner: {}, member: {}, viewer: {} } };
     }
   }
 
@@ -1166,7 +1166,7 @@ export class AdminController {
   @ApiResponse({ status: 200, description: 'Workspace permissions updated' })
   async updateWorkspacePermissions(
     @Request() req: AuthRequest,
-    @Body() body: { member?: Record<string, boolean>; viewer?: Record<string, boolean> },
+    @Body() body: { owner?: Record<string, boolean>; member?: Record<string, boolean>; viewer?: Record<string, boolean> },
   ) {
     const { organizationId } = getAuthContext(req);
     const org = await this.organizationsService.findOne(organizationId);
@@ -1174,6 +1174,7 @@ export class AdminController {
     await this.organizationsService.updateSettings(organizationId, {
       workspacePermissionDefaults: {
         ...currentDefaults,
+        owner: body.owner ?? currentDefaults.owner ?? {},
         member: body.member ?? currentDefaults.member ?? {},
         viewer: body.viewer ?? currentDefaults.viewer ?? {},
       },

--- a/zephix-frontend/src/features/administration/components/security/OrgPermissionsTab.tsx
+++ b/zephix-frontend/src/features/administration/components/security/OrgPermissionsTab.tsx
@@ -225,17 +225,17 @@ export function OrgPermissionsTab() {
                 <h3 className="text-sm font-semibold text-gray-900 mb-2">{category.label}</h3>
                 <div className="rounded-lg border border-gray-200 bg-white divide-y divide-gray-100">
                   {category.permissions.map((perm) => {
-                    const checked = rolePerms[perm.key] ?? false;
                     const isAdmin = selectedRole === "admin";
                     const isAdminOnly = perm.adminOnly && selectedRole !== "admin";
+                    const checked = isAdmin ? true : (rolePerms[perm.key] ?? false);
                     const disabled = isAdmin || isAdminOnly;
 
                     return (
                       <label
                         key={perm.key}
                         className={`flex items-center justify-between px-4 py-2.5 ${
-                          disabled ? "cursor-default opacity-60" : "cursor-pointer hover:bg-gray-50"
-                        }`}
+                          disabled ? "cursor-default" : "cursor-pointer hover:bg-gray-50"
+                        } ${isAdmin || isAdminOnly ? "opacity-50" : ""}`}
                       >
                         <div className="flex items-center gap-3">
                           <input

--- a/zephix-frontend/src/features/administration/components/security/WorkspacePermissionsTab.tsx
+++ b/zephix-frontend/src/features/administration/components/security/WorkspacePermissionsTab.tsx
@@ -226,16 +226,16 @@ export function WorkspacePermissionsTab() {
                   <h3 className="text-sm font-semibold text-gray-900 mb-2">{category.label}</h3>
                   <div className="rounded-lg border border-gray-200 bg-white divide-y divide-gray-100">
                     {category.permissions.map((perm) => {
-                      const checked = rolePerms[perm.key] ?? false;
                       const isOwner = selectedRole === "owner";
                       const isOwnerOnly = perm.ownerOnly && selectedRole !== "owner";
+                      const checked = isOwner ? true : (rolePerms[perm.key] ?? false);
                       const disabled = isOwner || isOwnerOnly;
 
                       return (
                         <label
                           key={perm.key}
                           className={`flex items-center justify-between px-4 py-2.5 ${
-                            disabled ? "cursor-default opacity-60" : "cursor-pointer hover:bg-gray-50"
+                            disabled ? "cursor-default opacity-50" : "cursor-pointer hover:bg-gray-50"
                           }`}
                         >
                           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Bugfixes found during staging deploy review of PR #123.

### Bug 1: GET workspace-permissions missing owner role
`GET /admin/organization/workspace-permissions` only returned `member` + `viewer`. The `owner` role was stripped from the response, preventing the frontend from managing workspace owner permissions. The enforcement layer maps `wsOwnersCanDeleteProjects` → `wsDefaults.owner.wsDeleteProjects`, which would always fall back to defaults.

### Bug 2: PATCH workspace-permissions missing owner role
`PATCH /admin/organization/workspace-permissions` didn't accept or persist the `owner` role. Any workspace owner permission configuration would be silently dropped on save.

### Bug 3: Admin/Owner checkboxes appear unchecked
Native checkbox with `disabled` + `opacity-60` made the blue checked fill nearly invisible. Fixed by forcing `checked=true` for non-editable roles and reducing opacity to 50%.

## Test plan
- [ ] GET /admin/organization/workspace-permissions returns owner/member/viewer
- [ ] PATCH /admin/organization/workspace-permissions persists owner role
- [ ] Admin role checkboxes show as checked in Org Permissions tab
- [ ] Owner role checkboxes show as checked in Workspace Permissions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)