### PR TITLE
feat(templates): activate 5 core templates + seed isActive fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ npm run dev                # Dev mode on port 5173
 
 ### Key Environment Variables
 - Backend: `DATABASE_URL`, `JWT_SECRET`, `JWT_EXPIRES_IN`
-- Frontend: `VITE_API_BASE` (optional, defaults to `/api`)
+- Frontend: `VITE_API_URL` (required in production builds; dev defaults to Vite proxy `/api`). Do not use legacy `VITE_API_BASE` / `VITE_API_BASE_URL` in Railway — only `VITE_API_URL` is read by `zephix-frontend/src/lib/api/client.ts`.
 
 ---
 

--- a/docs/ai/SESSION_HANDOFF_2026-04-11.md
+++ b/docs/ai/SESSION_HANDOFF_2026-04-11.md
@@ -1,0 +1,92 @@
+# Session handoff — 2026-04-11
+
+**Purpose:** Preserve decisions and operator steps from the staging / Template Center stabilization thread for the next session.
+
+---
+
+## Staging backend public URL (verified)
+
+- **Correct API base:** `https://zephix-backend-staging-staging.up.railway.app/api`
+- **Incorrect assumption:** `https://zephix-backend-staging.up.railway.app` — Railway edge returns **404** (no service at that subdomain).
+- **Why the double `staging`:** Service name `zephix-backend-staging` in Railway **environment** `staging` yields a default `*.up.railway.app` host that includes both tokens. Always confirm **Networking → Public URL** in the dashboard.
+
+**Repo sources of truth:**
+
+- `docs/ai/environments/staging.env` — `STAGING_BACKEND_BASE`, `STAGING_BACKEND_API`, frontend base.
+- `zephix-frontend/.env.staging` — local/staging build copy; must stay aligned with `STAGING_BACKEND_API`.
+
+---
+
+## Frontend Railway variables (canonical)
+
+1. Set **`VITE_API_URL`** = `https://zephix-backend-staging-staging.up.railway.app/api` (no trailing slash issues: client normalizes).
+2. Remove **`VITE_API_BASE`** (and **`VITE_API_BASE_URL`** if present) — not read by `zephix-frontend/src/lib/api/client.ts`; only **`VITE_API_URL`** is used in production.
+3. **Redeploy frontend** so Vite bakes env at build time.
+
+**Symptoms when wrong:** 401s, empty Template Center, or failed authenticated calls because the SPA hit the wrong host or a dead Railway subdomain.
+
+---
+
+## Staging DB: migration 066 + template seed
+
+**Migration 066 (repo):** `zephix-backend/src/migrations/18000000000066-AddColumnConfigToTemplatesAndProjects.ts`
+
+From repo root (requires `ZEPHIX_ENV=staging` and `DATABASE_URL` for staging Postgres):
+
+```bash
+export ZEPHIX_ENV=staging
+export DATABASE_URL='<from Railway staging DB>'
+bash scripts/migrations/run-staging.sh
+```
+
+**System template seed** (15 templates, `columnConfig`; guarded env flags). From `zephix-backend/`:
+
+```bash
+cd zephix-backend
+export DATABASE_URL='<same staging DB>'
+TEMPLATE_CENTER_SEED_OK=true TEMPLATE_CENTER_REFRESH_SYSTEM_DEF=true \
+  npx ts-node src/scripts/seed-system-templates.ts
+```
+
+**Done criteria:** Open Template Center on staging frontend; templates load (not empty / not persistent 401).
+
+---
+
+## Other topics touched this session (carry to next)
+
+Recorded here for continuity; verify in GitHub / design docs before implementing.
+
+| Topic | Notes |
+|-------|--------|
+| PR #123 | MVP-5, described as 4 commits — confirm branch/merge state in GitHub. |
+| PR #126 | P-2 / template-related — e.g. `columnConfig` seed alignment. |
+| Overview redesign | Spec: three colored cards — locate in design / issue tracker. |
+| Toolbar consolidation | Filter / Assignee / Search / Gear / … / +Task — product UX spec. |
+| Insight Center catalog | ~80 KPI cards — catalog / entitlement surface. |
+| Document–task bidirectional linking | Architecture discussion — find ADR or issue. |
+| Post-MVP backlog | Next session after Template Center stabilization is verified. |
+
+**Remaining MVP items:** Operator indicated **four** items after stabilization; list and owners to be picked up next session (not enumerated in this file).
+
+---
+
+## Related doc commits (this repo)
+
+- `docs/README.md` — frontend env docs corrected to **`VITE_API_URL`** (not legacy `VITE_API_BASE`).
+- `docs/ai/environments/staging.env` + `zephix-frontend/.env.staging` — Railway hostname and operator comments (commit `feaa78a8` area).
+
+---
+
+## Quick verification commands
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" "https://zephix-backend-staging-staging.up.railway.app/api/ping"
+# expect 200
+
+curl -sS -o /dev/null -w "%{http_code}\n" "https://zephix-backend-staging.up.railway.app/api/ping"
+# expect 404 unless you intentionally add that host in Railway
+```
+
+---
+
+**Next session entry:** After ops steps 1–5 above, smoke Template Center; then proceed with the four remaining MVP items and post-MVP spec as already documented elsewhere.

--- a/docs/ai/environments/staging.env
+++ b/docs/ai/environments/staging.env
@@ -1,3 +1,11 @@
+# ── Railway staging frontend (build-time) ───────────────────────────────────
+# Set ONLY: VITE_API_URL=<STAGING_BACKEND_API below>
+# Remove unused vars on the frontend service: VITE_API_BASE, VITE_API_BASE_URL (not read by app code).
+#
+# The API host MUST match Backend → Settings → Networking → Public URL + "/api".
+# The default *.up.railway.app hostname often includes the environment twice
+# (e.g. ...-staging-staging...). Using "zephix-backend-staging.up.railway.app" without
+# verifying in the dashboard often yields Railway edge 404 (no service at that host).
 STAGING_BACKEND_BASE=https://zephix-backend-staging-staging.up.railway.app
 STAGING_BACKEND_API=https://zephix-backend-staging-staging.up.railway.app/api
 STAGING_SMOKE_KEY=83cd663a9f80c7bcc3227203d3af1b9dd5ef17f294579557a81c16c8bd4846f3

--- a/docs/architecture/proofs/staging/migrations-last-run.txt
+++ b/docs/architecture/proofs/staging/migrations-last-run.txt
@@ -1,6 +1,6 @@
 # Staging migration proof — written by scripts/migrations/run-staging.sh
-date_utc:    2026-04-05T18:30:55Z
-commit_sha:  710def0cbe8ded0490cfa33119eb263b0185c4e7
+date_utc:    2026-04-11T06:20:17Z
+commit_sha:  d9884a7027df5c79a354a511d0cd6e84e274f504
 zephix_env:  staging
 db_host:     interchange.proxy.rlwy.net
 db_name:     railway

--- a/zephix-backend/src/migrations/18000000000066-AddColumnConfigToTemplatesAndProjects.ts
+++ b/zephix-backend/src/migrations/18000000000066-AddColumnConfigToTemplatesAndProjects.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * P-2: Add column_config JSONB to templates and projects.
+ *
+ * Templates carry methodology-specific column defaults (Tier 2 columns).
+ * Projects inherit column_config at creation time and can customize via gear icon.
+ *
+ * Three-tier model:
+ *   Tier 1 — Always visible (task name, status, assignee, dates, priority, completion, description)
+ *   Tier 2 — Template-activated (phase, sprint, story points, WIP limit, etc.)
+ *   Tier 3 — Manual toggle (approval status, risk level, time tracking)
+ */
+export class AddColumnConfigToTemplatesAndProjects18000000000066
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE templates
+        ADD COLUMN IF NOT EXISTS column_config jsonb DEFAULT NULL;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE projects
+        ADD COLUMN IF NOT EXISTS column_config jsonb DEFAULT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE projects
+        DROP COLUMN IF EXISTS column_config;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE templates
+        DROP COLUMN IF EXISTS column_config;
+    `);
+  }
+}

