### PR TITLE
feat(platform): P-2 — template activation + column configuration

### DIFF
--- a/zephix-backend/src/migrations/18000000000066-AddColumnConfigToTemplatesAndProjects.ts
+++ b/zephix-backend/src/migrations/18000000000066-AddColumnConfigToTemplatesAndProjects.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * P-2: Add column_config JSONB to templates and projects.
+ *
+ * Templates carry methodology-specific column defaults (Tier 2 columns).
+ * Projects inherit column_config at creation time and can customize via gear icon.
+ *
+ * Three-tier model:
+ *   Tier 1 — Always visible (task name, status, assignee, dates, priority, completion, description)
+ *   Tier 2 — Template-activated (phase, sprint, story points, WIP limit, etc.)
+ *   Tier 3 — Manual toggle (approval status, risk level, time tracking)
+ */
+export class AddColumnConfigToTemplatesAndProjects18000000000066
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE templates
+        ADD COLUMN IF NOT EXISTS column_config jsonb DEFAULT NULL;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE projects
+        ADD COLUMN IF NOT EXISTS column_config jsonb DEFAULT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE projects
+        DROP COLUMN IF EXISTS column_config;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE templates
+        DROP COLUMN IF EXISTS column_config;
+    `);
+  }
+}

--- a/zephix-backend/src/modules/projects/entities/project.entity.ts
+++ b/zephix-backend/src/modules/projects/entities/project.entity.ts
@@ -213,6 +213,10 @@ export class Project {
   @Column({ type: 'varchar', length: 50, default: 'agile', nullable: true })
   methodology: string;
 
+  /** P-2: Per-project column visibility config. Inherited from template, user-customizable via gear icon. */
+  @Column({ name: 'column_config', type: 'jsonb', nullable: true })
+  columnConfig: Record<string, boolean> | null;
+
   // Missing relations that other entities expect
   @OneToMany(() => Task, (task) => task.project)
   tasks: Task[];

--- a/zephix-backend/src/modules/projects/projects.controller.ts
+++ b/zephix-backend/src/modules/projects/projects.controller.ts
@@ -656,4 +656,22 @@ export class ProjectsController {
       tenant.userId,
     );
   }
+
+  // ── P-2: Column configuration ──────────────────────────────────────
+
+  @Patch(':id/column-config')
+  @UseGuards(JwtAuthGuard)
+  @RequireWorkspaceRole('workspace_member', { allowAdminOverride: true })
+  async updateColumnConfig(
+    @Param('id') id: string,
+    @Body() dto: { columnConfig: Record<string, boolean> },
+    @GetTenant() tenant: TenantContext,
+  ) {
+    this.logger.log(`Updating column config for project ${id}`);
+    return this.projectsService.updateColumnConfig(
+      id,
+      tenant.organizationId,
+      dto.columnConfig,
+    );
+  }
 }

--- a/zephix-backend/src/modules/projects/services/projects.service.ts
+++ b/zephix-backend/src/modules/projects/services/projects.service.ts
@@ -2075,4 +2075,22 @@ export class ProjectsService extends TenantAwareRepository<Project> {
       availableKPIs: kpiData.availableKPIs,
     };
   }
+
+  // ── P-2: Column configuration ──────────────────────────────────────
+
+  async updateColumnConfig(
+    projectId: string,
+    organizationId: string,
+    columnConfig: Record<string, boolean>,
+  ): Promise<{ data: { columnConfig: Record<string, boolean> } }> {
+    const project = await this.projectRepository.findOne({
+      where: { id: projectId, organizationId } as any,
+    });
+    if (!project) throw new NotFoundException('Project not found');
+
+    (project as any).columnConfig = columnConfig;
+    await this.projectRepository.save(project);
+
+    return { data: { columnConfig } };
+  }
 }

--- a/zephix-backend/src/modules/templates/data/system-template-definitions.ts
+++ b/zephix-backend/src/modules/templates/data/system-template-definitions.ts
@@ -129,6 +129,13 @@ export interface SystemTemplateDef {
    * (e.g. "Table", "Board"). Display-only; does not create views.
    */
   includedViews?: string[];
+  /**
+   * P-2: Tier 2 column defaults. Keys map to column identifiers in the
+   * gear icon panel. true = ON by default, false = available but OFF.
+   * Tier 1 columns (taskName, status, assignee, dates, priority, completion,
+   * description) are always visible and not listed here.
+   */
+  columnConfig?: Record<string, boolean>;
   phases: Array<{
     name: string;
     description: string;
@@ -214,6 +221,68 @@ const HYBRID_GOV = {
   waterfallEnabled: false,
 };
 
+// ── P-2: Methodology-specific column defaults (Tier 2) ──────────────
+
+const WATERFALL_COLUMNS: Record<string, boolean> = {
+  phase: true,
+  duration: true,
+  milestone: true,
+  dependency: true,
+  remarks: true,
+  sprint: false,
+  storyPoints: false,
+  epic: false,
+  wipLimit: false,
+  cycleTime: false,
+  leadTime: false,
+  labels: false,
+};
+
+const AGILE_COLUMNS: Record<string, boolean> = {
+  phase: false,
+  duration: false,
+  milestone: false,
+  dependency: false,
+  remarks: false,
+  sprint: true,
+  storyPoints: true,
+  epic: true,
+  wipLimit: false,
+  cycleTime: false,
+  leadTime: false,
+  labels: true,
+};
+
+const KANBAN_COLUMNS: Record<string, boolean> = {
+  phase: false,
+  duration: false,
+  milestone: false,
+  dependency: false,
+  remarks: false,
+  sprint: false,
+  storyPoints: false,
+  epic: false,
+  wipLimit: true,
+  cycleTime: true,
+  leadTime: true,
+  labels: true,
+};
+
+const HYBRID_COLUMNS: Record<string, boolean> = {
+  phase: true,
+  duration: true,
+  milestone: true,
+  dependency: true,
+  remarks: false,
+  sprint: true,
+  storyPoints: true,
+  epic: false,
+  wipLimit: false,
+  cycleTime: false,
+  leadTime: false,
+  labels: false,
+};
+
 // ── Phase 5A: 14 system project templates across 5 categories ────────
 
 export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
@@ -233,6 +302,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['waterfall', 'governance', 'baseline', 'evm', 'phase-gates', 'uat'],
     defaultTabs: ['overview', 'plan', 'gantt', 'tasks', 'budget', 'change-requests', 'documents', 'kpis', 'risks', 'resources'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     phases: [
       {
         name: 'Requirements & scope',
@@ -450,6 +520,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['waterfall', 'pmi', 'reference', 'governance', 'baseline'],
     defaultTabs: ['tasks', 'overview', 'gantt', 'documents', 'risks'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     bestFor:
       'Plan-driven projects that need clear phase structure, milestone gates, and the option to enforce governance later.',
     /**
@@ -755,6 +826,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['agile', 'sprint', 'iterative', 'backlog'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Backlog & Sprint Planning', description: 'Refinement, estimation, sprint goal', order: 0, estimatedDurationDays: 1 },
       { name: 'Sprint Execution', description: 'Build, daily standups, board flow', order: 1, estimatedDurationDays: 12 },
@@ -782,6 +854,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['hybrid', 'transformation', 'mixed'],
     defaultTabs: ['overview', 'plan', 'tasks', 'board', 'budget', 'change-requests', 'kpis', 'risks'],
     defaultGovernanceFlags: HYBRID_GOV,
+    columnConfig: HYBRID_COLUMNS,
     phases: [
       { name: 'Discovery', description: 'Requirements and architecture spikes', order: 0, estimatedDurationDays: 5 },
       { name: 'Iterative Delivery', description: 'Sprint-based execution with governance gates', order: 1, estimatedDurationDays: 30 },
@@ -809,6 +882,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['risk', 'compliance', 'register', 'grc'],
     defaultTabs: ['overview', 'board', 'tasks', 'kpis', 'risks', 'documents'],
     defaultGovernanceFlags: KANBAN_GOV,
+    columnConfig: KANBAN_COLUMNS,
     phases: [
       { name: 'Continuous Tracking', description: 'Ongoing risk and mitigation management', order: 0, estimatedDurationDays: 90 },
     ],
@@ -839,6 +913,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['product', 'discovery', 'research', 'validation'],
     defaultTabs: ['overview', 'tasks', 'board', 'documents', 'kpis'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Frame the Problem', description: 'Define problem statement and target users', order: 0, estimatedDurationDays: 3 },
       { name: 'Research & Interviews', description: 'User research, interviews, and synthesis', order: 1, estimatedDurationDays: 10 },
@@ -866,6 +941,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['product', 'launch', 'go-to-market'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks', 'documents'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Launch Planning', description: 'Scope, channels, milestones, success metrics', order: 0, estimatedDurationDays: 5 },
       { name: 'Sprint 1 — Build', description: 'Landing pages, messaging, collateral, FAQs', order: 1, estimatedDurationDays: 14 },
@@ -894,6 +970,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['product', 'roadmap', 'quarterly', 'okr'],
     defaultTabs: ['overview', 'plan', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: HYBRID_GOV,
+    columnConfig: HYBRID_COLUMNS,
     phases: [
       { name: 'Quarter Planning', description: 'OKRs, themes, and sprint slate', order: 0, estimatedDurationDays: 5 },
       { name: 'Build Sprints', description: 'Iterative delivery against quarterly themes', order: 1, estimatedDurationDays: 60 },
@@ -924,6 +1001,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['software', 'sprint', 'velocity', 'engineering'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Sprint Planning', description: 'Backlog refinement and sprint goal', order: 0, estimatedDurationDays: 1 },
       { name: 'Sprint Execution', description: 'Development, daily standups, code review', order: 1, estimatedDurationDays: 12 },
@@ -951,6 +1029,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['software', 'kanban', 'flow', 'continuous'],
     defaultTabs: ['overview', 'board', 'tasks', 'kpis'],
     defaultGovernanceFlags: KANBAN_GOV,
+    columnConfig: KANBAN_COLUMNS,
     phases: [
       { name: 'Continuous Flow', description: 'Ongoing pull-based execution', order: 0, estimatedDurationDays: 90 },
     ],
@@ -973,6 +1052,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['release', 'deployment', 'cut', 'hypercare'],
     defaultTabs: ['overview', 'plan', 'gantt', 'tasks', 'change-requests', 'documents', 'kpis', 'risks'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     phases: [
       { name: 'Release Plan', description: 'Scope freeze, release notes, dependencies', order: 0, estimatedDurationDays: 5 },
       { name: 'Cut & Stabilize', description: 'Branch cut and stabilization fixes', order: 1, estimatedDurationDays: 5 },
@@ -1005,6 +1085,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['operations', 'improvement', 'kaizen', 'service'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Assess Current State', description: 'Map process, baseline metrics, identify bottlenecks', order: 0, estimatedDurationDays: 5 },
       { name: 'Improvement Sprint 1', description: 'Highest-impact improvements', order: 1, estimatedDurationDays: 14 },
@@ -1032,6 +1113,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['operations', 'readiness', 'cutover', 'handover'],
     defaultTabs: ['overview', 'plan', 'gantt', 'tasks', 'budget', 'change-requests', 'documents', 'kpis', 'risks', 'resources'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     phases: [
       { name: 'Assessment', description: 'Inventory, runbook gap analysis, RACI', order: 0, estimatedDurationDays: 10 },
       { name: 'Build', description: 'Author runbooks, monitoring, on-call rota', order: 1, estimatedDurationDays: 15 },
@@ -1064,6 +1146,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['startup', 'mvp', 'lean', 'validation'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Discover', description: 'Hypotheses, riskiest assumption, success metric', order: 0, estimatedDurationDays: 3 },
       { name: 'Build', description: 'Smallest valuable slice', order: 1, estimatedDurationDays: 14 },
@@ -1091,6 +1174,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['startup', 'gtm', 'launch', 'positioning'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks', 'documents'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Positioning', description: 'Audience, message, channels, pricing', order: 0, estimatedDurationDays: 5 },
       { name: 'Build Assets', description: 'Landing, sales collateral, demo, FAQs', order: 1, estimatedDurationDays: 10 },

--- a/zephix-backend/src/modules/templates/entities/template.entity.ts
+++ b/zephix-backend/src/modules/templates/entities/template.entity.ts
@@ -167,6 +167,10 @@ export class Template {
   @Column({ name: 'default_governance_flags', type: 'jsonb', nullable: true })
   defaultGovernanceFlags?: Record<string, boolean>;
 
+  /** P-2: Tier 2 column defaults per methodology. Copied to project at creation. */
+  @Column({ name: 'column_config', type: 'jsonb', nullable: true })
+  columnConfig?: Record<string, boolean> | null;
+
   @Column({ name: 'phases', type: 'jsonb', nullable: true })
   phases?: Array<{
     name: string;

--- a/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
+++ b/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
@@ -256,6 +256,9 @@ export class TemplatesInstantiateV51Service {
           // branch falls through to TaskListSection instead of WaterfallTable.
           // This is the smoking gun the operator screenshots exposed.
           methodology: (template.methodology as string) || 'agile',
+          // P-2: Inherit column configuration from template.
+          // User can customize later via gear icon → PATCH /projects/:id/column-config.
+          columnConfig: (template as any).columnConfig || null,
         });
 
         project = await projectRepo.save(project);

--- a/zephix-backend/src/scripts/seed-system-templates.ts
+++ b/zephix-backend/src/scripts/seed-system-templates.ts
@@ -180,6 +180,7 @@ async function main() {
             taskTemplates: def.taskTemplates as any,
             defaultTabs: def.defaultTabs,
             defaultGovernanceFlags: def.defaultGovernanceFlags as any,
+            columnConfig: (def.columnConfig as any) || null,
             workTypeTags: def.workTypeTags,
             metadata: {
             purpose: def.purpose,
@@ -221,6 +222,7 @@ async function main() {
         riskPresets: (def.riskPresets as any) || [],
         defaultTabs: def.defaultTabs,
         defaultGovernanceFlags: def.defaultGovernanceFlags,
+        columnConfig: (def.columnConfig as any) || null,
         workTypeTags: def.workTypeTags,
         // Phase 5A: store one-line purpose copy in metadata for the
         // template-card body. SYSTEM templates use a different metadata


### PR DESCRIPTION
## Summary

Establishes the three-tier column configuration model and adds infrastructure for all 15 system templates to carry methodology-specific column defaults.

### Column configuration model

| Tier | Behavior | Examples |
|------|----------|----------|
| Tier 1 — Always visible | Cannot toggle off | Task name, Status, Assignee, Dates, Priority |
| Tier 2 — Template-activated | ON by default per methodology, toggleable | Phase (Waterfall), Sprint (Agile), WIP limit (Kanban) |
| Tier 3 — Manual toggle | OFF by default, user enables | Approval status, Tags, Date created/done |

### Methodology → default active columns

| Methodology | Tier 2 columns ON by default |
|-------------|------------------------------|
| Waterfall | Phase, Duration, Milestone, Dependency, Remarks |
| Agile | Sprint, Story points, Epic, Labels |
| Kanban | WIP limit, Cycle time, Lead time, Labels |
| Hybrid | Phase, Duration, Milestone, Dependency, Sprint, Story points |

### What shipped

- **Migration 066**: `column_config` JSONB on `templates` and `projects` tables
- **Template entity**: `columnConfig` field
- **Project entity**: `columnConfig` field
- **15 system template definitions**: all carry `columnConfig` per methodology
- **Seed script**: writes `columnConfig` on create and refresh
- **Instantiation v5.1**: copies `template.columnConfig` to new project at creation
- **PATCH /projects/:id/column-config**: endpoint for gear icon panel saves

### What's deferred

- Gear icon panel is still hardcoded for waterfall columns — a future phase will make it methodology-aware and consume `project.columnConfig`
- Table column rendering based on columnConfig (currently hardcoded `COLUMN_ORDER`)

### After merge: seed templates

Run on staging after deploy:
```bash
TEMPLATE_CENTER_SEED_OK=true TEMPLATE_CENTER_REFRESH_SYSTEM_DEF=true \
  npx ts-node src/scripts/seed-system-templates.ts
```

## Test plan
- [ ] Migration runs cleanly (column_config added to templates + projects)
- [ ] Seed script writes columnConfig to all 15 templates
- [ ] Create project from Waterfall template → project.columnConfig has waterfall defaults
- [ ] Create project from Agile template → project.columnConfig has agile defaults
- [ ] PATCH /projects/:id/column-config → persists updated config
- [ ] No frontend files modified
- [ ] No dead admin code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)