### PR TITLE
feat: project overview redesign — three colored cards

### DIFF
--- a/zephix-frontend/src/components/ui/GradientAvatar.tsx
+++ b/zephix-frontend/src/components/ui/GradientAvatar.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+const AVATAR_GRADIENTS: [string, string][] = [
+  ['#378ADD', '#85B7EB'],
+  ['#7F77DD', '#534AB7'],
+  ['#1D9E75', '#5DCAA5'],
+  ['#D85A30', '#F0997B'],
+  ['#EF9F27', '#FAC775'],
+  ['#D4537E', '#ED93B1'],
+];
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  return (name[0] || '?').toUpperCase();
+}
+
+function getGradient(name: string): [string, string] {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return AVATAR_GRADIENTS[Math.abs(hash) % AVATAR_GRADIENTS.length];
+}
+
+interface GradientAvatarProps {
+  name: string;
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function GradientAvatar({ name, size = 26, className = '', style }: GradientAvatarProps) {
+  const initials = getInitials(name);
+  const [from, to] = getGradient(name);
+  const fontSize = Math.max(8, Math.round(size * 0.35));
+
+  return (
+    <div
+      className={className}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: `linear-gradient(135deg, ${from}, ${to})`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize,
+        fontWeight: 500,
+        color: 'white',
+        flexShrink: 0,
+        ...style,
+      }}
+      title={name}
+    >
+      {initials}
+    </div>
+  );
+}

