### PR TITLE
feat: MVP final four — overview fix, gear popover, verification

### DIFF
--- a/docs/MVP_FINAL_FOUR_VERIFICATION.md
+++ b/docs/MVP_FINAL_FOUR_VERIFICATION.md
@@ -1,0 +1,49 @@
+# MVP Final Four — Verification Checklist
+
+## Pre-deployment (env var — ops action)
+- [ ] Set `ZEPHIX_WS_MEMBERSHIP_V1=1` on Railway backend staging service
+- [ ] Verify workspace_members rows exist for at least one non-admin test user
+- [ ] Redeploy backend (env var change requires restart)
+
+## Item 1: Sidebar role-based visibility (P-6)
+- [ ] Login as Admin — sidebar shows ALL workspaces
+- [ ] Login as Member — sidebar shows ONLY workspaces where user has workspace_members row
+- [ ] Login as Viewer — sidebar shows ONLY workspaces where user has workspace_members row
+- [ ] Admin still sees "Administration Console" in profile dropdown
+- [ ] Member does NOT see "Administration Console" in profile dropdown
+
+## Item 2: Gear icon popover
+- [ ] Open a Waterfall project — Activities tab — gear icon visible in toolbar above table
+- [ ] Open an Agile project — Activities tab — gear icon visible in toolbar
+- [ ] Open a Kanban project — Activities tab — gear icon visible in toolbar
+- [ ] Click gear icon (Waterfall) — popover appears anchored below button (not full-height slide-over)
+- [ ] Click gear icon (non-Waterfall) — "Coming soon" popover appears
+- [ ] Popover is ~320px wide with scroll
+- [ ] Click outside popover — closes
+- [ ] Press Escape — closes
+- [ ] Fields tab shows column toggles (Waterfall only)
+- [ ] View tab shows "Coming soon" message (Waterfall only)
+
+## Item 3: Admin overview page
+- [ ] Open Admin Console — Overview page loads without "Failed to load" error
+- [ ] Governance Health widget shows data OR "No governance alerts"
+- [ ] Decisions Required widget shows "No governance decisions pending" (graceful empty)
+- [ ] Workspace Snapshot widget shows data OR "No workspaces available"
+- [ ] Recent Activity widget shows "No recent governance activity"
+- [ ] Quick Actions section renders correctly
+
+## Item 4: Board view for non-waterfall projects
+- [ ] Create project from Waterfall template — Board tab — tasks in status columns
+- [ ] Create project from Agile template — Board tab — tasks in status columns
+- [ ] Create project from Kanban template — Board tab — tasks in status columns
+- [ ] Drag a task card between columns — status updates
+- [ ] Return to Activities tab — task status reflects the board change
+
+## End-to-end demo flow
+- [ ] Admin: sign in — Admin Console — Overview loads — People page works
+- [ ] Admin: create workspace — invite member
+- [ ] Member: sign in — sees only assigned workspace(s) in sidebar
+- [ ] Member: create project from Agile template — project appears in sidebar
+- [ ] Member: Activities tab — TaskListSection renders — can create tasks
+- [ ] Member: Board tab — tasks in columns — can drag to change status
+- [ ] Member: gear icon opens "Coming soon" popover