--- a/zephix-backend/src/modules/projects/entities/project.entity.ts
+++ b/zephix-backend/src/modules/projects/entities/project.entity.ts
@@ -213,6 +213,10 @@ export class Project {
   @Column({ type: 'varchar', length: 50, default: 'agile', nullable: true })
   methodology: string;
 
+  /** P-2: Per-project column visibility config. Inherited from template, user-customizable via gear icon. */
+  @Column({ name: 'column_config', type: 'jsonb', nullable: true })
+  columnConfig: Record<string, boolean> | null;
+
   // Missing relations that other entities expect
   @OneToMany(() => Task, (task) => task.project)
   tasks: Task[];

--- a/zephix-backend/src/modules/projects/projects.controller.ts
+++ b/zephix-backend/src/modules/projects/projects.controller.ts
@@ -656,4 +656,22 @@ export class ProjectsController {
       tenant.userId,
     );
   }
+
+  // ── P-2: Column configuration ──────────────────────────────────────
+
+  @Patch(':id/column-config')
+  @UseGuards(JwtAuthGuard)
+  @RequireWorkspaceRole('workspace_member', { allowAdminOverride: true })
+  async updateColumnConfig(
+    @Param('id') id: string,
+    @Body() dto: { columnConfig: Record<string, boolean> },
+    @GetTenant() tenant: TenantContext,
+  ) {
+    this.logger.log(`Updating column config for project ${id}`);
+    return this.projectsService.updateColumnConfig(
+      id,
+      tenant.organizationId,
+      dto.columnConfig,
+    );
+  }
 }

