### PR TITLE
fix(workspaces): workspace role prefix for add-member DTO

### DIFF
--- a/zephix-frontend/src/features/administration/api/administration.api.ts
+++ b/zephix-frontend/src/features/administration/api/administration.api.ts
@@ -394,7 +394,7 @@ export const administrationApi = {
   ): Promise<{ id: string }> {
     const payload = await request.post<Envelope<{ id: string }>>(
       `/workspaces/${workspaceId}/members`,
-      input,
+      { userId: input.userId, role: `workspace_${input.role}` },
     );
     return unwrapData(payload);
   },
@@ -406,7 +406,7 @@ export const administrationApi = {
   ): Promise<{ success: boolean }> {
     const payload = await request.patch<Envelope<{ success: boolean }>>(
       `/workspaces/${workspaceId}/members/${memberId}`,
-      { role },
+      { role: `workspace_${role}` },
     );
     return unwrapData(payload);
   },

--- a/zephix-frontend/src/features/workspaces/members/api.ts
+++ b/zephix-frontend/src/features/workspaces/members/api.ts
@@ -15,12 +15,12 @@ export async function listWorkspaceMembers(workspaceId: string): Promise<Workspa
 }
 
 export async function addWorkspaceMember(workspaceId: string, input: { userId: string; role: 'owner' | 'member' | 'viewer' }) {
-  const res = await api.post(`/workspaces/${workspaceId}/members`, input);
+  const res = await api.post(`/workspaces/${workspaceId}/members`, { userId: input.userId, role: `workspace_${input.role}` });
   return unwrapApiData<{ id: string }>(res.data);
 }
 
 export async function updateWorkspaceMemberRole(workspaceId: string, memberId: string, role: 'owner' | 'member' | 'viewer') {
-  const res = await api.patch(`/workspaces/${workspaceId}/members/${memberId}`, { role });
+  const res = await api.patch(`/workspaces/${workspaceId}/members/${memberId}`, { role: `workspace_${role}` });
   return unwrapApiData<{ success: true }>(res.data);
 }
 


### PR DESCRIPTION
## Summary
- Frontend sent `role: "member"` but backend `AddMemberDto` expects `role: "workspace_member"`
- Caused "property 'role' is not allowed" error when adding members to workspaces
- Fixes `addWorkspaceMember` and `updateWorkspaceMemberRole` in both API files

## Test plan
- [ ] Add member to workspace via sidebar → succeeds
- [ ] Change member role via workspace members page → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)