--- a/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
+++ b/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
@@ -1,0 +1,513 @@
+/**
+ * ProjectOverviewCards — three styled cards for the Overview tab.
+ *
+ * Card 1: Project header (gradient background)
+ * Card 2: Project team + Documents (side by side)
+ * Card 3: Immediate actions (needsAttention + nextActions)
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle,
+  Clock,
+  FileText,
+  FolderPlus,
+  Link2,
+  Pencil,
+  Shield,
+  Upload,
+  UserPlus,
+  Users,
+} from 'lucide-react';
+import { api } from '@/lib/api';
+import { listWorkspaceMembers, type WorkspaceMember } from '@/features/workspaces/workspace.api';
+import { projectsApi, type ProjectDetail } from '../projects.api';
+import {
+  overviewActionItemKey,
+  type NeedsAttentionItem,
+  type ProjectOverview,
+} from '../model/projectOverview';
+import { GradientAvatar } from '@/components/ui/GradientAvatar';
+
+/* ── Types ──────────────────────────────────────────────────── */
+
+interface ProjectDoc {
+  id: string;
+  title: string;
+  updatedAt?: string;
+}
+
+interface ProjectOverviewCardsProps {
+  project: ProjectDetail;
+  workspaceId: string;
+  overview: ProjectOverview | null;
+  canEdit: boolean;
+}
+
+/* ── Helpers ────────────────────────────────────────────────── */
+
+function memberName(m: WorkspaceMember): string {
+  if (m.name) return m.name;
+  if (m.user?.firstName || m.user?.lastName)
+    return `${m.user.firstName ?? ''} ${m.user.lastName ?? ''}`.trim();
+  return m.user?.email || m.email || 'Unknown';
+}
+
+const DOC_ICON_GRADIENTS: [string, string][] = [
+  ['#FAC775', '#EF9F27'],
+  ['#85B7EB', '#378ADD'],
+  ['#AFA9EC', '#7F77DD'],
+];
+
+/* ── Component ──────────────────────────────────────────────── */
+
+export function ProjectOverviewCards({
+  project,
+  workspaceId,
+  overview,
+  canEdit,
+}: ProjectOverviewCardsProps) {
+  const navigate = useNavigate();
+
+  // Data state
+  const [teamMembers, setTeamMembers] = useState<WorkspaceMember[]>([]);
+  const [pmMember, setPmMember] = useState<WorkspaceMember | null>(null);
+  const [docs, setDocs] = useState<ProjectDoc[]>([]);
+  const [teamLoading, setTeamLoading] = useState(true);
+  const [docsLoading, setDocsLoading] = useState(true);
+
+  // Fetch team + workspace members
+  useEffect(() => {
+    if (!project.id || !workspaceId) return;
+    let cancelled = false;
+    setTeamLoading(true);
+
+    Promise.allSettled([
+      projectsApi.getProjectTeam(project.id),
+      listWorkspaceMembers(workspaceId),
+    ]).then(([teamResult, membersResult]) => {
+      if (cancelled) return;
+      if (teamResult.status === 'fulfilled' && membersResult.status === 'fulfilled') {
+        const teamIds = new Set(teamResult.value.teamMemberIds || []);
+        const pmId = overview?.deliveryOwnerUserId ?? teamResult.value.projectManagerId ?? null;
+        const allMembers = membersResult.value || [];
+
+        const pm = pmId
+          ? allMembers.find((m) => m.userId === pmId || m.user?.id === pmId) ?? null
+          : null;
+        setPmMember(pm);
+
+        const filtered = allMembers.filter(
+          (m) => teamIds.has(m.userId || '') || teamIds.has(m.user?.id || ''),
+        );
+        setTeamMembers(filtered);
+      }
+      setTeamLoading(false);
+    });
+
+    return () => { cancelled = true; };
+  }, [project.id, workspaceId, overview?.deliveryOwnerUserId]);
+
+  // Fetch documents
+  useEffect(() => {
+    if (!project.id || !workspaceId) return;
+    let cancelled = false;
+    setDocsLoading(true);
+
+    api
+      .get(`/work/workspaces/${workspaceId}/projects/${project.id}/documents`)
+      .then((res: any) => {
+        if (cancelled) return;
+        const data = res?.data ?? res;
+        const items = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : [];
+        setDocs(items.map((d: any) => ({ id: d.id, title: d.title, updatedAt: d.updatedAt })));
+      })
+      .catch(() => { if (!cancelled) setDocs([]); })
+      .finally(() => { if (!cancelled) setDocsLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [project.id, workspaceId]);
+
+  // Immediate actions
+  const immediateItems = useMemo(() => {
+    if (!overview) return [];
+    const seen = new Set<string>();
+    const out: NeedsAttentionItem[] = [];
+    for (const item of [...overview.needsAttention, ...overview.nextActions]) {
+      const key = overviewActionItemKey(item);
+      if (!seen.has(key)) { seen.add(key); out.push(item); }
+    }
+    return out.slice(0, 5);
+  }, [overview]);
+
+  const attentionKeys = useMemo(() => {
+    if (!overview) return new Set<string>();
+    return new Set(overview.needsAttention.map(overviewActionItemKey));
+  }, [overview]);
+
+  return (
+    <div className="space-y-4">
+      {/* ── Card 1: Project Header ── */}
+      <div
+        className="relative overflow-hidden rounded-xl p-6"
+        style={{
+          background: 'linear-gradient(135deg, #EEEDFE 0%, #E6F1FB 100%)',
+          border: '0.5px solid #CECBF6',
+        }}
+      >
+        {/* Decorative circles */}
+        <div
+          className="pointer-events-none absolute"
+          style={{
+            width: 120, height: 120, borderRadius: '50%',
+            background: 'rgba(127,119,221,0.08)',
+            top: -20, right: -10,
+          }}
+        />
+        <div
+          className="pointer-events-none absolute"
+          style={{
+            width: 80, height: 80, borderRadius: '50%',
+            background: 'rgba(55,138,221,0.06)',
+            bottom: -15, right: 60,
+          }}
+        />
+
+        <div className="relative flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <h2
+              className="truncate"
+              style={{ fontSize: 22, fontWeight: 500, color: '#26215C' }}
+            >
+              {project.name}
+            </h2>
+            {project.description?.trim() ? (
+              <p
+                className="mt-2 line-clamp-3"
+                style={{ fontSize: 14, color: '#534AB7', opacity: 0.8, lineHeight: 1.6 }}
+              >
+                {project.description}
+              </p>
+            ) : (
+              <p
+                className="mt-2 italic"
+                style={{ fontSize: 14, color: '#534AB7', opacity: 0.5 }}
+              >
+                Add a project description...
+              </p>
+            )}
+          </div>
+
+          {canEdit && (
+            <button
+              type="button"
+              className="shrink-0 flex items-center justify-center"
+              style={{
+                width: 30, height: 30, borderRadius: '50%',
+                background: 'rgba(255,255,255,0.7)',
+              }}
+              title="Edit project"
+            >
+              <Pencil style={{ width: 14, height: 14, color: '#534AB7' }} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Card 2: Team + Documents (side by side) ── */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Left: Project Team */}
+        <div
+          className="rounded-xl bg-white overflow-hidden"
+          style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #1D9E75' }}
+        >
+          <div className="flex items-center justify-between px-5 py-3.5">
+            <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Project team</h3>
+            {canEdit && (
+              <button
+                type="button"
+                className="flex items-center gap-1 rounded-lg px-2.5 py-1"
+                style={{ fontSize: 12, color: '#0F6E56', background: '#E1F5EE' }}
+              >
+                <Users style={{ width: 12, height: 12 }} />
+                Manage
+              </button>
+            )}
+          </div>
+
+          <div className="space-y-2 px-5 pb-4">
+            {teamLoading ? (
+              <p className="text-xs text-slate-400 py-4 text-center">Loading team...</p>
+            ) : (
+              <>
+                {/* Project Lead / PM */}
+                <div
+                  className="flex items-center gap-3 rounded-xl p-3"
+                  style={{
+                    background: pmMember
+                      ? 'linear-gradient(135deg, #E6F1FB, #EEEDFE)'
+                      : undefined,
+                    border: pmMember ? 'none' : '0.5px solid #e2e8f0',
+                  }}
+                >
+                  <div
+                    className="flex items-center justify-center"
+                    style={{
+                      width: 38, height: 38, borderRadius: 10,
+                      background: 'linear-gradient(135deg, #1D9E75, #5DCAA5)',
+                    }}
+                  >
+                    <Shield style={{ width: 18, height: 18, color: 'white' }} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Project Lead</p>
+                    <p style={{ fontSize: 11, color: '#64748b' }}>
+                      {pmMember ? memberName(pmMember) : 'Not assigned'}
+                    </p>
+                  </div>
+                  {pmMember ? (
+                    <GradientAvatar name={memberName(pmMember)} size={20} />
+                  ) : canEdit ? (
+                    <button
+                      type="button"
+                      className="flex items-center gap-1 rounded-lg px-2 py-1"
+                      style={{ fontSize: 11, color: '#0F6E56', background: '#E1F5EE' }}
+                    >
+                      + Assign
+                    </button>
+                  ) : null}
+                </div>
+
+                {/* Team members */}
+                <div
+                  className="flex items-center gap-3 rounded-xl p-3"
+                  style={{ border: '0.5px solid #e2e8f0' }}
+                >
+                  <div
+                    className="flex items-center justify-center"
+                    style={{
+                      width: 38, height: 38, borderRadius: 10,
+                      background: 'linear-gradient(135deg, #EF9F27, #D85A30)',
+                    }}
+                  >
+                    <UserPlus style={{ width: 18, height: 18, color: 'white' }} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Team</p>
+                    {teamMembers.length > 0 ? (
+                      <div className="mt-1 flex items-center gap-2">
+                        <div className="flex">
+                          {teamMembers.slice(0, 4).map((m, i) => (
+                            <GradientAvatar
+                              key={m.userId || m.user?.id || i}
+                              name={memberName(m)}
+                              size={26}
+                              style={{
+                                border: '2px solid white',
+                                marginRight: i < Math.min(teamMembers.length, 4) - 1 ? -8 : 0,
+                              }}
+                            />
+                          ))}
+                          {teamMembers.length > 4 && (
+                            <div
+                              className="flex items-center justify-center"
+                              style={{
+                                width: 26, height: 26, borderRadius: '50%',
+                                background: '#f1f5f9', border: '2px solid white',
+                                fontSize: 10, fontWeight: 500, color: '#64748b', marginLeft: -8,
+                              }}
+                            >
+                              +{teamMembers.length - 4}
+                            </div>
+                          )}
+                        </div>
+                        <span style={{ fontSize: 11, color: '#64748b' }}>
+                          {teamMembers.length} {teamMembers.length === 1 ? 'person' : 'people'}
+                        </span>
+                      </div>
+                    ) : (
+                      <p style={{ fontSize: 11, color: '#94a3b8' }}>No team members yet</p>
+                    )}
+                  </div>
+                  {canEdit && (
+                    <button
+                      type="button"
+                      className="flex items-center gap-1 rounded-lg px-2 py-1"
+                      style={{ fontSize: 11, color: '#854F0B', background: '#FAEEDA' }}
+                    >
+                      + Add
+                    </button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Right: Documents */}
+        <div
+          className="rounded-xl bg-white overflow-hidden"
+          style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #534AB7' }}
+        >
+          <div className="flex items-center justify-between px-5 py-3.5">
+            <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Documents</h3>
+            {canEdit && (
+              <div className="flex items-center gap-1.5">
+                {[
+                  { icon: FolderPlus, label: 'New folder' },
+                  { icon: Upload, label: 'Upload' },
+                  { icon: Link2, label: 'Link' },
+                ].map(({ icon: Icon, label }) => (
+                  <button
+                    key={label}
+                    type="button"
+                    className="flex items-center justify-center"
+                    style={{
+                      width: 30, height: 30, borderRadius: 8,
+                      background: '#EEEDFE',
+                    }}
+                    title={label}
+                  >
+                    <Icon style={{ width: 14, height: 14, color: '#534AB7' }} />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="px-5 pb-4">
+            {docsLoading ? (
+              <p className="text-xs text-slate-400 py-4 text-center">Loading documents...</p>
+            ) : docs.length === 0 ? (
+              <p className="text-center py-6" style={{ fontSize: 13, color: '#94a3b8' }}>
+                No documents linked yet.
+              </p>
+            ) : (
+              <div className="space-y-1">
+                {docs.slice(0, 5).map((doc, i) => {
+                  const [g1, g2] = DOC_ICON_GRADIENTS[i % DOC_ICON_GRADIENTS.length];
+                  return (
+                    <div
+                      key={doc.id}
+                      className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-slate-50"
+                    >
+                      <div
+                        className="flex items-center justify-center shrink-0"
+                        style={{
+                          width: 36, height: 36, borderRadius: 10,
+                          background: `linear-gradient(135deg, ${g1}, ${g2})`,
+                        }}
+                      >
+                        <FileText style={{ width: 16, height: 16, color: 'white' }} />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }} className="truncate">
+                          {doc.title}
+                        </p>
+                        {doc.updatedAt && (
+                          <p style={{ fontSize: 11, color: '#94a3b8' }}>
+                            Updated {new Date(doc.updatedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+                {docs.length > 5 && (
+                  <div
+                    className="flex items-center justify-center py-2 mt-1"
+                    style={{ borderTop: '0.5px dashed #cbd5e1' }}
+                  >
+                    <span style={{ fontSize: 12, color: '#185FA5', cursor: 'pointer' }}>
+                      View all documents
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Card 3: Immediate Actions ── */}
+      <div
+        className="rounded-xl bg-white overflow-hidden"
+        style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #378ADD' }}
+      >
+        <div className="flex items-center justify-between px-5 py-3.5">
+          <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Immediate actions</h3>
+          <button
+            type="button"
+            onClick={() => navigate(`/projects/${project.id}/tasks`)}
+            className="flex items-center gap-1"
+            style={{ fontSize: 12, color: '#185FA5' }}
+          >
+            View all in Activities
+            <ArrowRight style={{ width: 12, height: 12 }} />
+          </button>
+        </div>
+
+        <div className="px-5 pb-4">
+          {immediateItems.length === 0 ? (
+            <div className="flex items-center gap-3 py-4 justify-center">
+              <div
+                className="flex items-center justify-center"
+                style={{
+                  width: 30, height: 30, borderRadius: '50%',
+                  background: 'linear-gradient(135deg, #C0DD97, #97C459)',
+                }}
+              >
+                <CheckCircle style={{ width: 16, height: 16, color: 'white' }} />
+              </div>
+              <p style={{ fontSize: 13, color: '#64748b' }}>
+                All caught up! No immediate actions.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {immediateItems.map((item, idx) => {
+                const isUrgent = attentionKeys.has(overviewActionItemKey(item));
+                return (
+                  <div
+                    key={item.entityRef?.taskId ?? idx}
+                    className="flex items-start gap-3 rounded-lg p-3"
+                    style={{ background: isUrgent ? '#FAEEDA' : '#f8fafc' }}
+                  >
+                    <div
+                      className="flex items-center justify-center shrink-0 mt-0.5"
+                      style={{
+                        width: 30, height: 30, borderRadius: '50%',
+                        background: isUrgent
+                          ? 'linear-gradient(135deg, #EF9F27, #D85A30)'
+                          : 'linear-gradient(135deg, #85B7EB, #378ADD)',
+                      }}
+                    >
+                      {isUrgent ? (
+                        <AlertTriangle style={{ width: 14, height: 14, color: 'white' }} />
+                      ) : (
+                        <Clock style={{ width: 14, height: 14, color: 'white' }} />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>
+                        {item.reasonText}
+                      </p>
+                      <p style={{ fontSize: 11, color: '#64748b' }} className="mt-0.5">
+                        {item.nextStepLabel}
+                        {item.dueDate && (
+                          <> &middot; Due {new Date(item.dueDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</>
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
+++ b/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
@@ -5,18 +5,17 @@
  * Card 2: Project team + Documents (side by side)
  * Card 3: Immediate actions (needsAttention + nextActions)
  */
-import { useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   AlertTriangle,
   ArrowRight,
   CheckCircle,
-  Clock,
   FileText,
   FolderPlus,
   Link2,
   Pencil,
-  Shield,
+  Settings,
   Upload,
   UserPlus,
   Users,
@@ -60,6 +59,23 @@ const DOC_ICON_GRADIENTS: [string, string][] = [
   ['#85B7EB', '#378ADD'],
   ['#AFA9EC', '#7F77DD'],
 ];
+
+const DOC_HOVER_TINTS = ['#FAEEDA', '#E6F1FB', '#EEEDFE'];
+
+/** Document row with family-specific hover tint. */
+function DocRow({ hoverTint, children }: { hoverTint: string; children: ReactNode }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors"
+      style={{ background: hovered ? hoverTint : undefined }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {children}
+    </div>
+  );
+}
 
 /* ── Component ──────────────────────────────────────────────── */
 
@@ -109,6 +125,13 @@ export function ProjectOverviewCards({
 
     return () => { cancelled = true; };
   }, [project.id, workspaceId, overview?.deliveryOwnerUserId]);
+
+  // Exclude PM from the team avatar stack to avoid duplication with Project Lead row.
+  const nonPmMembers = useMemo(() => {
+    const pmId = pmMember?.userId || pmMember?.user?.id;
+    if (!pmId) return teamMembers;
+    return teamMembers.filter((m) => (m.userId || m.user?.id) !== pmId);
+  }, [teamMembers, pmMember]);
 
   // Fetch documents
   useEffect(() => {
@@ -231,7 +254,7 @@ export function ProjectOverviewCards({
                 className="flex items-center gap-1 rounded-lg px-2.5 py-1"
                 style={{ fontSize: 12, color: '#0F6E56', background: '#E1F5EE' }}
               >
-                <Users style={{ width: 12, height: 12 }} />
+                <Settings style={{ width: 12, height: 12 }} />
                 Manage
               </button>
             )}
@@ -259,7 +282,7 @@ export function ProjectOverviewCards({
                       background: 'linear-gradient(135deg, #1D9E75, #5DCAA5)',
                     }}
                   >
-                    <Shield style={{ width: 18, height: 18, color: 'white' }} />
+                    <Users style={{ width: 18, height: 18, color: 'white' }} />
                   </div>
                   <div className="min-w-0 flex-1">
                     <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Project Lead</p>
@@ -296,21 +319,21 @@ export function ProjectOverviewCards({
                   </div>
                   <div className="min-w-0 flex-1">
                     <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Team</p>
-                    {teamMembers.length > 0 ? (
+                    {nonPmMembers.length > 0 ? (
                       <div className="mt-1 flex items-center gap-2">
                         <div className="flex">
-                          {teamMembers.slice(0, 4).map((m, i) => (
+                          {nonPmMembers.slice(0, 4).map((m, i) => (
                             <GradientAvatar
                               key={m.userId || m.user?.id || i}
                               name={memberName(m)}
                               size={26}
                               style={{
                                 border: '2px solid white',
-                                marginRight: i < Math.min(teamMembers.length, 4) - 1 ? -8 : 0,
+                                marginRight: i < Math.min(nonPmMembers.length, 4) - 1 ? -8 : 0,
                               }}
                             />
                           ))}
-                          {teamMembers.length > 4 && (
+                          {nonPmMembers.length > 4 && (
                             <div
                               className="flex items-center justify-center"
                               style={{
@@ -319,12 +342,15 @@ export function ProjectOverviewCards({
                                 fontSize: 10, fontWeight: 500, color: '#64748b', marginLeft: -8,
                               }}
                             >
-                              +{teamMembers.length - 4}
+                              +{nonPmMembers.length - 4}
                             </div>
                           )}
                         </div>
                         <span style={{ fontSize: 11, color: '#64748b' }}>
-                          {teamMembers.length} {teamMembers.length === 1 ? 'person' : 'people'}
+                          {nonPmMembers.length} {nonPmMembers.length === 1 ? 'person' : 'people'}
+                        </span>
+                        <span style={{ fontSize: 11, color: '#0F6E56', cursor: 'pointer' }}>
+                          View all
                         </span>
                       </div>
                     ) : (
@@ -388,11 +414,9 @@ export function ProjectOverviewCards({
               <div className="space-y-1">
                 {docs.slice(0, 5).map((doc, i) => {
                   const [g1, g2] = DOC_ICON_GRADIENTS[i % DOC_ICON_GRADIENTS.length];
+                  const hoverTint = DOC_HOVER_TINTS[i % DOC_HOVER_TINTS.length];
                   return (
-                    <div
-                      key={doc.id}
-                      className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-slate-50"
-                    >
+                    <DocRow key={doc.id} hoverTint={hoverTint}>
                       <div
                         className="flex items-center justify-center shrink-0"
                         style={{
@@ -412,13 +436,13 @@ export function ProjectOverviewCards({
                           </p>
                         )}
                       </div>
-                    </div>
+                    </DocRow>
                   );
                 })}
                 {docs.length > 5 && (
                   <div
                     className="flex items-center justify-center py-2 mt-1"
-                    style={{ borderTop: '0.5px dashed #cbd5e1' }}
+                    style={{ borderBottom: '0.5px dashed #cbd5e1' }}
                   >
                     <span style={{ fontSize: 12, color: '#185FA5', cursor: 'pointer' }}>
                       View all documents
@@ -487,7 +511,7 @@ export function ProjectOverviewCards({
                       {isUrgent ? (
                         <AlertTriangle style={{ width: 14, height: 14, color: 'white' }} />
                       ) : (
-                        <Clock style={{ width: 14, height: 14, color: 'white' }} />
+                        <ArrowRight style={{ width: 14, height: 14, color: 'white' }} />
                       )}
                     </div>
                     <div className="min-w-0 flex-1">

--- a/zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx
+++ b/zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx
@@ -207,24 +207,7 @@ export const ProjectPageLayout: React.FC = () => {
     // project's workspaceId; depending on activeWorkspaceId would double-fetch.
   }, [projectId]);
 
-  // Phase 5B.1 — Waterfall projects must land on the Tasks tab, not Overview.
-  // Only redirects once per project load, only when the current URL is the
-  // bare /projects/:id (no sub-path), so manual navigation back to Overview
-  // is not hijacked.
-  const waterfallLandingRedirected = useRef<string | null>(null);
-  useEffect(() => {
-    if (!project || !projectId) return;
-    if (waterfallLandingRedirected.current === projectId) return;
-    const isWaterfall = (project.methodology || '').toLowerCase() === 'waterfall';
-    if (!isWaterfall) return;
-    const path = location.pathname.replace(/\/+$/, '');
-    if (path === `/projects/${projectId}`) {
-      waterfallLandingRedirected.current = projectId;
-      navigate(`/projects/${projectId}/tasks`, { replace: true });
-    } else {
-      waterfallLandingRedirected.current = projectId;
-    }
-  }, [project, projectId, location.pathname, navigate]);
+  // Waterfall redirect removed — all projects land on Overview first.
 
   // Handle tab navigation
   const handleTabClick = (tab: typeof PROJECT_TABS[number]) => {

--- a/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
@@ -8,15 +8,13 @@
  * Health panel + cost/advanced metrics + program/portfolio remain below.
  */
 
-import React, { useMemo, useState, useEffect } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Play, AlertCircle, CheckCircle } from 'lucide-react';
-import { api } from '@/lib/api';
+import React, { useMemo } from 'react';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { AlertCircle, CheckCircle } from 'lucide-react';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { useWorkspaceRole } from '@/hooks/useWorkspaceRole';
 import { useProjectContext } from '../layout/ProjectPageLayout';
 import { EmptyState } from '@/components/ui/feedback/EmptyState';
-import { getApiErrorMessage } from '@/utils/apiErrorMessage';
 import { ProjectLinkingSection } from '../components/ProjectLinkingSection';
 import { ProjectKpiPanel } from '../components/ProjectKpiPanel';
 import { BudgetSummaryPanel } from '../components/BudgetSummaryPanel';
@@ -24,6 +22,7 @@ import { BaselinePanel } from '../components/BaselinePanel';
 import { EarnedValuePanel } from '../components/EarnedValuePanel';
 import { ProjectOverviewCards } from '../components/ProjectOverviewCards';
 import type { ProjectOverview } from '../model/projectOverview';
+import { useEffect } from 'react';
 
 const healthConfig: Record<string, { bg: string; text: string; icon: typeof CheckCircle }> = {
   HEALTHY: { bg: 'bg-green-50', text: 'text-green-700', icon: CheckCircle },
@@ -47,9 +46,6 @@ export const ProjectOverviewTab: React.FC = () => {
   const effectiveWorkspaceId = project?.workspaceId ?? workspaceId ?? '';
   const capabilities = { baselinesEnabled: false, earnedValueEnabled: false };
 
-  const [startWorkError, setStartWorkError] = useState<string | null>(null);
-  const [startingWork, setStartingWork] = useState(false);
-
   const overview: ProjectOverview | null = overviewSnapshot;
 
   useEffect(() => {
@@ -58,27 +54,6 @@ export const ProjectOverviewTab: React.FC = () => {
       navigate(`/projects/${projectId}/tasks?taskId=${taskId}`, { replace: true });
     }
   }, [projectId, searchParams, navigate]);
-
-  const handleStartWork = async () => {
-    if (!projectId || !effectiveWorkspaceId) return;
-    setStartingWork(true);
-    setStartWorkError(null);
-    try {
-      await api.post(
-        `/work/projects/${projectId}/start`,
-        {},
-        { headers: { 'x-workspace-id': effectiveWorkspaceId } },
-      );
-      await refreshOverviewSnapshot();
-      await refreshProject();
-    } catch (err: any) {
-      const errorCode = err?.response?.data?.code;
-      const errorMessage = err?.response?.data?.message;
-      setStartWorkError(getApiErrorMessage({ code: errorCode, message: errorMessage }));
-    } finally {
-      setStartingWork(false);
-    }
-  };
 
   const showHealthPanel = useMemo(() => {
     if (!overview) return false;
@@ -130,27 +105,6 @@ export const ProjectOverviewTab: React.FC = () => {
           overview={overview}
           canEdit={canWrite}
         />
-      )}
-
-      {/* Start Work button (DRAFT only) */}
-      {overview.projectState === 'DRAFT' && canWrite && (
-        <div className="flex flex-wrap items-center gap-3">
-          <button
-            type="button"
-            onClick={handleStartWork}
-            disabled={startingWork}
-            className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <Play className="h-4 w-4" />
-            {startingWork ? 'Starting...' : 'Start Work'}
-          </button>
-        </div>
-      )}
-
-      {startWorkError && (
-        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
-          <p className="text-sm text-yellow-800">{startWorkError}</p>
-        </div>
       )}
 
       {/* Health panel */}

--- a/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
@@ -1,14 +1,16 @@
 /**
- * ProjectOverviewTab — Phase 5A.6
+ * ProjectOverviewTab — redesigned with three colored cards.
  *
- * Overview is a focused launch surface: template essentials, quick actions,
- * compact immediate actions, then optional health. Heavy modules are collapsed.
- * Overview data comes from ProjectContext (fetched in ProjectPageLayout).
+ * Card 1: Project header (gradient)
+ * Card 2: Team + Documents (side by side)
+ * Card 3: Immediate actions
+ *
+ * Health panel + cost/advanced metrics + program/portfolio remain below.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Play, AlertCircle, CheckCircle, Clock } from 'lucide-react';
+import { Play, AlertCircle, CheckCircle } from 'lucide-react';
 import { api } from '@/lib/api';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { useWorkspaceRole } from '@/hooks/useWorkspaceRole';
@@ -20,12 +22,9 @@ import { ProjectKpiPanel } from '../components/ProjectKpiPanel';
 import { BudgetSummaryPanel } from '../components/BudgetSummaryPanel';
 import { BaselinePanel } from '../components/BaselinePanel';
 import { EarnedValuePanel } from '../components/EarnedValuePanel';
-import { ProjectMetadataCard } from '../components/ProjectMetadataCard';
-import {
-  overviewActionItemKey,
-  type NeedsAttentionItem,
-  type ProjectOverview,
-} from '../model/projectOverview';
+import { ProjectOverviewCards } from '../components/ProjectOverviewCards';
+import type { ProjectOverview } from '../model/projectOverview';
+
 const healthConfig: Record<string, { bg: string; text: string; icon: typeof CheckCircle }> = {
   HEALTHY: { bg: 'bg-green-50', text: 'text-green-700', icon: CheckCircle },
   AT_RISK: { bg: 'bg-yellow-50', text: 'text-yellow-700', icon: AlertCircle },
@@ -62,17 +61,13 @@ export const ProjectOverviewTab: React.FC = () => {
 
   const handleStartWork = async () => {
     if (!projectId || !effectiveWorkspaceId) return;
-
     setStartingWork(true);
     setStartWorkError(null);
-
     try {
       await api.post(
         `/work/projects/${projectId}/start`,
         {},
-        {
-          headers: { 'x-workspace-id': effectiveWorkspaceId },
-        },
+        { headers: { 'x-workspace-id': effectiveWorkspaceId } },
       );
       await refreshOverviewSnapshot();
       await refreshProject();
@@ -84,29 +79,6 @@ export const ProjectOverviewTab: React.FC = () => {
       setStartingWork(false);
     }
   };
-
-  const handleOpenPlan = () => {
-    navigate(`/projects/${projectId}/plan`);
-  };
-
-  const immediateActionItems = useMemo(() => {
-    if (!overview) return [];
-    const seen = new Set<string>();
-    const out: NeedsAttentionItem[] = [];
-    const ordered = [...overview.needsAttention, ...overview.nextActions];
-    for (const item of ordered) {
-      const key = overviewActionItemKey(item);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(item);
-    }
-    return out;
-  }, [overview]);
-
-  const attentionKeys = useMemo(() => {
-    if (!overview) return new Set<string>();
-    return new Set(overview.needsAttention.map(overviewActionItemKey));
-  }, [overview]);
 
   const showHealthPanel = useMemo(() => {
     if (!overview) return false;
@@ -143,37 +115,26 @@ export const ProjectOverviewTab: React.FC = () => {
     );
   }
 
-  if (!overview) {
-    return null;
-  }
+  if (!overview) return null;
 
   const healthStyle = healthConfig[overview.healthCode] || healthConfig.HEALTHY;
   const HealthIcon = healthStyle.icon;
-  const topActions = immediateActionItems.slice(0, 5);
 
   return (
     <div className="space-y-6">
+      {/* Three styled cards */}
       {project && effectiveWorkspaceId && (
-        <ProjectMetadataCard
+        <ProjectOverviewCards
           project={project}
           workspaceId={effectiveWorkspaceId}
-          deliveryOwnerUserId={overview.deliveryOwnerUserId}
+          overview={overview}
           canEdit={canWrite}
-          structureLocked={overview.structureLocked}
-          projectState={overview.projectState}
         />
       )}
 
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
-          onClick={handleOpenPlan}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 transition-colors"
-        >
-          Open Plan
-        </button>
-
-        {overview.projectState === 'DRAFT' && canWrite && (
+      {/* Start Work button (DRAFT only) */}
+      {overview.projectState === 'DRAFT' && canWrite && (
+        <div className="flex flex-wrap items-center gap-3">
           <button
             type="button"
             onClick={handleStartWork}
@@ -183,8 +144,8 @@ export const ProjectOverviewTab: React.FC = () => {
             <Play className="h-4 w-4" />
             {startingWork ? 'Starting...' : 'Start Work'}
           </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {startWorkError && (
         <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
@@ -192,52 +153,7 @@ export const ProjectOverviewTab: React.FC = () => {
         </div>
       )}
 
-      {topActions.length > 0 && (
-        <div
-          className="bg-white rounded-lg border border-slate-200 p-4"
-          data-testid="project-overview-immediate-actions"
-        >
-          <div className="flex items-center justify-between gap-2 mb-3">
-            <h3 className="text-sm font-semibold text-slate-900">Immediate actions</h3>
-            <button
-              type="button"
-              onClick={() => navigate(`/projects/${projectId}/tasks`)}
-              className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
-            >
-              All in Activities →
-            </button>
-          </div>
-          <ul className="space-y-2">
-            {topActions.map((item, index) => {
-              const urgent = attentionKeys.has(overviewActionItemKey(item));
-              return (
-                <li
-                  key={`${item.entityRef?.taskId ?? index}`}
-                  className={`flex items-start gap-2 p-2.5 rounded-md border text-sm ${
-                    urgent ? 'bg-amber-50 border-amber-100' : 'bg-slate-50 border-slate-100'
-                  }`}
-                >
-                  {urgent ? (
-                    <AlertCircle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
-                  ) : (
-                    <Clock className="h-4 w-4 text-slate-500 shrink-0 mt-0.5" />
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <p className="font-medium text-slate-900">{item.reasonText}</p>
-                    <p className="text-xs text-slate-500 mt-0.5">{item.nextStepLabel}</p>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-          {immediateActionItems.length > 5 && (
-            <p className="text-xs text-slate-500 mt-2">
-              +{immediateActionItems.length - 5} more — open Activities for the full list.
-            </p>
-          )}
-        </div>
-      )}
-
+      {/* Health panel */}
       {showHealthPanel && (
         <div className={`rounded-lg border p-4 ${healthStyle.bg}`}>
           <div className="flex items-center gap-3">
@@ -254,6 +170,7 @@ export const ProjectOverviewTab: React.FC = () => {
         </div>
       )}
 
+      {/* Cost & advanced metrics */}
       <details className="rounded-lg border border-slate-200 bg-white group">
         <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-slate-700 hover:bg-slate-50 rounded-lg [&::-webkit-details-marker]:hidden flex items-center justify-between">
           <span>Cost &amp; advanced metrics</span>
@@ -282,6 +199,7 @@ export const ProjectOverviewTab: React.FC = () => {
         </div>
       </details>
 
+      {/* Program & portfolio */}
       {project && (
         <details className="rounded-lg border border-dashed border-slate-200 bg-slate-50/50">
           <summary className="cursor-pointer list-none px-4 py-3 text-xs font-medium uppercase tracking-wide text-slate-500 hover:bg-slate-100/80 rounded-lg [&::-webkit-details-marker]:hidden">


### PR DESCRIPTION
## Summary
Replaces ProjectMetadataCard with three modern colored cards matching the approved design mockup.

**Card 1 — Project header:** Purple-to-blue pastel gradient with decorative circles, project name, description, edit pencil.

**Card 2 — Team + Documents (side by side):**
- Team: teal top border, gradient role icons (rounded-square), PM card with gradient fill when assigned, team avatar stack with overlap
- Documents: purple top border, gradient folder icons cycling amber/blue/purple, linked doc list

**Card 3 — Immediate actions:** Blue top border, combines `needsAttention` + `nextActions` from overview API. Amber gradient circles for urgent, blue for next actions. Green check empty state.

**New:** `GradientAvatar` component with 6 brand gradient pairs (deterministic by name).

**Removed:** Waterfall auto-redirect from Overview to Tasks — all projects now land on Overview.

## Test plan
- [ ] Open Waterfall project → lands on Overview (not redirected to Tasks)
- [ ] Card 1: gradient background, project name, description or placeholder
- [ ] Card 2 left: PM shown if assigned, team avatar stack with overlap
- [ ] Card 2 right: documents listed with gradient folder icons, or empty state
- [ ] Card 3: immediate actions shown, or green "All caught up!" empty state
- [ ] Health panel shows below cards when AT_RISK or BLOCKED
- [ ] Cost & advanced metrics collapsible section works
- [ ] Mobile: team + docs cards stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)