--- a/zephix-backend/src/modules/projects/services/projects.service.ts
+++ b/zephix-backend/src/modules/projects/services/projects.service.ts
@@ -2075,4 +2075,22 @@ export class ProjectsService extends TenantAwareRepository<Project> {
       availableKPIs: kpiData.availableKPIs,
     };
   }
+
+  // ── P-2: Column configuration ──────────────────────────────────────
+
+  async updateColumnConfig(
+    projectId: string,
+    organizationId: string,
+    columnConfig: Record<string, boolean>,
+  ): Promise<{ data: { columnConfig: Record<string, boolean> } }> {
+    const project = await this.projectRepository.findOne({
+      where: { id: projectId, organizationId } as any,
+    });
+    if (!project) throw new NotFoundException('Project not found');
+
+    (project as any).columnConfig = columnConfig;
+    await this.projectRepository.save(project);
+
+    return { data: { columnConfig } };
+  }
 }

--- a/zephix-backend/src/modules/templates/data/system-template-definitions.ts
+++ b/zephix-backend/src/modules/templates/data/system-template-definitions.ts
@@ -1203,7 +1203,11 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
  * per template later without a redeploy.
  */
 export const ACTIVE_TEMPLATE_CODES: ReadonlySet<string> = new Set<string>([
-  'pm_waterfall_v2',
+  'pm_waterfall_v2',        // Waterfall — already active
+  'pm_agile_v1',            // Agile
+  'sw_kanban_delivery_v1',  // Kanban
+  'pm_hybrid_v1',           // Hybrid
+  'sw_scrum_delivery_v1',   // Scrum (Agile variant)
 ]);
 
 export function isTemplateComingSoon(code: string | null | undefined): boolean {

--- a/zephix-backend/src/modules/templates/data/system-template-definitions.ts
+++ b/zephix-backend/src/modules/templates/data/system-template-definitions.ts
@@ -129,6 +129,13 @@ export interface SystemTemplateDef {
    * (e.g. "Table", "Board"). Display-only; does not create views.
    */
   includedViews?: string[];
+  /**
+   * P-2: Tier 2 column defaults. Keys map to column identifiers in the
+   * gear icon panel. true = ON by default, false = available but OFF.
+   * Tier 1 columns (taskName, status, assignee, dates, priority, completion,
+   * description) are always visible and not listed here.
+   */
+  columnConfig?: Record<string, boolean>;
   phases: Array<{
     name: string;
     description: string;
@@ -214,6 +221,68 @@ const HYBRID_GOV = {
   waterfallEnabled: false,
 };
 
+// ── P-2: Methodology-specific column defaults (Tier 2) ──────────────
+
+const WATERFALL_COLUMNS: Record<string, boolean> = {
+  phase: true,
+  duration: true,
+  milestone: true,
+  dependency: true,
+  remarks: true,
+  sprint: false,
+  storyPoints: false,
+  epic: false,
+  wipLimit: false,
+  cycleTime: false,
+  leadTime: false,
+  labels: false,
+};
+
+const AGILE_COLUMNS: Record<string, boolean> = {
+  phase: false,
+  duration: false,
+  milestone: false,
+  dependency: false,
+  remarks: false,
+  sprint: true,
+  storyPoints: true,
+  epic: true,
+  wipLimit: false,
+  cycleTime: false,
+  leadTime: false,
+  labels: true,
+};
+
+const KANBAN_COLUMNS: Record<string, boolean> = {
+  phase: false,
+  duration: false,
+  milestone: false,
+  dependency: false,
+  remarks: false,
+  sprint: false,
+  storyPoints: false,
+  epic: false,
+  wipLimit: true,
+  cycleTime: true,
+  leadTime: true,
+  labels: true,
+};
+
+const HYBRID_COLUMNS: Record<string, boolean> = {
+  phase: true,
+  duration: true,
+  milestone: true,
+  dependency: true,
+  remarks: false,
+  sprint: true,
+  storyPoints: true,
+  epic: false,
+  wipLimit: false,
+  cycleTime: false,
+  leadTime: false,
+  labels: false,
+};
+
 // ── Phase 5A: 14 system project templates across 5 categories ────────
 
 export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
@@ -233,6 +302,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['waterfall', 'governance', 'baseline', 'evm', 'phase-gates', 'uat'],
     defaultTabs: ['overview', 'plan', 'gantt', 'tasks', 'budget', 'change-requests', 'documents', 'kpis', 'risks', 'resources'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     phases: [
       {
         name: 'Requirements & scope',
@@ -450,6 +520,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['waterfall', 'pmi', 'reference', 'governance', 'baseline'],
     defaultTabs: ['tasks', 'overview', 'gantt', 'documents', 'risks'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     bestFor:
       'Plan-driven projects that need clear phase structure, milestone gates, and the option to enforce governance later.',
     /**
@@ -755,6 +826,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['agile', 'sprint', 'iterative', 'backlog'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Backlog & Sprint Planning', description: 'Refinement, estimation, sprint goal', order: 0, estimatedDurationDays: 1 },
       { name: 'Sprint Execution', description: 'Build, daily standups, board flow', order: 1, estimatedDurationDays: 12 },
@@ -782,6 +854,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['hybrid', 'transformation', 'mixed'],
     defaultTabs: ['overview', 'plan', 'tasks', 'board', 'budget', 'change-requests', 'kpis', 'risks'],
     defaultGovernanceFlags: HYBRID_GOV,
+    columnConfig: HYBRID_COLUMNS,
     phases: [
       { name: 'Discovery', description: 'Requirements and architecture spikes', order: 0, estimatedDurationDays: 5 },
       { name: 'Iterative Delivery', description: 'Sprint-based execution with governance gates', order: 1, estimatedDurationDays: 30 },
@@ -809,6 +882,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['risk', 'compliance', 'register', 'grc'],
     defaultTabs: ['overview', 'board', 'tasks', 'kpis', 'risks', 'documents'],
     defaultGovernanceFlags: KANBAN_GOV,
+    columnConfig: KANBAN_COLUMNS,
     phases: [
       { name: 'Continuous Tracking', description: 'Ongoing risk and mitigation management', order: 0, estimatedDurationDays: 90 },
     ],
@@ -839,6 +913,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['product', 'discovery', 'research', 'validation'],
     defaultTabs: ['overview', 'tasks', 'board', 'documents', 'kpis'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Frame the Problem', description: 'Define problem statement and target users', order: 0, estimatedDurationDays: 3 },
       { name: 'Research & Interviews', description: 'User research, interviews, and synthesis', order: 1, estimatedDurationDays: 10 },
@@ -866,6 +941,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['product', 'launch', 'go-to-market'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks', 'documents'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Launch Planning', description: 'Scope, channels, milestones, success metrics', order: 0, estimatedDurationDays: 5 },
       { name: 'Sprint 1 — Build', description: 'Landing pages, messaging, collateral, FAQs', order: 1, estimatedDurationDays: 14 },
@@ -894,6 +970,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['product', 'roadmap', 'quarterly', 'okr'],
     defaultTabs: ['overview', 'plan', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: HYBRID_GOV,
+    columnConfig: HYBRID_COLUMNS,
     phases: [
       { name: 'Quarter Planning', description: 'OKRs, themes, and sprint slate', order: 0, estimatedDurationDays: 5 },
       { name: 'Build Sprints', description: 'Iterative delivery against quarterly themes', order: 1, estimatedDurationDays: 60 },
@@ -924,6 +1001,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['software', 'sprint', 'velocity', 'engineering'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Sprint Planning', description: 'Backlog refinement and sprint goal', order: 0, estimatedDurationDays: 1 },
       { name: 'Sprint Execution', description: 'Development, daily standups, code review', order: 1, estimatedDurationDays: 12 },
@@ -951,6 +1029,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['software', 'kanban', 'flow', 'continuous'],
     defaultTabs: ['overview', 'board', 'tasks', 'kpis'],
     defaultGovernanceFlags: KANBAN_GOV,
+    columnConfig: KANBAN_COLUMNS,
     phases: [
       { name: 'Continuous Flow', description: 'Ongoing pull-based execution', order: 0, estimatedDurationDays: 90 },
     ],
@@ -973,6 +1052,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['release', 'deployment', 'cut', 'hypercare'],
     defaultTabs: ['overview', 'plan', 'gantt', 'tasks', 'change-requests', 'documents', 'kpis', 'risks'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     phases: [
       { name: 'Release Plan', description: 'Scope freeze, release notes, dependencies', order: 0, estimatedDurationDays: 5 },
       { name: 'Cut & Stabilize', description: 'Branch cut and stabilization fixes', order: 1, estimatedDurationDays: 5 },
@@ -1005,6 +1085,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['operations', 'improvement', 'kaizen', 'service'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Assess Current State', description: 'Map process, baseline metrics, identify bottlenecks', order: 0, estimatedDurationDays: 5 },
       { name: 'Improvement Sprint 1', description: 'Highest-impact improvements', order: 1, estimatedDurationDays: 14 },
@@ -1032,6 +1113,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['operations', 'readiness', 'cutover', 'handover'],
     defaultTabs: ['overview', 'plan', 'gantt', 'tasks', 'budget', 'change-requests', 'documents', 'kpis', 'risks', 'resources'],
     defaultGovernanceFlags: WATERFALL_GOV,
+    columnConfig: WATERFALL_COLUMNS,
     phases: [
       { name: 'Assessment', description: 'Inventory, runbook gap analysis, RACI', order: 0, estimatedDurationDays: 10 },
       { name: 'Build', description: 'Author runbooks, monitoring, on-call rota', order: 1, estimatedDurationDays: 15 },
@@ -1064,6 +1146,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['startup', 'mvp', 'lean', 'validation'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Discover', description: 'Hypotheses, riskiest assumption, success metric', order: 0, estimatedDurationDays: 3 },
       { name: 'Build', description: 'Smallest valuable slice', order: 1, estimatedDurationDays: 14 },
@@ -1091,6 +1174,7 @@ export const SYSTEM_TEMPLATE_DEFS: SystemTemplateDef[] = [
     workTypeTags: ['startup', 'gtm', 'launch', 'positioning'],
     defaultTabs: ['overview', 'tasks', 'board', 'kpis', 'risks', 'documents'],
     defaultGovernanceFlags: SCRUM_GOV,
+    columnConfig: AGILE_COLUMNS,
     phases: [
       { name: 'Positioning', description: 'Audience, message, channels, pricing', order: 0, estimatedDurationDays: 5 },
       { name: 'Build Assets', description: 'Landing, sales collateral, demo, FAQs', order: 1, estimatedDurationDays: 10 },

--- a/zephix-backend/src/modules/templates/entities/template.entity.ts
+++ b/zephix-backend/src/modules/templates/entities/template.entity.ts
@@ -167,6 +167,10 @@ export class Template {
   @Column({ name: 'default_governance_flags', type: 'jsonb', nullable: true })
   defaultGovernanceFlags?: Record<string, boolean>;
 
+  /** P-2: Tier 2 column defaults per methodology. Copied to project at creation. */
+  @Column({ name: 'column_config', type: 'jsonb', nullable: true })
+  columnConfig?: Record<string, boolean> | null;
+
   @Column({ name: 'phases', type: 'jsonb', nullable: true })
   phases?: Array<{
     name: string;

--- a/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
+++ b/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
@@ -256,6 +256,9 @@ export class TemplatesInstantiateV51Service {
           // branch falls through to TaskListSection instead of WaterfallTable.
           // This is the smoking gun the operator screenshots exposed.
           methodology: (template.methodology as string) || 'agile',
+          // P-2: Inherit column configuration from template.
+          // User can customize later via gear icon → PATCH /projects/:id/column-config.
+          columnConfig: (template as any).columnConfig || null,
         });
 
         project = await projectRepo.save(project);

--- a/zephix-backend/src/scripts/seed-system-templates.ts
+++ b/zephix-backend/src/scripts/seed-system-templates.ts
@@ -180,6 +180,7 @@ async function main() {
             taskTemplates: def.taskTemplates as any,
             defaultTabs: def.defaultTabs,
             defaultGovernanceFlags: def.defaultGovernanceFlags as any,
+            columnConfig: (def.columnConfig as any) || null,
             workTypeTags: def.workTypeTags,
             metadata: {
             purpose: def.purpose,
@@ -221,6 +222,7 @@ async function main() {
         riskPresets: (def.riskPresets as any) || [],
         defaultTabs: def.defaultTabs,
         defaultGovernanceFlags: def.defaultGovernanceFlags,
+        columnConfig: (def.columnConfig as any) || null,
         workTypeTags: def.workTypeTags,
         // Phase 5A: store one-line purpose copy in metadata for the
         // template-card body. SYSTEM templates use a different metadata

--- a/zephix-backend/src/scripts/seed-system-templates.ts
+++ b/zephix-backend/src/scripts/seed-system-templates.ts
@@ -22,7 +22,7 @@ import { KpiDefinitionEntity } from '../modules/kpis/entities/kpi-definition.ent
 import { TemplateKpiEntity } from '../modules/kpis/entities/template-kpi.entity';
 import { KPI_PACKS } from '../modules/kpis/engine/kpi-packs';
 import { KPI_REGISTRY_DEFAULTS } from '../modules/kpis/engine/kpi-registry-defaults';
-import { SYSTEM_TEMPLATE_DEFS } from '../modules/templates/data/system-template-definitions';
+import { SYSTEM_TEMPLATE_DEFS, ACTIVE_TEMPLATE_CODES } from '../modules/templates/data/system-template-definitions';
 
 
 async function ensureKpiDefinitions(dataSource: DataSource): Promise<Map<string, string>> {
@@ -182,6 +182,7 @@ async function main() {
             defaultGovernanceFlags: def.defaultGovernanceFlags as any,
             columnConfig: (def.columnConfig as any) || null,
             workTypeTags: def.workTypeTags,
+            isActive: ACTIVE_TEMPLATE_CODES.has(def.code),
             metadata: {
             purpose: def.purpose,
             // Phase 5B.1 — preview-only Waterfall metadata
@@ -213,7 +214,7 @@ async function main() {
         organizationId: null,
         createdById: user.id,
         templateScope: 'SYSTEM',
-        isActive: true,
+        isActive: ACTIVE_TEMPLATE_CODES.has(def.code),
         isSystem: true,
         isDefault: false,
         isPublished: true,

--- a/zephix-frontend/.env.staging
+++ b/zephix-frontend/.env.staging
@@ -1,4 +1,5 @@
-# Do not edit domain here. Update docs/ai/environments/staging.env then re-copy.
+# Copy from docs/ai/environments/staging.env (STAGING_BACKEND_API). Must match Railway
+# backend public URL + /api — see comments in that file (wrong host → 401/404 from edge).
 VITE_API_URL=https://zephix-backend-staging-staging.up.railway.app/api
 VITE_STRICT_JWT=false
 VITE_SENTRY_ENVIRONMENT=staging

--- a/zephix-frontend/src/pages/projects/ProjectsPage.tsx
+++ b/zephix-frontend/src/pages/projects/ProjectsPage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-
 import { toast } from 'sonner';
 
 import { Button } from '../../components/ui/button/Button';
@@ -10,6 +9,7 @@ import { useProjects, type ProjectListItem } from '../../features/projects/hooks
 import { deleteProject } from '../../features/projects/api';
 import { getErrorText } from '../../lib/api/errors';
 import { useAuth } from '../../state/AuthContext';
+
 import {
   PLATFORM_TRASH_RETENTION_DAYS,
   trashRetentionDeleteSentence,


### PR DESCRIPTION
## Summary
- Expand `ACTIVE_TEMPLATE_CODES` to 5 core templates: Waterfall, Agile, Kanban, Hybrid, Scrum — one per methodology for MVP
- Seed script refresh path now sets `isActive` from `ACTIVE_TEMPLATE_CODES` instead of skipping it
- Seed script creation path uses `ACTIVE_TEMPLATE_CODES.has(def.code)` instead of hardcoded `true`
- Includes P-2 column configuration model (migration 066), staging env URL fixes, and lint fix

## Post-merge steps
After deploying to staging, run the seed with refresh flag to flip the 4 new templates to active:
```bash
TEMPLATE_CENTER_SEED_OK=true TEMPLATE_CENTER_REFRESH_SYSTEM_DEF=true \
  npx ts-node src/scripts/seed-system-templates.ts
```

## Test plan
- [ ] Template center shows 5 active templates: Waterfall, Agile, Kanban, Hybrid, Scrum
- [ ] Remaining 9 templates show "Coming Soon" badge
- [ ] Create a project from each active template — Waterfall lands on Activities tab, others on Overview tab
- [ ] Verify `columnConfig` is populated on all 5 active templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)