--- a/zephix-frontend/src/features/administration/pages/AdministrationOverviewPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationOverviewPage.tsx
@@ -36,7 +36,6 @@ export default function AdministrationOverviewPage() {
 
   const loadOverview = async () => {
     setLoading(true);
-    setError(null);
     const results = await Promise.allSettled([
       administrationApi.listPendingDecisions({ page: 1, limit: 20 }),
       administrationApi.getGovernanceHealth(),

--- a/zephix-frontend/src/features/administration/pages/AdministrationOverviewPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationOverviewPage.tsx
@@ -28,7 +28,6 @@ function HealthCard({ label, value }: { label: string; value: number | null }) {
 
 export default function AdministrationOverviewPage() {
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [actioningId, setActioningId] = useState<string | null>(null);
   const [decisions, setDecisions] = useState<GovernanceDecision[]>([]);
   const [health, setHealth] = useState<GovernanceHealth | null>(null);
@@ -38,22 +37,17 @@ export default function AdministrationOverviewPage() {
   const loadOverview = async () => {
     setLoading(true);
     setError(null);
-    try {
-      const [decisionData, healthData, workspaceData, activityData] = await Promise.all([
-        administrationApi.listPendingDecisions({ page: 1, limit: 20 }),
-        administrationApi.getGovernanceHealth(),
-        administrationApi.getWorkspaceSnapshot({ page: 1, limit: 20 }),
-        administrationApi.listRecentActivity(20),
-      ]);
-      setDecisions(decisionData.data);
-      setHealth(healthData);
-      setWorkspaceSnapshot(workspaceData.data);
-      setActivity(activityData);
-    } catch {
-      setError("Failed to load administration overview.");
-    } finally {
-      setLoading(false);
-    }
+    const results = await Promise.allSettled([
+      administrationApi.listPendingDecisions({ page: 1, limit: 20 }),
+      administrationApi.getGovernanceHealth(),
+      administrationApi.getWorkspaceSnapshot({ page: 1, limit: 20 }),
+      administrationApi.listRecentActivity(20),
+    ]);
+    if (results[0].status === 'fulfilled') setDecisions(results[0].value.data);
+    if (results[1].status === 'fulfilled') setHealth(results[1].value);
+    if (results[2].status === 'fulfilled') setWorkspaceSnapshot(results[2].value.data);
+    if (results[3].status === 'fulfilled') setActivity(results[3].value);
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -131,7 +125,6 @@ export default function AdministrationOverviewPage() {
           <h2 className="text-sm font-semibold text-gray-900">Decisions Required</h2>
         </div>
         <div className="space-y-3 p-4">
-          {error ? <p className="text-sm text-red-600">{error}</p> : null}
           {loading ? (
             <p className="text-sm text-gray-500">Loading decisions...</p>
           ) : decisions.length === 0 ? (
@@ -218,7 +211,7 @@ export default function AdministrationOverviewPage() {
                 </tr>
               ) : (
                 workspaceSnapshot.map((workspace) => (
-                  <tr key={workspace.id} className="border-t border-gray-200 text-sm text-gray-700">
+                  <tr key={workspace.workspaceId} className="border-t border-gray-200 text-sm text-gray-700">
                     <td className="px-4 py-3">{workspace.workspaceName}</td>
                     <td className="px-4 py-3">{workspace.projectCount}</td>
                     <td className="px-4 py-3">{workspace.budgetStatus}</td>

--- a/zephix-frontend/src/features/projects/tabs/ProjectTasksTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectTasksTab.tsx
@@ -1,12 +1,13 @@
 /**
  * ProjectTasksTab
- * 
+ *
  * Tasks tab content - renders the task list for the project.
+ * Gear icon lives here so it's available for ALL methodologies.
  */
 
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { ListTodo } from 'lucide-react';
+import { ListTodo, Loader2, Settings } from 'lucide-react';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { TaskListSection } from '../components/TaskListSection';
 import { EmptyState } from '@/components/ui/feedback/EmptyState';
@@ -17,6 +18,10 @@ export const ProjectTasksTab: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>();
   const { activeWorkspaceId: workspaceId } = useWorkspaceStore();
   const [searchParams] = useSearchParams();
+
+  // Shared gear icon state — controls the customize view panel for all methodologies.
+  const [customizeViewOpen, setCustomizeViewOpen] = useState(false);
+  const gearRef = useRef<HTMLButtonElement>(null);
 
   // Handle taskId highlight from URL
   useEffect(() => {
@@ -56,25 +61,94 @@ export const ProjectTasksTab: React.FC = () => {
     );
   }
 
-  // Phase 5B.1 — Waterfall projects render the dedicated WaterfallTable.
-  // All other methodologies keep the existing TaskListSection unchanged.
-  // Reading methodology from ProjectContext (loaded by ProjectPageLayout)
-  // means this component does not refetch the project itself.
-  // ctx.project may be null briefly while the layout is still loading the
-  // project; in that case we render the legacy list to avoid a flash of the
-  // "Project not found" empty state. The layout always resolves before tasks
-  // can render anything meaningful, so this is a safe default.
   const ctx = useProjectContext();
   const isWaterfall =
     (ctx.project?.methodology || '').toLowerCase() === 'waterfall';
 
+  const handleClose = useCallback(() => setCustomizeViewOpen(false), []);
+
   return (
     <div id="task-list-section">
+      {/* Shared toolbar — visible for ALL methodologies */}
+      <div className="mb-2 flex items-center justify-end gap-2 px-1">
+        <div className="relative">
+          <button
+            ref={gearRef}
+            type="button"
+            onClick={() => setCustomizeViewOpen((v) => !v)}
+            aria-label="Customize view"
+            data-testid="customize-view-button"
+            title="Customize view (fields, filters, grouping)"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          >
+            <Settings className="h-4 w-4" />
+          </button>
+
+          {/* Non-waterfall: lightweight "coming soon" popover */}
+          {customizeViewOpen && !isWaterfall && (
+            <NonWaterfallCustomizePopover onClose={handleClose} />
+          )}
+        </div>
+      </div>
+
+      {/* Methodology-specific content */}
       {isWaterfall ? (
-        <WaterfallTable projectId={projectId} workspaceId={workspaceId} />
+        <WaterfallTable
+          projectId={projectId}
+          workspaceId={workspaceId}
+          customizeViewOpen={customizeViewOpen}
+          onCustomizeViewClose={handleClose}
+        />
       ) : (
         <TaskListSection projectId={projectId} workspaceId={workspaceId} />
       )}
+    </div>
+  );
+};
+
+/** Lightweight popover for non-waterfall projects. */
+const NonWaterfallCustomizePopover: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full z-40 mt-1 w-72 rounded-lg border border-slate-200 bg-white shadow-xl"
+      role="dialog"
+      aria-label="Customize view"
+      data-testid="customize-view-panel"
+    >
+      <div className="px-4 py-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-800">
+          <Settings className="h-4 w-4 text-slate-500" />
+          Customize view
+        </div>
+      </div>
+      <div className="border-t border-slate-200 px-4 py-4">
+        <div className="flex items-center gap-2 text-sm text-amber-800">
+          <Loader2 className="h-3.5 w-3.5" />
+          <span className="font-medium">Coming soon</span>
+        </div>
+        <p className="mt-1 text-xs text-slate-500 leading-relaxed">
+          Column configuration for this project type will be available in a future release.
+        </p>
+      </div>
     </div>
   );
 };

--- a/zephix-frontend/src/features/projects/tabs/ProjectTasksTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectTasksTab.tsx
@@ -86,7 +86,7 @@ export const ProjectTasksTab: React.FC = () => {
 
           {/* Non-waterfall: lightweight "coming soon" popover */}
           {customizeViewOpen && !isWaterfall && (
-            <NonWaterfallCustomizePopover onClose={handleClose} />
+            <NonWaterfallCustomizePopover onClose={handleClose} anchorRef={gearRef} />
           )}
         </div>
       </div>
@@ -98,6 +98,7 @@ export const ProjectTasksTab: React.FC = () => {
           workspaceId={workspaceId}
           customizeViewOpen={customizeViewOpen}
           onCustomizeViewClose={handleClose}
+          gearAnchorRef={gearRef}
         />
       ) : (
         <TaskListSection projectId={projectId} workspaceId={workspaceId} />
@@ -107,7 +108,10 @@ export const ProjectTasksTab: React.FC = () => {
 };
 
 /** Lightweight popover for non-waterfall projects. */
-const NonWaterfallCustomizePopover: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+const NonWaterfallCustomizePopover: React.FC<{
+  onClose: () => void;
+  anchorRef?: React.RefObject<HTMLElement | null>;
+}> = ({ onClose, anchorRef }) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -120,11 +124,15 @@ const NonWaterfallCustomizePopover: React.FC<{ onClose: () => void }> = ({ onClo
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      const target = e.target as Node;
+      if (ref.current && !ref.current.contains(target)
+          && !(anchorRef?.current && anchorRef.current.contains(target))) {
+        onClose();
+      }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [onClose]);
+  }, [onClose, anchorRef]);
 
   return (
     <div

--- a/zephix-frontend/src/features/projects/waterfall/CustomizeViewPanel.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/CustomizeViewPanel.tsx
@@ -51,7 +51,7 @@
  *   - Future expansion (View tab, custom field create, etc.) keeps the
  *     panel growing without affecting the table
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Eye, EyeOff, Loader2, Settings, X } from 'lucide-react';
 
 /**
@@ -127,6 +127,7 @@ export const CustomizeViewPanel: React.FC<CustomizeViewPanelProps> = ({
   onClose,
 }) => {
   const [activeTab, setActiveTab] = useState<TabKey>('fields');
+  const panelRef = useRef<HTMLDivElement>(null);
 
   // Escape closes the panel.
   useEffect(() => {
@@ -140,80 +141,82 @@ export const CustomizeViewPanel: React.FC<CustomizeViewPanelProps> = ({
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  return (
-    <>
-      {/* Backdrop overlay */}
-      <div
-        className="fixed inset-0 z-30 bg-slate-900/20"
-        onClick={onClose}
-        aria-hidden
-        data-testid="customize-view-panel-backdrop"
-      />
-      {/* Panel */}
-      <aside
-        className="fixed top-0 right-0 z-40 h-full w-full max-w-[440px] overflow-y-auto border-l border-slate-200 bg-white shadow-xl"
-        role="dialog"
-        aria-label="Customize view"
-        data-testid="customize-view-panel"
-      >
-        {/* Header */}
-        <div className="sticky top-0 z-10 border-b border-slate-200 bg-white px-5 py-3">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2 text-sm font-semibold text-slate-800">
-              <Settings className="h-4 w-4 text-slate-500" />
-              Customize view
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close customize view"
-              data-testid="customize-view-panel-close"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-          {/* Tabs */}
-          <div className="mt-3 flex gap-1 -mb-px">
-            <button
-              type="button"
-              onClick={() => setActiveTab('fields')}
-              className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
-                activeTab === 'fields'
-                  ? 'border-blue-600 text-blue-700'
-                  : 'border-transparent text-slate-500 hover:text-slate-700'
-              }`}
-              data-testid="customize-view-tab-fields"
-            >
-              Fields
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab('view')}
-              className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
-                activeTab === 'view'
-                  ? 'border-blue-600 text-blue-700'
-                  : 'border-transparent text-slate-500 hover:text-slate-700'
-              }`}
-              data-testid="customize-view-tab-view"
-            >
-              View
-            </button>
-          </div>
-        </div>
+  // Click outside closes the panel.
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
 
-        {/* Tab content */}
-        <div className="px-5 py-4">
-          {activeTab === 'fields' && (
-            <FieldsTab
-              hiddenColumns={hiddenColumns}
-              onToggleColumn={onToggleColumn}
-            />
-          )}
-          {activeTab === 'view' && <ViewTab />}
+  return (
+    <div
+      ref={panelRef}
+      className="absolute right-0 top-full z-40 mt-1 w-80 max-h-[500px] overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-xl"
+      role="dialog"
+      aria-label="Customize view"
+      data-testid="customize-view-panel"
+    >
+      {/* Header */}
+      <div className="border-b border-slate-200 px-4 py-2.5">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-slate-800">
+            <Settings className="h-4 w-4 text-slate-500" />
+            Customize view
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close customize view"
+            data-testid="customize-view-panel-close"
+            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
-      </aside>
-    </>
+        {/* Tabs */}
+        <div className="mt-2 flex gap-1 -mb-px">
+          <button
+            type="button"
+            onClick={() => setActiveTab('fields')}
+            className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
+              activeTab === 'fields'
+                ? 'border-blue-600 text-blue-700'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
+            }`}
+            data-testid="customize-view-tab-fields"
+          >
+            Fields
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('view')}
+            className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
+              activeTab === 'view'
+                ? 'border-blue-600 text-blue-700'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
+            }`}
+            data-testid="customize-view-tab-view"
+          >
+            View
+          </button>
+        </div>
+      </div>
+
+      {/* Tab content */}
+      <div className="px-4 py-3">
+        {activeTab === 'fields' && (
+          <FieldsTab
+            hiddenColumns={hiddenColumns}
+            onToggleColumn={onToggleColumn}
+          />
+        )}
+        {activeTab === 'view' && <ViewTab />}
+      </div>
+    </div>
   );
 };
 

--- a/zephix-frontend/src/features/projects/waterfall/CustomizeViewPanel.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/CustomizeViewPanel.tsx
@@ -115,8 +115,10 @@ interface CustomizeViewPanelProps {
   hiddenColumns: Set<WaterfallColumnKey>;
   /** Toggle a single column's visibility. */
   onToggleColumn: (key: WaterfallColumnKey) => void;
-  /** Close handler — invoked by X button, Escape, and backdrop click. */
+  /** Close handler — invoked by X button, Escape, and click outside. */
   onClose: () => void;
+  /** Ref to the anchor button — clicks on it are excluded from click-outside. */
+  anchorRef?: React.RefObject<HTMLElement | null>;
 }
 
 type TabKey = 'fields' | 'view';
@@ -125,6 +127,7 @@ export const CustomizeViewPanel: React.FC<CustomizeViewPanelProps> = ({
   hiddenColumns,
   onToggleColumn,
   onClose,
+  anchorRef,
 }) => {
   const [activeTab, setActiveTab] = useState<TabKey>('fields');
   const panelRef = useRef<HTMLDivElement>(null);
@@ -141,16 +144,18 @@ export const CustomizeViewPanel: React.FC<CustomizeViewPanelProps> = ({
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  // Click outside closes the panel.
+  // Click outside closes the panel (excludes anchor button).
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (panelRef.current && !panelRef.current.contains(target)
+          && !(anchorRef?.current && anchorRef.current.contains(target))) {
         onClose();
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [onClose]);
+  }, [onClose, anchorRef]);
 
   return (
     <div

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -59,7 +59,6 @@ import {
   Loader2,
   MoreVertical,
   Plus,
-  Settings,
   SquareArrowOutUpRight,
   Trash2,
   X,
@@ -302,11 +301,17 @@ const PHYSICAL_COLUMN_COUNT = COLUMN_ORDER.length + 2;
 interface WaterfallTableProps {
   projectId: string;
   workspaceId: string;
+  /** When true, opens the CustomizeViewPanel. Controlled by ProjectTasksTab. */
+  customizeViewOpen?: boolean;
+  /** Called when the panel requests close. */
+  onCustomizeViewClose?: () => void;
 }
 
 export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   projectId,
   workspaceId,
+  customizeViewOpen: externalOpen,
+  onCustomizeViewClose: externalClose,
 }) => {
   const statusGroups = useWaterfallStatusSet();
 
@@ -365,7 +370,6 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   const [hiddenColumnSet, setHiddenColumnSet] = useState<Set<ColumnKey>>(
     () => new Set(),
   );
-  const [customizeViewOpen, setCustomizeViewOpen] = useState(false);
 
   const toggleColumnVisibility = useCallback((key: ColumnKey) => {
     setHiddenColumnSet((prev) => {
@@ -1051,24 +1055,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
 
   return (
     <div data-testid="waterfall-table-container">
-      {/*
-       * Phase 13 — Toolbar above the table.
-       * For now: just the gear icon on the right edge that opens the
-       * Customize View panel. Future phases will add the global
-       * "+ Task" button, filter funnel, search, etc. on this row.
-       */}
-      <div className="mb-2 flex items-center justify-end gap-2">
-        <button
-          type="button"
-          onClick={() => setCustomizeViewOpen(true)}
-          aria-label="Customize view"
-          data-testid="waterfall-customize-view-button"
-          title="Customize view (fields, filters, grouping)"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
-        >
-          <Settings className="h-4 w-4" />
-        </button>
-      </div>
+      {/* Toolbar — gear icon lifted to ProjectTasksTab. Future: filters, search. */}
       <div
         className="overflow-x-auto rounded-lg border border-slate-200 bg-white"
         data-testid="waterfall-table"
@@ -1538,11 +1525,11 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
        * button, Escape, or backdrop click. Outside the inner table
        * div so the backdrop overlay covers the table cleanly.
        */}
-      {customizeViewOpen && (
+      {externalOpen && (
         <CustomizeViewPanel
           hiddenColumns={hiddenColumnSet}
           onToggleColumn={toggleColumnVisibility}
-          onClose={() => setCustomizeViewOpen(false)}
+          onClose={() => externalClose?.()}
         />
       )}
     </div>

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -305,6 +305,8 @@ interface WaterfallTableProps {
   customizeViewOpen?: boolean;
   /** Called when the panel requests close. */
   onCustomizeViewClose?: () => void;
+  /** Ref to the gear button in ProjectTasksTab — passed to popover click-outside. */
+  gearAnchorRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 export const WaterfallTable: React.FC<WaterfallTableProps> = ({
@@ -312,6 +314,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   workspaceId,
   customizeViewOpen: externalOpen,
   onCustomizeViewClose: externalClose,
+  gearAnchorRef,
 }) => {
   const statusGroups = useWaterfallStatusSet();
 
@@ -1530,6 +1533,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
           hiddenColumns={hiddenColumnSet}
           onToggleColumn={toggleColumnVisibility}
           onClose={() => externalClose?.()}
+          anchorRef={gearAnchorRef}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- **Admin overview fix:** `Promise.all` → `Promise.allSettled` so each widget loads independently. 3 of 4 endpoints don't exist yet — widgets now show graceful empty states instead of breaking the page. Fixes workspace snapshot React key bug.
- **Gear icon lift + popover:** Moved from WaterfallTable to ProjectTasksTab shared toolbar. Non-waterfall projects (Agile/Kanban/Hybrid/Scrum) now have gear icon. Converted from 440px fixed slide-over to 320px anchored popover.
- **Verification checklist:** `docs/MVP_FINAL_FOUR_VERIFICATION.md`

### Env var (ops action — not in this PR)
Set `ZEPHIX_WS_MEMBERSHIP_V1=1` on Railway backend staging to enable sidebar role-based visibility (Item 1). Backend logic already exists — zero code changes needed.

### Board view (Item 4)
No code changes. Board is already methodology-agnostic. Verification only.

## Test plan
- [ ] Admin overview loads without "Failed to load" error
- [ ] Gear icon visible on Activities tab for Waterfall AND non-Waterfall projects
- [ ] Gear popover anchored under button (not full-height slide-over)
- [ ] Click outside / Escape dismisses popover
- [ ] `tsc --noEmit` passes (FE + BE: 0 errors)
- [ ] No backend files modified
- [ ] No dead code (`features/admin/`, `pages/admin/`) modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)