### PR TITLE
feat(projects): overview v2 + waterfall UX — inline create, bulk bar, task row menu

### DIFF
--- a/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
+++ b/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
@@ -1,28 +1,32 @@
 /**
- * ProjectOverviewCards — three styled cards for the Overview tab.
+ * ProjectOverviewCards — Overview tab content cards.
  *
- * Card 1: Project header (gradient background)
- * Card 2: Project team + Documents (side by side)
- * Card 3: Immediate actions (needsAttention + nextActions)
+ * 1. Project Team (full width)
+ * 2. To Do + Immediate Actions (side by side)
+ * 3. Documents (full width, bottom)
  */
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import React, { type ReactNode, useEffect, useMemo, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   AlertTriangle,
   ArrowRight,
   CheckCircle,
+  Circle,
   FileText,
   FolderPlus,
   Link2,
-  Pencil,
+  Loader2,
   Settings,
+  Shield,
   Upload,
   UserPlus,
   Users,
 } from 'lucide-react';
 import { api } from '@/lib/api';
+import { useAuth } from '@/state/AuthContext';
 import { listWorkspaceMembers, type WorkspaceMember } from '@/features/workspaces/workspace.api';
 import { projectsApi, type ProjectDetail } from '../projects.api';
+// listTasks/updateTask will be used when To Do gets backend persistence
 import {
   overviewActionItemKey,
   type NeedsAttentionItem,
@@ -62,7 +66,6 @@ const DOC_ICON_GRADIENTS: [string, string][] = [
 
 const DOC_HOVER_TINTS = ['#FAEEDA', '#E6F1FB', '#EEEDFE'];
 
-/** Document row with family-specific hover tint. */
 function DocRow({ hoverTint, children }: { hoverTint: string; children: ReactNode }) {
   const [hovered, setHovered] = useState(false);
   return (
@@ -77,6 +80,195 @@ function DocRow({ hoverTint, children }: { hoverTint: string; children: ReactNod
   );
 }
 
+function isThisWeek(dateStr: string | null | undefined): boolean {
+  if (!dateStr) return false;
+  const d = new Date(dateStr);
+  const now = new Date();
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() - now.getDay());
+  startOfWeek.setHours(0, 0, 0, 0);
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(startOfWeek.getDate() + 7);
+  return d >= startOfWeek && d < endOfWeek;
+}
+
+function formatShortDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return '';
+  try {
+    return new Date(dateStr).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch { return ''; }
+}
+
+/* ── To Do Category Colors ─────────────────────────────────── */
+
+const TODO_CATEGORIES = [
+  { id: 'action', label: 'Action', color: '#6366f1' },
+  { id: 'review', label: 'Review', color: '#3b82f6' },
+  { id: 'followup', label: 'Follow-up', color: '#f59e0b' },
+  { id: 'blocker', label: 'Blocker', color: '#ef4444' },
+] as const;
+
+type TodoCategory = typeof TODO_CATEGORIES[number]['id'];
+
+interface TodoItem {
+  id: string;
+  text: string;
+  done: boolean;
+  category: TodoCategory;
+  author: string;
+}
+
+let todoCounter = 0;
+
+/* ── ToDoCard ──────────────────────────────────────────────── */
+
+function ToDoCard({ canEdit, userName }: { canEdit: boolean; userName: string }) {
+  const [items, setItems] = useState<TodoItem[]>([]);
+  const [draft, setDraft] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<TodoCategory>('action');
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const addItem = () => {
+    const text = draft.trim();
+    if (!text) return;
+    setItems((prev) => [
+      ...prev,
+      { id: `todo-${++todoCounter}`, text, done: false, category: selectedCategory, author: userName },
+    ]);
+    setDraft('');
+    inputRef.current?.focus();
+  };
+
+  const toggleItem = (id: string) => {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, done: !it.done } : it)));
+  };
+
+  const removeItem = (id: string) => {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+  };
+
+  const catColor = (cat: TodoCategory) => TODO_CATEGORIES.find((c) => c.id === cat)?.color ?? '#6366f1';
+
+  return (
+    <div
+      className="rounded-xl bg-white overflow-hidden flex flex-col"
+      style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #6366f1' }}
+    >
+      <div className="flex items-center justify-between px-5 py-3.5">
+        <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>To Do</h3>
+        <span style={{ fontSize: 12, color: '#94a3b8' }}>
+          {items.filter((i) => !i.done).length} remaining
+        </span>
+      </div>
+
+      <div className="px-5 pb-4 flex-1">
+        {/* Add input */}
+        {canEdit && (
+          <div className="flex items-center gap-2 mb-3">
+            <div className="flex-1 flex items-center rounded-xl border border-slate-200 bg-slate-50 overflow-hidden">
+              {/* Category selector */}
+              <select
+                value={selectedCategory}
+                onChange={(e) => setSelectedCategory(e.target.value as TodoCategory)}
+                className="bg-transparent border-none text-xs font-medium px-2.5 py-2.5 outline-none"
+                style={{ color: catColor(selectedCategory), width: 90 }}
+              >
+                {TODO_CATEGORIES.map((c) => (
+                  <option key={c.id} value={c.id}>{c.label}</option>
+                ))}
+              </select>
+              <input
+                ref={inputRef}
+                type="text"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') addItem(); }}
+                placeholder="Add a to-do item..."
+                className="flex-1 bg-transparent border-none outline-none text-sm text-slate-700 py-2.5 pr-2"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={addItem}
+              disabled={!draft.trim()}
+              className="shrink-0 flex items-center justify-center rounded-xl disabled:opacity-30 transition-opacity"
+              style={{ width: 36, height: 36, background: '#6366f1' }}
+            >
+              <span className="text-white text-lg font-light leading-none">+</span>
+            </button>
+          </div>
+        )}
+
+        {/* Items */}
+        {items.length === 0 ? (
+          <div className="flex items-center gap-3 py-6 justify-center">
+            <div className="flex items-center justify-center" style={{ width: 30, height: 30, borderRadius: '50%', background: 'linear-gradient(135deg, #C0DD97, #97C459)' }}>
+              <CheckCircle style={{ width: 16, height: 16, color: 'white' }} />
+            </div>
+            <p style={{ fontSize: 13, color: '#64748b' }}>No to-do items yet. Add one above.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.map((item) => {
+              const color = catColor(item.category);
+              const catLabel = TODO_CATEGORIES.find((c) => c.id === item.category)?.label ?? '';
+              return (
+                <div
+                  key={item.id}
+                  className="flex items-start gap-3 rounded-xl p-3 transition-colors group"
+                  style={{
+                    borderLeft: `3px solid ${color}`,
+                    background: item.done ? '#f8fafc' : `${color}08`,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleItem(item.id)}
+                    className="shrink-0 mt-0.5 transition-colors"
+                    title={item.done ? 'Mark incomplete' : 'Mark complete'}
+                  >
+                    {item.done ? (
+                      <div className="flex items-center justify-center" style={{ width: 20, height: 20, borderRadius: '50%', background: color }}>
+                        <CheckCircle style={{ width: 14, height: 14, color: 'white' }} />
+                      </div>
+                    ) : (
+                      <Circle style={{ width: 20, height: 20, color: '#cbd5e1' }} />
+                    )}
+                  </button>
+                  <div className="min-w-0 flex-1">
+                    <p style={{ fontSize: 11, fontWeight: 600, color, textTransform: 'capitalize' }}>{catLabel}</p>
+                    <p
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 500,
+                        color: item.done ? '#94a3b8' : '#1e293b',
+                        textDecoration: item.done ? 'line-through' : 'none',
+                      }}
+                    >
+                      {item.text}
+                    </p>
+                    <p style={{ fontSize: 11, color: '#94a3b8' }}>{item.author}</p>
+                  </div>
+                  {canEdit && (
+                    <button
+                      type="button"
+                      onClick={() => removeItem(item.id)}
+                      className="shrink-0 opacity-0 group-hover:opacity-100 text-slate-300 hover:text-red-400 transition-all"
+                      title="Remove"
+                    >
+                      <span style={{ fontSize: 16, lineHeight: 1 }}>&times;</span>
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /* ── Component ──────────────────────────────────────────────── */
 
 export function ProjectOverviewCards({
@@ -86,13 +278,17 @@ export function ProjectOverviewCards({
   canEdit,
 }: ProjectOverviewCardsProps) {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
-  // Data state
+  // Team state
   const [teamMembers, setTeamMembers] = useState<WorkspaceMember[]>([]);
   const [pmMember, setPmMember] = useState<WorkspaceMember | null>(null);
-  const [docs, setDocs] = useState<ProjectDoc[]>([]);
   const [teamLoading, setTeamLoading] = useState(true);
+
+  // Docs state
+  const [docs, setDocs] = useState<ProjectDoc[]>([]);
   const [docsLoading, setDocsLoading] = useState(true);
+
 
   // Fetch team + workspace members
   useEffect(() => {
@@ -109,24 +305,14 @@ export function ProjectOverviewCards({
         const teamIds = new Set(teamResult.value.teamMemberIds || []);
         const pmId = overview?.deliveryOwnerUserId ?? teamResult.value.projectManagerId ?? null;
         const allMembers = membersResult.value || [];
-
-        const pm = pmId
-          ? allMembers.find((m) => m.userId === pmId || m.user?.id === pmId) ?? null
-          : null;
-        setPmMember(pm);
-
-        const filtered = allMembers.filter(
-          (m) => teamIds.has(m.userId || '') || teamIds.has(m.user?.id || ''),
-        );
-        setTeamMembers(filtered);
+        setPmMember(pmId ? allMembers.find((m) => m.userId === pmId || m.user?.id === pmId) ?? null : null);
+        setTeamMembers(allMembers.filter((m) => teamIds.has(m.userId || '') || teamIds.has(m.user?.id || '')));
       }
       setTeamLoading(false);
     });
-
     return () => { cancelled = true; };
   }, [project.id, workspaceId, overview?.deliveryOwnerUserId]);
 
-  // Exclude PM from the team avatar stack to avoid duplication with Project Lead row.
   const nonPmMembers = useMemo(() => {
     const pmId = pmMember?.userId || pmMember?.user?.id;
     if (!pmId) return teamMembers;
@@ -138,9 +324,7 @@ export function ProjectOverviewCards({
     if (!project.id || !workspaceId) return;
     let cancelled = false;
     setDocsLoading(true);
-
-    api
-      .get(`/work/workspaces/${workspaceId}/projects/${project.id}/documents`)
+    api.get(`/work/workspaces/${workspaceId}/projects/${project.id}/documents`)
       .then((res: any) => {
         if (cancelled) return;
         const data = res?.data ?? res;
@@ -149,11 +333,11 @@ export function ProjectOverviewCards({
       })
       .catch(() => { if (!cancelled) setDocs([]); })
       .finally(() => { if (!cancelled) setDocsLoading(false); });
-
     return () => { cancelled = true; };
   }, [project.id, workspaceId]);
 
-  // Immediate actions
+
+  // Immediate actions — filter to due this week
   const immediateItems = useMemo(() => {
     if (!overview) return [];
     const seen = new Set<string>();
@@ -172,362 +356,239 @@ export function ProjectOverviewCards({
 
   return (
     <div className="space-y-4">
-      {/* ── Card 1: Project Header ── */}
+      {/* ── Project Team (full width) ── */}
       <div
-        className="relative overflow-hidden rounded-xl p-6"
-        style={{
-          background: 'linear-gradient(135deg, #EEEDFE 0%, #E6F1FB 100%)',
-          border: '0.5px solid #CECBF6',
-        }}
+        className="rounded-xl bg-white overflow-hidden"
+        style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #1D9E75' }}
       >
-        {/* Decorative circles */}
-        <div
-          className="pointer-events-none absolute"
-          style={{
-            width: 120, height: 120, borderRadius: '50%',
-            background: 'rgba(127,119,221,0.08)',
-            top: -20, right: -10,
-          }}
-        />
-        <div
-          className="pointer-events-none absolute"
-          style={{
-            width: 80, height: 80, borderRadius: '50%',
-            background: 'rgba(55,138,221,0.06)',
-            bottom: -15, right: 60,
-          }}
-        />
-
-        <div className="relative flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1">
-            <h2
-              className="truncate"
-              style={{ fontSize: 22, fontWeight: 500, color: '#26215C' }}
-            >
-              {project.name}
-            </h2>
-            {project.description?.trim() ? (
-              <p
-                className="mt-2 line-clamp-3"
-                style={{ fontSize: 14, color: '#534AB7', opacity: 0.8, lineHeight: 1.6 }}
-              >
-                {project.description}
-              </p>
-            ) : (
-              <p
-                className="mt-2 italic"
-                style={{ fontSize: 14, color: '#534AB7', opacity: 0.5 }}
-              >
-                Add a project description...
-              </p>
-            )}
-          </div>
-
+        <div className="flex items-center justify-between px-5 py-3.5">
+          <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Project team</h3>
           {canEdit && (
             <button
               type="button"
-              className="shrink-0 flex items-center justify-center"
-              style={{
-                width: 30, height: 30, borderRadius: '50%',
-                background: 'rgba(255,255,255,0.7)',
-              }}
-              title="Edit project"
+              className="flex items-center gap-1 rounded-lg px-2.5 py-1"
+              style={{ fontSize: 12, color: '#0F6E56', background: '#E1F5EE' }}
             >
-              <Pencil style={{ width: 14, height: 14, color: '#534AB7' }} />
+              <Settings style={{ width: 12, height: 12 }} />
+              Manage
             </button>
+          )}
+        </div>
+
+        <div className="space-y-2 px-5 pb-4">
+          {teamLoading ? (
+            <p className="text-xs text-slate-400 py-4 text-center">Loading team...</p>
+          ) : (
+            <>
+              {/* Project Lead */}
+              <div
+                className="flex items-center gap-3 rounded-xl p-3"
+                style={{
+                  background: pmMember ? 'linear-gradient(135deg, #E6F1FB, #EEEDFE)' : undefined,
+                  border: pmMember ? 'none' : '0.5px solid #e2e8f0',
+                }}
+              >
+                <div className="flex items-center justify-center" style={{ width: 38, height: 38, borderRadius: 10, background: 'linear-gradient(135deg, #1D9E75, #5DCAA5)' }}>
+                  <Users style={{ width: 18, height: 18, color: 'white' }} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Project Lead</p>
+                  <p style={{ fontSize: 11, color: '#64748b' }}>{pmMember ? memberName(pmMember) : 'Not assigned'}</p>
+                </div>
+                {pmMember ? (
+                  <GradientAvatar name={memberName(pmMember)} size={20} />
+                ) : canEdit ? (
+                  <button type="button" className="flex items-center gap-1 rounded-lg px-2 py-1" style={{ fontSize: 11, color: '#0F6E56', background: '#E1F5EE' }}>+ Assign</button>
+                ) : null}
+              </div>
+
+              {/* Business Lead */}
+              <div className="flex items-center gap-3 rounded-xl p-3" style={{ border: '0.5px solid #e2e8f0' }}>
+                <div className="flex items-center justify-center" style={{ width: 38, height: 38, borderRadius: 10, background: 'linear-gradient(135deg, #378ADD, #7F77DD)' }}>
+                  <Shield style={{ width: 18, height: 18, color: 'white' }} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Business Lead</p>
+                  <p style={{ fontSize: 11, color: '#94a3b8' }}>Not assigned</p>
+                </div>
+                {canEdit && (
+                  <button type="button" className="flex items-center gap-1 rounded-lg px-2 py-1" style={{ fontSize: 11, color: '#0F6E56', background: '#E1F5EE' }}>+ Assign</button>
+                )}
+              </div>
+
+              {/* Team members */}
+              <div className="flex items-center gap-3 rounded-xl p-3" style={{ border: '0.5px solid #e2e8f0' }}>
+                <div className="flex items-center justify-center" style={{ width: 38, height: 38, borderRadius: 10, background: 'linear-gradient(135deg, #EF9F27, #D85A30)' }}>
+                  <UserPlus style={{ width: 18, height: 18, color: 'white' }} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Team</p>
+                  {nonPmMembers.length > 0 ? (
+                    <div className="mt-1 flex items-center gap-2">
+                      <div className="flex">
+                        {nonPmMembers.slice(0, 4).map((m, i) => (
+                          <GradientAvatar
+                            key={m.userId || m.user?.id || i}
+                            name={memberName(m)}
+                            size={26}
+                            style={{ border: '2px solid white', marginRight: i < Math.min(nonPmMembers.length, 4) - 1 ? -8 : 0 }}
+                          />
+                        ))}
+                        {nonPmMembers.length > 4 && (
+                          <div className="flex items-center justify-center" style={{ width: 26, height: 26, borderRadius: '50%', background: '#f1f5f9', border: '2px solid white', fontSize: 10, fontWeight: 500, color: '#64748b', marginLeft: -8 }}>
+                            +{nonPmMembers.length - 4}
+                          </div>
+                        )}
+                      </div>
+                      <span style={{ fontSize: 11, color: '#64748b' }}>{nonPmMembers.length} {nonPmMembers.length === 1 ? 'person' : 'people'}</span>
+                      <span style={{ fontSize: 11, color: '#0F6E56', cursor: 'pointer' }}>View all</span>
+                    </div>
+                  ) : (
+                    <p style={{ fontSize: 11, color: '#94a3b8' }}>No team members yet</p>
+                  )}
+                </div>
+                {canEdit && (
+                  <button type="button" className="flex items-center gap-1 rounded-lg px-2 py-1" style={{ fontSize: 11, color: '#854F0B', background: '#FAEEDA' }}>+ Add</button>
+                )}
+              </div>
+            </>
           )}
         </div>
       </div>
 
-      {/* ── Card 2: Team + Documents (side by side) ── */}
+      {/* ── To Do + Immediate Actions (side by side) ── */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        {/* Left: Project Team */}
+        {/* Left: To Do — manual checklist managed by PM */}
+        <ToDoCard canEdit={canEdit} userName={user?.firstName || user?.email?.split('@')[0] || 'You'} />
+
+        {/* Right: Immediate Actions */}
         <div
           className="rounded-xl bg-white overflow-hidden"
-          style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #1D9E75' }}
+          style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #378ADD' }}
         >
           <div className="flex items-center justify-between px-5 py-3.5">
-            <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Project team</h3>
-            {canEdit && (
-              <button
-                type="button"
-                className="flex items-center gap-1 rounded-lg px-2.5 py-1"
-                style={{ fontSize: 12, color: '#0F6E56', background: '#E1F5EE' }}
-              >
-                <Settings style={{ width: 12, height: 12 }} />
-                Manage
-              </button>
-            )}
-          </div>
-
-          <div className="space-y-2 px-5 pb-4">
-            {teamLoading ? (
-              <p className="text-xs text-slate-400 py-4 text-center">Loading team...</p>
-            ) : (
-              <>
-                {/* Project Lead / PM */}
-                <div
-                  className="flex items-center gap-3 rounded-xl p-3"
-                  style={{
-                    background: pmMember
-                      ? 'linear-gradient(135deg, #E6F1FB, #EEEDFE)'
-                      : undefined,
-                    border: pmMember ? 'none' : '0.5px solid #e2e8f0',
-                  }}
-                >
-                  <div
-                    className="flex items-center justify-center"
-                    style={{
-                      width: 38, height: 38, borderRadius: 10,
-                      background: 'linear-gradient(135deg, #1D9E75, #5DCAA5)',
-                    }}
-                  >
-                    <Users style={{ width: 18, height: 18, color: 'white' }} />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Project Lead</p>
-                    <p style={{ fontSize: 11, color: '#64748b' }}>
-                      {pmMember ? memberName(pmMember) : 'Not assigned'}
-                    </p>
-                  </div>
-                  {pmMember ? (
-                    <GradientAvatar name={memberName(pmMember)} size={20} />
-                  ) : canEdit ? (
-                    <button
-                      type="button"
-                      className="flex items-center gap-1 rounded-lg px-2 py-1"
-                      style={{ fontSize: 11, color: '#0F6E56', background: '#E1F5EE' }}
-                    >
-                      + Assign
-                    </button>
-                  ) : null}
-                </div>
-
-                {/* Team members */}
-                <div
-                  className="flex items-center gap-3 rounded-xl p-3"
-                  style={{ border: '0.5px solid #e2e8f0' }}
-                >
-                  <div
-                    className="flex items-center justify-center"
-                    style={{
-                      width: 38, height: 38, borderRadius: 10,
-                      background: 'linear-gradient(135deg, #EF9F27, #D85A30)',
-                    }}
-                  >
-                    <UserPlus style={{ width: 18, height: 18, color: 'white' }} />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Team</p>
-                    {nonPmMembers.length > 0 ? (
-                      <div className="mt-1 flex items-center gap-2">
-                        <div className="flex">
-                          {nonPmMembers.slice(0, 4).map((m, i) => (
-                            <GradientAvatar
-                              key={m.userId || m.user?.id || i}
-                              name={memberName(m)}
-                              size={26}
-                              style={{
-                                border: '2px solid white',
-                                marginRight: i < Math.min(nonPmMembers.length, 4) - 1 ? -8 : 0,
-                              }}
-                            />
-                          ))}
-                          {nonPmMembers.length > 4 && (
-                            <div
-                              className="flex items-center justify-center"
-                              style={{
-                                width: 26, height: 26, borderRadius: '50%',
-                                background: '#f1f5f9', border: '2px solid white',
-                                fontSize: 10, fontWeight: 500, color: '#64748b', marginLeft: -8,
-                              }}
-                            >
-                              +{nonPmMembers.length - 4}
-                            </div>
-                          )}
-                        </div>
-                        <span style={{ fontSize: 11, color: '#64748b' }}>
-                          {nonPmMembers.length} {nonPmMembers.length === 1 ? 'person' : 'people'}
-                        </span>
-                        <span style={{ fontSize: 11, color: '#0F6E56', cursor: 'pointer' }}>
-                          View all
-                        </span>
-                      </div>
-                    ) : (
-                      <p style={{ fontSize: 11, color: '#94a3b8' }}>No team members yet</p>
-                    )}
-                  </div>
-                  {canEdit && (
-                    <button
-                      type="button"
-                      className="flex items-center gap-1 rounded-lg px-2 py-1"
-                      style={{ fontSize: 11, color: '#854F0B', background: '#FAEEDA' }}
-                    >
-                      + Add
-                    </button>
-                  )}
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Right: Documents */}
-        <div
-          className="rounded-xl bg-white overflow-hidden"
-          style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #534AB7' }}
-        >
-          <div className="flex items-center justify-between px-5 py-3.5">
-            <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Documents</h3>
-            {canEdit && (
-              <div className="flex items-center gap-1.5">
-                {[
-                  { icon: FolderPlus, label: 'New folder' },
-                  { icon: Upload, label: 'Upload' },
-                  { icon: Link2, label: 'Link' },
-                ].map(({ icon: Icon, label }) => (
-                  <button
-                    key={label}
-                    type="button"
-                    className="flex items-center justify-center"
-                    style={{
-                      width: 30, height: 30, borderRadius: 8,
-                      background: '#EEEDFE',
-                    }}
-                    title={label}
-                  >
-                    <Icon style={{ width: 14, height: 14, color: '#534AB7' }} />
-                  </button>
-                ))}
-              </div>
-            )}
+            <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Immediate actions</h3>
+            <button
+              type="button"
+              onClick={() => navigate(`/projects/${project.id}/tasks`)}
+              className="flex items-center gap-1"
+              style={{ fontSize: 12, color: '#185FA5' }}
+            >
+              View all
+              <ArrowRight style={{ width: 12, height: 12 }} />
+            </button>
           </div>
 
           <div className="px-5 pb-4">
-            {docsLoading ? (
-              <p className="text-xs text-slate-400 py-4 text-center">Loading documents...</p>
-            ) : docs.length === 0 ? (
-              <p className="text-center py-6" style={{ fontSize: 13, color: '#94a3b8' }}>
-                No documents linked yet.
-              </p>
+            {immediateItems.length === 0 ? (
+              <div className="flex items-center gap-3 py-6 justify-center">
+                <div className="flex items-center justify-center" style={{ width: 30, height: 30, borderRadius: '50%', background: 'linear-gradient(135deg, #C0DD97, #97C459)' }}>
+                  <CheckCircle style={{ width: 16, height: 16, color: 'white' }} />
+                </div>
+                <p style={{ fontSize: 13, color: '#64748b' }}>All caught up! No immediate actions.</p>
+              </div>
             ) : (
-              <div className="space-y-1">
-                {docs.slice(0, 5).map((doc, i) => {
-                  const [g1, g2] = DOC_ICON_GRADIENTS[i % DOC_ICON_GRADIENTS.length];
-                  const hoverTint = DOC_HOVER_TINTS[i % DOC_HOVER_TINTS.length];
+              <div className="space-y-2">
+                {immediateItems.map((item, idx) => {
+                  const isUrgent = attentionKeys.has(overviewActionItemKey(item));
                   return (
-                    <DocRow key={doc.id} hoverTint={hoverTint}>
+                    <div
+                      key={item.entityRef?.taskId ?? idx}
+                      className="flex items-start gap-3 rounded-lg p-3"
+                      style={{ background: isUrgent ? '#FAEEDA' : '#f8fafc' }}
+                    >
                       <div
-                        className="flex items-center justify-center shrink-0"
+                        className="flex items-center justify-center shrink-0 mt-0.5"
                         style={{
-                          width: 36, height: 36, borderRadius: 10,
-                          background: `linear-gradient(135deg, ${g1}, ${g2})`,
+                          width: 30, height: 30, borderRadius: '50%',
+                          background: isUrgent
+                            ? 'linear-gradient(135deg, #EF9F27, #D85A30)'
+                            : 'linear-gradient(135deg, #85B7EB, #378ADD)',
                         }}
                       >
-                        <FileText style={{ width: 16, height: 16, color: 'white' }} />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }} className="truncate">
-                          {doc.title}
-                        </p>
-                        {doc.updatedAt && (
-                          <p style={{ fontSize: 11, color: '#94a3b8' }}>
-                            Updated {new Date(doc.updatedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
-                          </p>
+                        {isUrgent ? (
+                          <AlertTriangle style={{ width: 14, height: 14, color: 'white' }} />
+                        ) : (
+                          <ArrowRight style={{ width: 14, height: 14, color: 'white' }} />
                         )}
                       </div>
-                    </DocRow>
+                      <div className="min-w-0 flex-1">
+                        <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>{item.reasonText}</p>
+                        <p style={{ fontSize: 11, color: '#64748b' }} className="mt-0.5">
+                          {item.nextStepLabel}
+                          {item.dueDate && <> &middot; Due {formatShortDate(item.dueDate)}</>}
+                        </p>
+                      </div>
+                    </div>
                   );
                 })}
-                {docs.length > 5 && (
-                  <div
-                    className="flex items-center justify-center py-2 mt-1"
-                    style={{ borderBottom: '0.5px dashed #cbd5e1' }}
-                  >
-                    <span style={{ fontSize: 12, color: '#185FA5', cursor: 'pointer' }}>
-                      View all documents
-                    </span>
-                  </div>
-                )}
               </div>
             )}
           </div>
         </div>
       </div>
 
-      {/* ── Card 3: Immediate Actions ── */}
+      {/* ── Documents (full width, bottom) ── */}
       <div
         className="rounded-xl bg-white overflow-hidden"
-        style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #378ADD' }}
+        style={{ border: '0.5px solid #e2e8f0', borderTop: '3px solid #534AB7' }}
       >
         <div className="flex items-center justify-between px-5 py-3.5">
-          <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Immediate actions</h3>
-          <button
-            type="button"
-            onClick={() => navigate(`/projects/${project.id}/tasks`)}
-            className="flex items-center gap-1"
-            style={{ fontSize: 12, color: '#185FA5' }}
-          >
-            View all in Activities
-            <ArrowRight style={{ width: 12, height: 12 }} />
-          </button>
+          <h3 style={{ fontSize: 15, fontWeight: 500, color: '#1e293b' }}>Documents</h3>
+          {canEdit && (
+            <div className="flex items-center gap-1.5">
+              {[
+                { icon: FolderPlus, label: 'New folder' },
+                { icon: Upload, label: 'Upload' },
+                { icon: Link2, label: 'Link' },
+              ].map(({ icon: Icon, label }) => (
+                <button
+                  key={label}
+                  type="button"
+                  className="flex items-center justify-center"
+                  style={{ width: 30, height: 30, borderRadius: 8, background: '#EEEDFE' }}
+                  title={label}
+                >
+                  <Icon style={{ width: 14, height: 14, color: '#534AB7' }} />
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="px-5 pb-4">
-          {immediateItems.length === 0 ? (
-            <div className="flex items-center gap-3 py-4 justify-center">
-              <div
-                className="flex items-center justify-center"
-                style={{
-                  width: 30, height: 30, borderRadius: '50%',
-                  background: 'linear-gradient(135deg, #C0DD97, #97C459)',
-                }}
-              >
-                <CheckCircle style={{ width: 16, height: 16, color: 'white' }} />
-              </div>
-              <p style={{ fontSize: 13, color: '#64748b' }}>
-                All caught up! No immediate actions.
-              </p>
+          {docsLoading ? (
+            <p className="text-xs text-slate-400 py-4 text-center">Loading documents...</p>
+          ) : docs.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 gap-2 rounded-xl" style={{ background: '#fafafa', border: '1px dashed #e2e8f0' }}>
+              <FileText style={{ width: 32, height: 32, color: '#cbd5e1' }} />
+              <p style={{ fontSize: 13, fontWeight: 500, color: '#64748b' }}>No documents linked yet</p>
+              <p style={{ fontSize: 12, color: '#94a3b8' }}>Upload files or add links to get started</p>
             </div>
           ) : (
-            <div className="space-y-2">
-              {immediateItems.map((item, idx) => {
-                const isUrgent = attentionKeys.has(overviewActionItemKey(item));
+            <div className="space-y-1">
+              {docs.slice(0, 5).map((doc, i) => {
+                const [g1, g2] = DOC_ICON_GRADIENTS[i % DOC_ICON_GRADIENTS.length];
+                const hoverTint = DOC_HOVER_TINTS[i % DOC_HOVER_TINTS.length];
                 return (
-                  <div
-                    key={item.entityRef?.taskId ?? idx}
-                    className="flex items-start gap-3 rounded-lg p-3"
-                    style={{ background: isUrgent ? '#FAEEDA' : '#f8fafc' }}
-                  >
-                    <div
-                      className="flex items-center justify-center shrink-0 mt-0.5"
-                      style={{
-                        width: 30, height: 30, borderRadius: '50%',
-                        background: isUrgent
-                          ? 'linear-gradient(135deg, #EF9F27, #D85A30)'
-                          : 'linear-gradient(135deg, #85B7EB, #378ADD)',
-                      }}
-                    >
-                      {isUrgent ? (
-                        <AlertTriangle style={{ width: 14, height: 14, color: 'white' }} />
-                      ) : (
-                        <ArrowRight style={{ width: 14, height: 14, color: 'white' }} />
-                      )}
+                  <DocRow key={doc.id} hoverTint={hoverTint}>
+                    <div className="flex items-center justify-center shrink-0" style={{ width: 36, height: 36, borderRadius: 10, background: `linear-gradient(135deg, ${g1}, ${g2})` }}>
+                      <FileText style={{ width: 16, height: 16, color: 'white' }} />
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>
-                        {item.reasonText}
-                      </p>
-                      <p style={{ fontSize: 11, color: '#64748b' }} className="mt-0.5">
-                        {item.nextStepLabel}
-                        {item.dueDate && (
-                          <> &middot; Due {new Date(item.dueDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</>
-                        )}
-                      </p>
+                      <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }} className="truncate">{doc.title}</p>
+                      {doc.updatedAt && (
+                        <p style={{ fontSize: 11, color: '#94a3b8' }}>Updated {formatShortDate(doc.updatedAt)}</p>
+                      )}
                     </div>
-                  </div>
+                  </DocRow>
                 );
               })}
+              {docs.length > 5 && (
+                <div className="flex items-center justify-center py-2 mt-1" style={{ borderBottom: '0.5px dashed #cbd5e1' }}>
+                  <span style={{ fontSize: 12, color: '#185FA5', cursor: 'pointer' }}>View all documents</span>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx
+++ b/zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx
@@ -9,7 +9,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Outlet, useParams, useNavigate, useLocation, Link } from 'react-router-dom';
+import { Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
 import { Folder, LayoutDashboard, ListTodo, AlertTriangle, Users, LayoutGrid, Table2, BarChart3, GitPullRequest, FileText, DollarSign, Activity } from 'lucide-react';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { getWorkspace } from '@/features/workspaces/api';
@@ -18,7 +18,7 @@ import { projectsApi, type ProjectDetail } from '../projects.api';
 import { EmptyState } from '@/components/ui/feedback/EmptyState';
 import { SaveAsTemplateModal } from '../components/SaveAsTemplateModal';
 import { DuplicateProjectModal } from '../components/DuplicateProjectModal';
-import { ProjectIdentityFrame } from '../components/ProjectIdentityFrame';
+// ProjectIdentityFrame removed — project name + description now in persistent header
 import { api } from '@/lib/api';
 import {
   normalizeProjectOverview,
@@ -292,72 +292,16 @@ export const ProjectPageLayout: React.FC = () => {
       }}
     >
       <div className="min-h-full bg-slate-50">
-        {/* Header with breadcrumbs */}
         <div className="bg-white border-b border-slate-200">
           <div className="container mx-auto px-4 py-4">
-            {/* Breadcrumbs — workspace is parent when project carries workspaceId */}
-            <nav className="mb-2" aria-label="Breadcrumb">
-              {project.workspaceId ? (
-                <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs list-none m-0 p-0 text-slate-500">
-                  <li className="min-w-0">
-                    <Link
-                      to={`/workspaces/${project.workspaceId}/home`}
-                      className="hover:text-indigo-600 truncate max-w-[240px] inline-block align-bottom"
-                    >
-                      {workspaceDisplayName ?? 'Unknown workspace'}
-                    </Link>
-                  </li>
-                  <li className="text-slate-300 select-none" aria-hidden>
-                    /
-                  </li>
-                  <li
-                    className="text-slate-600 font-medium truncate max-w-[min(100%,320px)]"
-                    aria-current="page"
-                  >
-                    {project.name}
-                  </li>
-                </ol>
-              ) : (
-                <span className="text-slate-600 font-medium truncate max-w-[320px] text-xs">
-                  {project.name}
-                </span>
-              )}
-            </nav>
-
-            {/*
-             * Phase 2 (2026-04-08): identity frame renders ONLY on the Overview
-             * tab. Operator complaint: "what is showing is Overview its
-             * appearing top of Activities dont need that here looks bad."
-             * The big metadata block (workspace badge, project name h1,
-             * methodology pill, lifecycle pill, status pill, PM/Team/Start/
-             * Target 4-cell grid, structure help text) was rendering on every
-             * tab, eating screen space above the work surface. Now scoped to
-             * Overview only. Breadcrumb (above), status badge + project menu
-             * (right), and tab rail (below) all remain visible on every tab —
-             * matches ClickUp's pattern of minimal header + tabs always,
-             * tab-specific content below. On non-Overview tabs we still render
-             * a thin project name h1 so the page has a heading for screen
-             * readers and visual anchoring.
-             */}
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-              {project.workspaceId && activeTab === 'overview' ? (
-                <ProjectIdentityFrame
-                  workspaceDisplayName={workspaceDisplayName}
-                  workspaceId={project.workspaceId}
-                  project={project}
-                  overview={overviewSnapshot}
-                />
-              ) : (
-                <div className="min-w-0 flex-1">
-                  <h1 className="text-2xl font-bold text-slate-900 truncate">{project.name}</h1>
-                  {project.description && activeTab === 'overview' && (
-                    <p className="mt-1 text-sm text-slate-500 line-clamp-2">{project.description}</p>
-                  )}
-                </div>
-              )}
-
-              {/* Project actions (save-as-template, duplicate) moved to toolbar ... menu */}
-            </div>
+            {/* Persistent project header — visible on all tabs, editable */}
+            <EditableProjectHeader
+              project={project}
+              onSave={async (patch) => {
+                await projectsApi.updateProjectSettings(project.id, patch);
+                await loadProject();
+              }}
+            />
 
             {project && (
               <>
@@ -415,5 +359,119 @@ export const ProjectPageLayout: React.FC = () => {
     </ProjectContext.Provider>
   );
 };
+
+/* ── Editable Project Header ─────────────────────────────────── */
+
+function EditableProjectHeader({
+  project,
+  onSave,
+}: {
+  project: ProjectDetail;
+  onSave: (patch: { name?: string; description?: string }) => Promise<void>;
+}) {
+  const [editingName, setEditingName] = useState(false);
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [nameVal, setNameVal] = useState(project.name);
+  const [descVal, setDescVal] = useState(project.description || '');
+  const [saving, setSaving] = useState(false);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const descRef = useRef<HTMLTextAreaElement>(null);
+
+  // Sync if project changes externally
+  useEffect(() => { setNameVal(project.name); }, [project.name]);
+  useEffect(() => { setDescVal(project.description || ''); }, [project.description]);
+
+  const saveName = async () => {
+    const trimmed = nameVal.trim();
+    if (!trimmed || trimmed === project.name) { setEditingName(false); setNameVal(project.name); return; }
+    setSaving(true);
+    try { await onSave({ name: trimmed }); } catch { setNameVal(project.name); }
+    finally { setSaving(false); setEditingName(false); }
+  };
+
+  const saveDesc = async () => {
+    const trimmed = descVal.trim();
+    if (trimmed === (project.description || '')) { setEditingDesc(false); return; }
+    setSaving(true);
+    try { await onSave({ description: trimmed || undefined }); } catch { setDescVal(project.description || ''); }
+    finally { setSaving(false); setEditingDesc(false); }
+  };
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-xl p-6 mb-4"
+      style={{
+        background: 'linear-gradient(135deg, #EEEDFE 0%, #E6F1FB 100%)',
+        border: '0.5px solid #CECBF6',
+      }}
+    >
+      <div
+        className="pointer-events-none absolute"
+        style={{ width: 120, height: 120, borderRadius: '50%', background: 'rgba(127,119,221,0.08)', top: -20, right: -10 }}
+      />
+      <div
+        className="pointer-events-none absolute"
+        style={{ width: 80, height: 80, borderRadius: '50%', background: 'rgba(55,138,221,0.06)', bottom: -15, right: 60 }}
+      />
+      <div className="relative">
+        {/* Editable project name */}
+        {editingName ? (
+          <input
+            ref={nameRef}
+            autoFocus
+            value={nameVal}
+            onChange={(e) => setNameVal(e.target.value)}
+            onBlur={saveName}
+            onKeyDown={(e) => { if (e.key === 'Enter') saveName(); if (e.key === 'Escape') { setNameVal(project.name); setEditingName(false); } }}
+            disabled={saving}
+            className="w-full text-2xl font-bold bg-white/60 rounded-lg px-2 py-1 outline-none focus:ring-2 focus:ring-indigo-300"
+            style={{ color: '#26215C' }}
+          />
+        ) : (
+          <h1
+            className="text-2xl font-bold truncate cursor-text hover:bg-white/30 rounded-lg px-2 py-1 -mx-2 transition-colors"
+            style={{ color: '#26215C' }}
+            onClick={() => setEditingName(true)}
+            title="Click to edit project name"
+          >
+            {project.name}
+          </h1>
+        )}
+
+        {/* Editable description */}
+        {editingDesc ? (
+          <textarea
+            ref={descRef}
+            autoFocus
+            value={descVal}
+            onChange={(e) => setDescVal(e.target.value)}
+            onBlur={saveDesc}
+            onKeyDown={(e) => { if (e.key === 'Escape') { setDescVal(project.description || ''); setEditingDesc(false); } }}
+            disabled={saving}
+            rows={3}
+            className="w-full mt-2 text-sm bg-white/60 rounded-lg px-2 py-1.5 outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
+            style={{ color: '#534AB7', lineHeight: 1.6 }}
+            placeholder="Add a project description..."
+          />
+        ) : (
+          <p
+            className="mt-2 cursor-text hover:bg-white/30 rounded-lg px-2 py-1 -mx-2 transition-colors"
+            style={{
+              fontSize: 14,
+              color: '#534AB7',
+              opacity: project.description?.trim() ? 0.8 : 0.5,
+              lineHeight: 1.6,
+              fontStyle: project.description?.trim() ? 'normal' : 'italic',
+            }}
+            onClick={() => setEditingDesc(true)}
+            title="Click to edit description"
+          >
+            {project.description?.trim() || 'Add a project description...'}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export default ProjectPageLayout;

--- a/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
@@ -1,28 +1,17 @@
 /**
- * ProjectOverviewTab — redesigned with three colored cards.
- *
- * Card 1: Project header (gradient)
- * Card 2: Team + Documents (side by side)
- * Card 3: Immediate actions
- *
- * Health panel + cost/advanced metrics + program/portfolio remain below.
+ * ProjectOverviewTab — three styled cards: team, documents, immediate actions.
+ * Project name + description are in the persistent header (ProjectPageLayout).
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { AlertCircle, CheckCircle } from 'lucide-react';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { useWorkspaceRole } from '@/hooks/useWorkspaceRole';
 import { useProjectContext } from '../layout/ProjectPageLayout';
 import { EmptyState } from '@/components/ui/feedback/EmptyState';
-import { ProjectLinkingSection } from '../components/ProjectLinkingSection';
-import { ProjectKpiPanel } from '../components/ProjectKpiPanel';
-import { BudgetSummaryPanel } from '../components/BudgetSummaryPanel';
-import { BaselinePanel } from '../components/BaselinePanel';
-import { EarnedValuePanel } from '../components/EarnedValuePanel';
 import { ProjectOverviewCards } from '../components/ProjectOverviewCards';
 import type { ProjectOverview } from '../model/projectOverview';
-import { useEffect } from 'react';
 
 const healthConfig: Record<string, { bg: string; text: string; icon: typeof CheckCircle }> = {
   HEALTHY: { bg: 'bg-green-50', text: 'text-green-700', icon: CheckCircle },
@@ -38,13 +27,11 @@ export const ProjectOverviewTab: React.FC = () => {
   const { canWrite } = useWorkspaceRole(workspaceId);
   const {
     project,
-    refresh: refreshProject,
     overviewSnapshot,
     overviewLoading,
     refreshOverviewSnapshot,
   } = useProjectContext();
   const effectiveWorkspaceId = project?.workspaceId ?? workspaceId ?? '';
-  const capabilities = { baselinesEnabled: false, earnedValueEnabled: false };
 
   const overview: ProjectOverview | null = overviewSnapshot;
 
@@ -124,50 +111,6 @@ export const ProjectOverviewTab: React.FC = () => {
         </div>
       )}
 
-      {/* Cost & advanced metrics */}
-      <details className="rounded-lg border border-slate-200 bg-white group">
-        <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-slate-700 hover:bg-slate-50 rounded-lg [&::-webkit-details-marker]:hidden flex items-center justify-between">
-          <span>Cost &amp; advanced metrics</span>
-          <span className="text-xs text-slate-400 group-open:hidden">Show</span>
-          <span className="text-xs text-slate-400 hidden group-open:inline">Hide</span>
-        </summary>
-        <div className="border-t border-slate-100 p-4 space-y-4">
-          {projectId && <BudgetSummaryPanel projectId={projectId} />}
-          {projectId && project && (
-            <BaselinePanel
-              projectId={projectId}
-              baselinesEnabled={capabilities.baselinesEnabled}
-              workspaceRole={(project as { workspaceRole?: string }).workspaceRole}
-            />
-          )}
-          {projectId && project && (
-            <EarnedValuePanel
-              projectId={projectId}
-              earnedValueEnabled={capabilities.earnedValueEnabled}
-              workspaceRole={(project as { workspaceRole?: string }).workspaceRole}
-            />
-          )}
-          {effectiveWorkspaceId && (
-            <ProjectKpiPanel projectId={projectId!} workspaceId={effectiveWorkspaceId} />
-          )}
-        </div>
-      </details>
-
-      {/* Program & portfolio */}
-      {project && (
-        <details className="rounded-lg border border-dashed border-slate-200 bg-slate-50/50">
-          <summary className="cursor-pointer list-none px-4 py-3 text-xs font-medium uppercase tracking-wide text-slate-500 hover:bg-slate-100/80 rounded-lg [&::-webkit-details-marker]:hidden">
-            Program &amp; portfolio (optional)
-          </summary>
-          <div className="border-t border-slate-200 p-4">
-            <ProjectLinkingSection
-              projectId={projectId!}
-              project={project}
-              onUpdated={refreshProject}
-            />
-          </div>
-        </details>
-      )}
     </div>
   );
 };

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -50,6 +50,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import {
   AlertCircle,
   Check,
@@ -1430,26 +1431,18 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
        * `depPanelTaskId` state, the open handler, and this render block
        * all come back together as one cohesive feature.
        */}
+      </div>
 
       {/*
        * Phase 7 — Task detail side panel.
-       * Renders only when `detailPanelTaskId` is set. The task itself is
-       * resolved on every render from the local `tasks` state, so any
-       * concurrent change (inline edit, bulk action, comment add, panel
-       * field edit) flows in without re-fetching. If the task is deleted
-       * while the panel is open (e.g. via bulk delete), the resolved task
-       * becomes undefined and the panel auto-closes via the conditional.
-       *
-       * The phaseName is resolved by walking phases for the task's
-       * phaseId. Subtasks are filtered by parentTaskId. Both lookups are
-       * O(N) but N is small (MVP-scale Waterfall).
+       * MUST live outside the horizontal scroll wrapper: `fixed` backdrop +
+       * panel inside `overflow-x-auto` clips / swallows interactions with
+       * the table in some layouts (Activities tab felt “empty” / unusable).
        */}
       {detailPanelTaskId &&
         (() => {
           const detailTask = tasks.find((t) => t.id === detailPanelTaskId);
           if (!detailTask) {
-            // Task was deleted/removed — auto-close on next render via state setter.
-            // Wrapped in a microtask so we don't call setState during render.
             queueMicrotask(closeDetailPanel);
             return null;
           }
@@ -1473,111 +1466,114 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
             />
           );
         })()}
-      </div>
 
       {/*
-       * Bulk action bar — fixed to viewport (outside overflow-x-auto) so it
-       * stays visible while scrolling the table. Same handlers as before.
+       * Bulk action bar — portaled to document.body so `fixed` is always
+       * viewport-relative (never clipped or re-rooted by a transformed /
+       * overflow ancestor). Same handlers as before.
        */}
-      {selectedTaskIds.size > 0 && (
-        <div
-          className="fixed bottom-6 left-1/2 z-50 flex max-w-[min(100vw-2rem,56rem)] -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-slate-700 bg-slate-900 px-4 py-2.5 text-white shadow-2xl"
-          data-testid="waterfall-bulk-action-bar"
-        >
-          <div className="flex shrink-0 items-center gap-2">
-            <span className="text-sm font-medium text-white">
-              {selectedTaskIds.size} selected
-            </span>
+      {typeof document !== 'undefined' &&
+        selectedTaskIds.size > 0 &&
+        createPortal(
+          <div
+            className="fixed bottom-6 left-1/2 z-[200] flex max-w-[min(100vw-2rem,56rem)] -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-slate-700 bg-slate-900 px-4 py-2.5 text-white shadow-2xl"
+            data-testid="waterfall-bulk-action-bar"
+          >
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-sm font-medium text-white">
+                {selectedTaskIds.size} selected
+              </span>
+              <button
+                type="button"
+                onClick={clearSelection}
+                disabled={bulkActionPending}
+                className="rounded p-1 text-slate-300 hover:bg-slate-800 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Clear selection"
+                data-testid="waterfall-bulk-clear"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <label className="inline-flex items-center gap-1.5">
+              <span className="sr-only">Set status</span>
+              <select
+                value=""
+                disabled={bulkActionPending}
+                onChange={(e) => {
+                  const v = e.target.value as WorkTaskStatus;
+                  if (!v) return;
+                  void handleBulkSetStatus(v);
+                  e.target.value = '';
+                }}
+                className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                data-testid="waterfall-bulk-status"
+                aria-label="Set status for selected tasks"
+              >
+                <option value="">Set status…</option>
+                {statusGroups.flatMap((group) =>
+                  group.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  )),
+                )}
+              </select>
+            </label>
+
+            <label className="inline-flex items-center gap-1.5">
+              <span className="sr-only">Set assignee</span>
+              <select
+                value=""
+                disabled={bulkActionPending}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  if (raw === '') return;
+                  const next = raw === '__none__' ? null : raw;
+                  void handleBulkSetAssignee(next);
+                  e.target.value = '';
+                }}
+                className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                data-testid="waterfall-bulk-assignee"
+                aria-label="Set assignee for selected tasks"
+              >
+                <option value="">Set assignee…</option>
+                <option value="__none__">Unassigned</option>
+                {members.map((m: any) => {
+                  const u = m.user ?? {};
+                  const id = m.userId ?? u.id ?? m.id;
+                  const full = [u.firstName, u.lastName]
+                    .filter(Boolean)
+                    .join(' ')
+                    .trim();
+                  const label =
+                    full || u.name || m.name || u.email || m.email || 'Member';
+                  return (
+                    <option key={id} value={id}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+
             <button
               type="button"
-              onClick={clearSelection}
+              onClick={() => void handleBulkDelete()}
               disabled={bulkActionPending}
-              className="rounded p-1 text-slate-300 hover:bg-slate-800 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label="Clear selection"
-              data-testid="waterfall-bulk-clear"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+              data-testid="waterfall-bulk-delete"
             >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-
-          <label className="inline-flex items-center gap-1.5">
-            <span className="sr-only">Set status</span>
-            <select
-              value=""
-              disabled={bulkActionPending}
-              onChange={(e) => {
-                const v = e.target.value as WorkTaskStatus;
-                if (!v) return;
-                void handleBulkSetStatus(v);
-                e.target.value = '';
-              }}
-              className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
-              data-testid="waterfall-bulk-status"
-              aria-label="Set status for selected tasks"
-            >
-              <option value="">Set status…</option>
-              {statusGroups.flatMap((group) =>
-                group.options.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                )),
+              {bulkActionPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
               )}
-            </select>
-          </label>
-
-          <label className="inline-flex items-center gap-1.5">
-            <span className="sr-only">Set assignee</span>
-            <select
-              value=""
-              disabled={bulkActionPending}
-              onChange={(e) => {
-                const raw = e.target.value;
-                if (raw === '') return;
-                const next = raw === '__none__' ? null : raw;
-                void handleBulkSetAssignee(next);
-                e.target.value = '';
-              }}
-              className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
-              data-testid="waterfall-bulk-assignee"
-              aria-label="Set assignee for selected tasks"
-            >
-              <option value="">Set assignee…</option>
-              <option value="__none__">Unassigned</option>
-              {members.map((m: any) => {
-                const u = m.user ?? {};
-                const id = m.userId ?? u.id ?? m.id;
-                const full = [u.firstName, u.lastName]
-                  .filter(Boolean)
-                  .join(' ')
-                  .trim();
-                const label =
-                  full || u.name || m.name || u.email || m.email || 'Member';
-                return (
-                  <option key={id} value={id}>
-                    {label}
-                  </option>
-                );
-              })}
-            </select>
-          </label>
-
-          <button
-            type="button"
-            onClick={() => void handleBulkDelete()}
-            disabled={bulkActionPending}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
-            data-testid="waterfall-bulk-delete"
-          >
-            {bulkActionPending ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Trash2 className="h-3.5 w-3.5" />
-            )}
-            Delete
-          </button>
-        </div>
-      )}
+              Delete
+            </button>
+          </div>,
+          document.body,
+        )}
 
       {/*
        * Phase 13 — Customize View side panel.

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -330,6 +330,23 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   // Inline-add state per phase. Map phaseId -> draft title.
   const [adding, setAdding] = useState<Record<string, string>>({});
 
+  /** Latest `adding` for blur/Enter submit handlers (avoid stale closures). */
+  const addingRef = useRef(adding);
+  addingRef.current = adding;
+
+  /** Prevents double-submit when Enter is followed immediately by blur. */
+  const phaseBottomSubmitLockRef = useRef(false);
+
+  /** Latest tasks for subtask submit (parent lookup). */
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
+
+  /** Latest inline subtask slot for blur submit. */
+  const addingSubtaskRef = useRef<{
+    parentTaskId: string;
+    draft: string;
+  } | null>(null);
+
   // Phase 12 (2026-04-08) — Inline subtask add state.
   // Operator wants Add Sub Task to behave exactly like the existing
   // phase-bottom Add task input: click the row ⋮ menu's "Add subtask"
@@ -345,6 +362,11 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
     parentTaskId: string;
     draft: string;
   } | null>(null);
+
+  addingSubtaskRef.current = addingSubtaskFor;
+
+  /** Prevents double-submit on subtask inline input (Enter then blur). */
+  const subtaskSubmitLockRef = useRef(false);
 
   // Row focus for keyboard nav (5B.1A: also tracks focused column for Space).
   const [focusedTaskId, setFocusedTaskId] = useState<string | null>(null);
@@ -633,28 +655,6 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
     setAddingSubtaskFor(null);
   }, []);
 
-  /**
-   * Commit the inline subtask draft. Looks up the parent in local
-   * `tasks` state to inherit phaseId, then delegates to the existing
-   * `handleAddSubtask` (Phase 8) which handles createTask + optimistic
-   * append + reload-on-error. Clears the draft on success only —
-   * failure leaves the typed text in place so the user can retry
-   * without re-typing.
-   */
-  const submitInlineSubtaskAdd = useCallback(async () => {
-    if (!addingSubtaskFor) return;
-    const parent = tasks.find((t) => t.id === addingSubtaskFor.parentTaskId);
-    if (!parent) {
-      // Parent disappeared (e.g. concurrent delete). Drop the input.
-      setAddingSubtaskFor(null);
-      return;
-    }
-    const created = await handleAddSubtask(parent, addingSubtaskFor.draft);
-    if (created) {
-      setAddingSubtaskFor(null);
-    }
-  }, [addingSubtaskFor, tasks]);
-
   /* ---- Add subtask from detail panel (Phase 8) ---- */
 
   /**
@@ -694,6 +694,35 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
     },
     [projectId, loadAll],
   );
+
+  /**
+   * Commit inline subtask draft (Enter, blur with text). Uses refs + lock so
+   * Enter→blur does not create twice. Empty blur closes without creating.
+   */
+  const submitInlineSubtaskAdd = useCallback(async () => {
+    const slot = addingSubtaskRef.current;
+    if (!slot) return;
+    if (subtaskSubmitLockRef.current) return;
+    const title = slot.draft.trim();
+    if (!title) {
+      setAddingSubtaskFor(null);
+      return;
+    }
+    const parent = tasksRef.current.find((t) => t.id === slot.parentTaskId);
+    if (!parent) {
+      setAddingSubtaskFor(null);
+      return;
+    }
+    subtaskSubmitLockRef.current = true;
+    try {
+      const created = await handleAddSubtask(parent, title);
+      if (created) {
+        setAddingSubtaskFor(null);
+      }
+    } finally {
+      subtaskSubmitLockRef.current = false;
+    }
+  }, [handleAddSubtask]);
 
   /* ---- Single-row actions (Phase 6) ---- */
 
@@ -908,22 +937,30 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
     [phases, loadAll, cancelEditingPhase],
   );
 
-  /* ---- Add task inline ---- */
+  /* ---- Add task inline (phase bottom + blur-to-save, PR #133) ---- */
 
-  const handleAddSubmit = useCallback(
+  const submitPhaseBottomTask = useCallback(
     async (phaseId: string) => {
-      const title = (adding[phaseId] ?? '').trim();
+      if (phaseBottomSubmitLockRef.current) return;
+      const title = (addingRef.current[phaseId] ?? '').trim();
       if (!title) return;
+      phaseBottomSubmitLockRef.current = true;
       try {
         const created = await createTask({ projectId, title, phaseId });
         setTasks((prev) => [...prev, created]);
         setAdding((prev) => ({ ...prev, [phaseId]: '' }));
-        setFocusedTaskId(created.id);
+        requestAnimationFrame(() => {
+          document
+            .querySelector<HTMLInputElement>(`[data-phase-input="${phaseId}"]`)
+            ?.focus();
+        });
       } catch (err: any) {
         setError(err?.response?.data?.message || err?.message || 'Could not add task');
+      } finally {
+        phaseBottomSubmitLockRef.current = false;
       }
     },
-    [adding, projectId],
+    [projectId],
   );
 
   /* ---- Keyboard nav ---- */
@@ -1107,7 +1144,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
             return (
             <React.Fragment key={phase.id}>
               <tr
-                className="bg-slate-50/80 border-y border-slate-200"
+                className="group bg-slate-50/80 border-y border-slate-200"
                 data-testid={`waterfall-row-group-${phase.name}`}
               >
                 <td
@@ -1118,6 +1155,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                    * Phase 4 phase header: color dot + name + count badge +
                    * duration badge + completion bar tinted with the phase
                    * color. Matches the operator's mockup aesthetic.
+                   * PR #133: `group` enables hover-revealed "+ Add task" control.
                    */}
                   <div className="flex items-center gap-3">
                     <span
@@ -1187,6 +1225,25 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                         {rollup.durationDays} day{rollup.durationDays === 1 ? '' : 's'}
                       </span>
                     )}
+                    <button
+                      type="button"
+                      className="opacity-0 group-hover:opacity-100 transition-opacity ml-1 shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-emerald-50 text-emerald-700 text-xs font-medium hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                      data-testid={`phase-header-add-task-${phase.id}`}
+                      aria-label={`Add task in ${phase.name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        const el = document.querySelector<HTMLInputElement>(
+                          `[data-phase-input="${phase.id}"]`,
+                        );
+                        if (el) {
+                          el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                          el.focus();
+                        }
+                      }}
+                    >
+                      <Plus className="h-3 w-3 shrink-0" aria-hidden />
+                      Add task
+                    </button>
                     <div className="flex items-center gap-2 ml-auto min-w-[140px]">
                       <div className="h-1.5 flex-1 max-w-[120px] rounded-full bg-slate-200 overflow-hidden">
                         <div
@@ -1245,9 +1302,8 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                    * Renders directly under the parent row when the row
                    * ⋮ menu's "Add subtask" item was clicked. Indented
                    * to `level + 1` to visually anchor to the parent.
-                   * Enter saves, Escape cancels, blur cancels (matches
-                   * the keyboard pattern of the phase-bottom Add task
-                   * input). Disabled depth limit: subtasks can nest at
+                   * Enter saves, Escape cancels, blur saves when non-empty
+                   * (matches phase-bottom Add task). Disabled depth limit: subtasks can nest at
                    * level 0→1, 1→2; the existing render only supports
                    * 3 levels (0/1/2), so trying to add a sub-subtask
                    * under a level-2 row is gracefully blocked at the
@@ -1276,7 +1332,9 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                                   : prev,
                               )
                             }
-                            onBlur={cancelInlineSubtaskAdd}
+                            onBlur={() => {
+                              void submitInlineSubtaskAdd();
+                            }}
                             onKeyDown={(e) => {
                               if (e.key === 'Enter') {
                                 e.preventDefault();
@@ -1304,18 +1362,23 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                     <Plus className="h-3.5 w-3.5 text-slate-400" />
                     <input
                       type="text"
+                      data-phase-input={phase.id}
                       value={adding[phase.id] ?? ''}
                       placeholder="Add task"
                       onChange={(e) =>
                         setAdding((prev) => ({ ...prev, [phase.id]: e.target.value }))
                       }
+                      onBlur={() => {
+                        void submitPhaseBottomTask(phase.id);
+                      }}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') {
                           e.preventDefault();
-                          void handleAddSubmit(phase.id);
+                          void submitPhaseBottomTask(phase.id);
                         } else if (e.key === 'Escape') {
                           e.preventDefault();
                           setAdding((prev) => ({ ...prev, [phase.id]: '' }));
+                          e.currentTarget.blur();
                         }
                       }}
                       className="w-full bg-transparent text-sm text-slate-700 placeholder:text-slate-400 focus:outline-none"
@@ -1764,26 +1827,43 @@ const WaterfallRow: React.FC<RowProps> = ({
        * handler.
        */}
       <Td focused={focused} testId={`cell-title-${task.id}`} onClick={() => onFocusCell('title')}>
-        <button
-          type="button"
-          className="flex w-full items-center gap-2 text-left text-slate-800 hover:text-blue-700"
-          style={{ paddingLeft: `${level * 18}px` }}
-          onClick={(e) => {
-            e.stopPropagation();
-            onViewDetails();
-          }}
-          data-row-level={level}
-          data-testid={`title-open-panel-${task.id}`}
-          title="Open task details"
-        >
-          {level > 0 && (
-            <span className="text-slate-300" aria-hidden>
-              {level === 1 ? '└' : '└─'}
-            </span>
+        <div className="flex w-full min-w-0 items-center gap-1">
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 items-center gap-2 text-left text-slate-800 hover:text-blue-700"
+            style={{ paddingLeft: `${level * 18}px` }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewDetails();
+            }}
+            data-row-level={level}
+            data-testid={`title-open-panel-${task.id}`}
+            title="Open task details"
+          >
+            {level > 0 && (
+              <span className="text-slate-300" aria-hidden>
+                {level === 1 ? '└' : '└─'}
+              </span>
+            )}
+            {task.isMilestone && <Diamond className="h-3 w-3 shrink-0 text-amber-500" />}
+            <span className="truncate">{task.title}</span>
+          </button>
+          {level < 2 && (
+            <button
+              type="button"
+              className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-slate-200 bg-white text-xs font-medium text-blue-600 hover:bg-blue-50 hover:border-blue-200 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              data-testid={`title-add-subtask-pill-${task.id}`}
+              aria-label={`Add sub-task under ${task.title}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddSubtask();
+              }}
+            >
+              <Plus size={10} className="shrink-0" aria-hidden />
+              Sub-task
+            </button>
           )}
-          {task.isMilestone && <Diamond className="h-3 w-3 shrink-0 text-amber-500" />}
-          <span className="truncate">{task.title}</span>
-        </button>
+        </div>
       </Td>
 
       {/* Assignee — Phase 3 (renamed from Owner). Same data, same editor. */}

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -28,7 +28,7 @@
  *   - Sub-child rows (the table renders parent + child only this phase).
  *   - SVG dependency lines.
  *   - Drag-reorder of rows.
- *   - Bulk multi-select bar (the existing TaskListSection still owns that).
+ *   - Bulk multi-select: fixed viewport bar + header select-all (this file).
  *   - Virtualization (no perf failure observed at MVP scale).
  *   - Mobile editing.
  *   - Admin status-set editing UI (status set is sourced from
@@ -1117,7 +1117,26 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
            * constant, not chasing colSpans.
            */}
           <tr>
-            <Th className="w-[36px] px-2" />
+            <Th className="w-[36px] px-2">
+              <input
+                type="checkbox"
+                className="h-4 w-4 cursor-pointer rounded border-slate-300 text-blue-600 focus:ring-blue-400"
+                checked={
+                  flatRows.length > 0 &&
+                  selectedTaskIds.size > 0 &&
+                  selectedTaskIds.size === flatRows.length
+                }
+                onChange={() => {
+                  if (flatRows.length === 0) return;
+                  if (selectedTaskIds.size === flatRows.length) {
+                    setSelectedTaskIds(new Set());
+                  } else {
+                    setSelectedTaskIds(new Set(flatRows.map((t) => t.id)));
+                  }
+                }}
+                aria-label="Select all tasks"
+              />
+            </Th>
             {/* Phase 13 — title is hard-locked visible (row anchor). */}
             <Th>Tasks</Th>
             {!hiddenColumnSet.has('assignee') && <Th className="w-[160px]">Assignee</Th>}
@@ -1413,134 +1432,6 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
        */}
 
       {/*
-       * Phase 4 — Bulk action bar.
-       * Renders only when at least one row is selected. Floats inside the
-       * table container at the bottom (sticky-style) so users always see
-       * what's selected and what they can do without scrolling. Action set
-       * for MVP: Delete + Clear selection. Bulk Duplicate is deferred to
-       * Phase 5+ once the backend ships either a bulk-duplicate endpoint
-       * or we accept N parallel POSTs to /work/tasks (which is fine for
-       * MVP scale but not yet wired). Bulk Status / Assignee changes use
-       * the existing `bulkUpdate` endpoint and will be added next.
-       */}
-      {selectedTaskIds.size > 0 && (
-        <div
-          className="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-4 py-3 shadow-[0_-4px_16px_-8px_rgba(0,0,0,0.08)]"
-          data-testid="waterfall-bulk-action-bar"
-        >
-          <div className="flex items-center gap-3 flex-wrap">
-            <span className="text-sm font-medium text-slate-700">
-              {selectedTaskIds.size} selected
-            </span>
-
-            {/*
-             * Phase 6 — Bulk Status dropdown.
-             * Native <select> for simplicity (avoids a custom dropdown
-             * component for the action bar). Each <option> uses the raw
-             * status enum value; the displayed label comes from the
-             * shared status set so renames in the future propagate
-             * automatically. Selecting any non-placeholder value fires
-             * `handleBulkSetStatus` and immediately resets the select
-             * back to the placeholder so the same status can be applied
-             * again to a fresh selection without bouncing through a
-             * different value.
-             */}
-            <label className="inline-flex items-center gap-1.5 text-xs text-slate-600">
-              <span className="sr-only">Set status</span>
-              <select
-                value=""
-                disabled={bulkActionPending}
-                onChange={(e) => {
-                  const v = e.target.value as WorkTaskStatus;
-                  if (!v) return;
-                  void handleBulkSetStatus(v);
-                  e.target.value = '';
-                }}
-                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-200"
-                data-testid="waterfall-bulk-status"
-                aria-label="Set status for selected tasks"
-              >
-                <option value="">Set status…</option>
-                {statusGroups.flatMap((group) =>
-                  group.options.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  )),
-                )}
-              </select>
-            </label>
-
-            {/*
-             * Phase 6 — Bulk Assignee dropdown.
-             * Lists "Unassigned" + every workspace member. Same
-             * reset-on-pick pattern as the status dropdown.
-             */}
-            <label className="inline-flex items-center gap-1.5 text-xs text-slate-600">
-              <span className="sr-only">Set assignee</span>
-              <select
-                value=""
-                disabled={bulkActionPending}
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  if (raw === '') return;
-                  // Special sentinel "__none__" → clear assignee.
-                  const next = raw === '__none__' ? null : raw;
-                  void handleBulkSetAssignee(next);
-                  e.target.value = '';
-                }}
-                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-200"
-                data-testid="waterfall-bulk-assignee"
-                aria-label="Set assignee for selected tasks"
-              >
-                <option value="">Set assignee…</option>
-                <option value="__none__">Unassigned</option>
-                {members.map((m: any) => {
-                  const u = m.user ?? {};
-                  const id = m.userId ?? u.id ?? m.id;
-                  const full = [u.firstName, u.lastName]
-                    .filter(Boolean)
-                    .join(' ')
-                    .trim();
-                  const label =
-                    full || u.name || m.name || u.email || m.email || 'Member';
-                  return (
-                    <option key={id} value={id}>
-                      {label}
-                    </option>
-                  );
-                })}
-              </select>
-            </label>
-
-            <button
-              type="button"
-              onClick={() => void handleBulkDelete()}
-              disabled={bulkActionPending}
-              className="inline-flex items-center gap-1.5 rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              data-testid="waterfall-bulk-delete"
-            >
-              {bulkActionPending ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <Trash2 className="h-3 w-3" />
-              )}
-              Delete
-            </button>
-            <button
-              type="button"
-              onClick={clearSelection}
-              disabled={bulkActionPending}
-              className="ml-auto text-xs text-slate-500 hover:text-slate-700 disabled:opacity-50"
-              data-testid="waterfall-bulk-clear"
-            >
-              Clear selection
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/*
        * Phase 7 — Task detail side panel.
        * Renders only when `detailPanelTaskId` is set. The task itself is
        * resolved on every render from the local `tasks` state, so any
@@ -1583,6 +1474,111 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
           );
         })()}
       </div>
+
+      {/*
+       * Bulk action bar — fixed to viewport (outside overflow-x-auto) so it
+       * stays visible while scrolling the table. Same handlers as before.
+       */}
+      {selectedTaskIds.size > 0 && (
+        <div
+          className="fixed bottom-6 left-1/2 z-50 flex max-w-[min(100vw-2rem,56rem)] -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-slate-700 bg-slate-900 px-4 py-2.5 text-white shadow-2xl"
+          data-testid="waterfall-bulk-action-bar"
+        >
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="text-sm font-medium text-white">
+              {selectedTaskIds.size} selected
+            </span>
+            <button
+              type="button"
+              onClick={clearSelection}
+              disabled={bulkActionPending}
+              className="rounded p-1 text-slate-300 hover:bg-slate-800 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Clear selection"
+              data-testid="waterfall-bulk-clear"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <label className="inline-flex items-center gap-1.5">
+            <span className="sr-only">Set status</span>
+            <select
+              value=""
+              disabled={bulkActionPending}
+              onChange={(e) => {
+                const v = e.target.value as WorkTaskStatus;
+                if (!v) return;
+                void handleBulkSetStatus(v);
+                e.target.value = '';
+              }}
+              className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              data-testid="waterfall-bulk-status"
+              aria-label="Set status for selected tasks"
+            >
+              <option value="">Set status…</option>
+              {statusGroups.flatMap((group) =>
+                group.options.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                )),
+              )}
+            </select>
+          </label>
+
+          <label className="inline-flex items-center gap-1.5">
+            <span className="sr-only">Set assignee</span>
+            <select
+              value=""
+              disabled={bulkActionPending}
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (raw === '') return;
+                const next = raw === '__none__' ? null : raw;
+                void handleBulkSetAssignee(next);
+                e.target.value = '';
+              }}
+              className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              data-testid="waterfall-bulk-assignee"
+              aria-label="Set assignee for selected tasks"
+            >
+              <option value="">Set assignee…</option>
+              <option value="__none__">Unassigned</option>
+              {members.map((m: any) => {
+                const u = m.user ?? {};
+                const id = m.userId ?? u.id ?? m.id;
+                const full = [u.firstName, u.lastName]
+                  .filter(Boolean)
+                  .join(' ')
+                  .trim();
+                const label =
+                  full || u.name || m.name || u.email || m.email || 'Member';
+                return (
+                  <option key={id} value={id}>
+                    {label}
+                  </option>
+                );
+              })}
+            </select>
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void handleBulkDelete()}
+            disabled={bulkActionPending}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+            data-testid="waterfall-bulk-delete"
+          >
+            {bulkActionPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" />
+            )}
+            Delete
+          </button>
+        </div>
+      )}
+
       {/*
        * Phase 13 — Customize View side panel.
        * Opens when the gear icon in the toolbar above the table is

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -56,6 +56,7 @@ import {
   Check,
   Copy,
   Diamond,
+  Link,
   Link2,
   Loader2,
   MoreVertical,
@@ -64,6 +65,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { api } from '@/lib/api';
 import {
   bulkUpdate,
@@ -800,6 +802,31 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
     [loadAll],
   );
 
+  const handleCopyTaskLink = useCallback(
+    async (taskId: string) => {
+      const url = `${window.location.origin}/projects/${projectId}?taskId=${taskId}`;
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success('Link copied');
+      } catch {
+        try {
+          const textArea = document.createElement('textarea');
+          textArea.value = url;
+          textArea.style.position = 'fixed';
+          textArea.style.opacity = '0';
+          document.body.appendChild(textArea);
+          textArea.select();
+          document.execCommand('copy');
+          document.body.removeChild(textArea);
+          toast.success('Link copied');
+        } catch {
+          toast.error('Could not copy link');
+        }
+      }
+    },
+    [projectId],
+  );
+
   /* ---- Bulk Status / Assignee changes (Phase 6) ---- */
 
   /**
@@ -1301,6 +1328,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                     onViewDetails={() => openDetailPanel(task.id)}
                     onAddSubtask={() => startInlineSubtaskAdd(task.id)}
                     onDuplicate={() => void handleDuplicateTask(task)}
+                    onCopyTaskLink={() => void handleCopyTaskLink(task.id)}
                     onDelete={() => void handleDeleteSingleTask(task)}
                     onFocusRow={() => setFocusedTaskId(task.id)}
                     onFocusCell={(col) => {
@@ -1702,6 +1730,7 @@ interface RowProps {
   onAddSubtask: () => void;
   /** Phase 6 — single-row actions from the ⋮ menu */
   onDuplicate: () => void;
+  onCopyTaskLink: () => void;
   onDelete: () => void;
   onFocusRow: () => void;
   onFocusCell: (col: ColumnKey) => void;
@@ -1726,6 +1755,7 @@ const WaterfallRow: React.FC<RowProps> = ({
   onViewDetails,
   onAddSubtask,
   onDuplicate,
+  onCopyTaskLink,
   onDelete,
   onFocusRow,
   onFocusCell,
@@ -2033,9 +2063,9 @@ const WaterfallRow: React.FC<RowProps> = ({
        * leftmost checkbox cell. Click the ⋮ button → opens a small
        * dropdown anchored to the button. Outside-click closes via the
        * effect at the top of the row component. The menu items are
-       * intentionally minimal for MVP: Duplicate + Delete. "Add subtask",
-       * "Move", "Convert to milestone", "Archive" arrive with the task
-       * detail panel in Phase 7+ when the parentTaskId surface lands.
+       * intentionally minimal for MVP: detail, sub-task add (depth-limited),
+       * duplicate, copy link, delete. "Move", "Convert to milestone",
+       * "Archive" arrive with the task detail panel in Phase 7+ when needed.
        *
        * The menu container is `relative` so the absolute-positioned
        * dropdown anchors to the row gutter. `z-20` keeps it above the
@@ -2076,31 +2106,32 @@ const WaterfallRow: React.FC<RowProps> = ({
                 data-testid={`row-menu-view-${task.id}`}
               >
                 <SquareArrowOutUpRight className="h-3.5 w-3.5" />
-                View details
+                Detail
               </button>
               {/*
-               * Phase 12 — Add subtask via row ⋮ menu.
+               * Phase 12 — Add sub-task via row ⋮ menu (hidden when level is 2).
                * Reveals an inline input row directly under this row,
                * indented one level deeper. Type a title + Enter creates
                * the subtask in the same phase via createTask with
                * parentTaskId. Same UX pattern as the existing
                * phase-bottom Add task input — operator's stated direction.
                */}
-              <button
-                type="button"
-                role="menuitem"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                  onAddSubtask();
-                }}
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50"
-                data-testid={`row-menu-add-subtask-${task.id}`}
-              >
-                <Plus className="h-3.5 w-3.5" />
-                Add subtask
-              </button>
-              <div className="h-px bg-slate-100 my-1" />
+              {level < 2 && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setMenuOpen(false);
+                    onAddSubtask();
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50"
+                  data-testid={`row-menu-add-subtask-${task.id}`}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add sub-task
+                </button>
+              )}
               <button
                 type="button"
                 role="menuitem"
@@ -2115,6 +2146,21 @@ const WaterfallRow: React.FC<RowProps> = ({
                 <Copy className="h-3.5 w-3.5" />
                 Duplicate
               </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenuOpen(false);
+                  void onCopyTaskLink();
+                }}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-50"
+                data-testid={`row-menu-copy-link-${task.id}`}
+              >
+                <Link className="h-3.5 w-3.5" />
+                Copy link
+              </button>
+              <div className="h-px bg-slate-100 my-1" />
               <button
                 type="button"
                 role="menuitem"

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -1468,26 +1468,25 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
         })()}
 
       {/*
-       * Bulk action bar — portaled to document.body so `fixed` is always
-       * viewport-relative (never clipped or re-rooted by a transformed /
-       * overflow ancestor). Same handlers as before.
+       * Bulk action bar — portaled to document.body; fixed bottom-center.
+       * Three actions: Status, Assignee, Delete (+ count + clear). White bar.
        */}
       {typeof document !== 'undefined' &&
         selectedTaskIds.size > 0 &&
         createPortal(
           <div
-            className="fixed bottom-6 left-1/2 z-[200] flex max-w-[min(100vw-2rem,56rem)] -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-slate-700 bg-slate-900 px-4 py-2.5 text-white shadow-2xl"
+            className="fixed bottom-6 left-1/2 z-50 flex max-w-[min(100vw-2rem,56rem)] -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-slate-700 shadow-lg"
             data-testid="waterfall-bulk-action-bar"
           >
             <div className="flex shrink-0 items-center gap-2">
-              <span className="text-sm font-medium text-white">
+              <span className="text-sm font-medium text-slate-700">
                 {selectedTaskIds.size} selected
               </span>
               <button
                 type="button"
                 onClick={clearSelection}
                 disabled={bulkActionPending}
-                className="rounded p-1 text-slate-300 hover:bg-slate-800 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded p-1 text-slate-500 hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
                 aria-label="Clear selection"
                 data-testid="waterfall-bulk-clear"
               >
@@ -1495,8 +1494,10 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
               </button>
             </div>
 
-            <label className="inline-flex items-center gap-1.5">
-              <span className="sr-only">Set status</span>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs font-medium text-slate-500 whitespace-nowrap">
+                Status
+              </span>
               <select
                 value=""
                 disabled={bulkActionPending}
@@ -1506,11 +1507,11 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                   void handleBulkSetStatus(v);
                   e.target.value = '';
                 }}
-                className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 data-testid="waterfall-bulk-status"
                 aria-label="Set status for selected tasks"
               >
-                <option value="">Set status…</option>
+                <option value="">Choose…</option>
                 {statusGroups.flatMap((group) =>
                   group.options.map((opt) => (
                     <option key={opt.value} value={opt.value}>
@@ -1519,10 +1520,12 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                   )),
                 )}
               </select>
-            </label>
+            </div>
 
-            <label className="inline-flex items-center gap-1.5">
-              <span className="sr-only">Set assignee</span>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs font-medium text-slate-500 whitespace-nowrap">
+                Assignee
+              </span>
               <select
                 value=""
                 disabled={bulkActionPending}
@@ -1533,11 +1536,11 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                   void handleBulkSetAssignee(next);
                   e.target.value = '';
                 }}
-                className="rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-200"
                 data-testid="waterfall-bulk-assignee"
                 aria-label="Set assignee for selected tasks"
               >
-                <option value="">Set assignee…</option>
+                <option value="">Choose…</option>
                 <option value="__none__">Unassigned</option>
                 {members.map((m: any) => {
                   const u = m.user ?? {};
@@ -1555,17 +1558,17 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                   );
                 })}
               </select>
-            </label>
+            </div>
 
             <button
               type="button"
               onClick={() => void handleBulkDelete()}
               disabled={bulkActionPending}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
               data-testid="waterfall-bulk-delete"
             >
               {bulkActionPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-red-600" />
               ) : (
                 <Trash2 className="h-3.5 w-3.5" />
               )}

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -1844,7 +1844,7 @@ const WaterfallRow: React.FC<RowProps> = ({
        * Phase 10 (2026-04-08) — Title editing moved entirely to the
        * task detail panel. Clicking the title button now opens the
        * panel via `onViewDetails` (the same handler the row ⋮ menu's
-       * "View details" item uses). This matches the operator's stated
+       * "Detail" item uses). This matches the operator's stated
        * ClickUp-pattern direction. The InlineText editor is removed.
        * Title is in `READ_ONLY_COLUMNS` so Tab traversal still focuses
        * the cell but never enters an editor; pressing Enter on a


### PR DESCRIPTION
## Summary
Bundles **Project Overview v2** and **Waterfall** UX work currently on `feat/overview-v2` that is not yet on `staging`.

## Commits (new vs `origin/staging`)
- `feat(projects): overview v2 — persistent header, to-do checklist, stacked layout`
- `feat(waterfall): inline task creation UX — hover + buttons and blur-to-save`
- `fix(waterfall): move bulk action bar to fixed viewport position`
- `fix(waterfall): unblock Activities table — move detail panel out of overflow, portal bulk bar`
- `style(waterfall): white bulk bar, three actions, z-50`
- `feat(waterfall): polish task row menu — copy link, reorder, level guard`
- `chore(waterfall): align title-cell comment with Detail menu label`

## Files touched
- `zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx`
- `zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx`
- `zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx`
- `zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx`

## Waterfall row ⋮ menu (PR #135 alignment)
- **Detail** (rename), **Add sub-task** (hidden at level 2), **Duplicate**, **Copy link** (clipboard + sonner toast), separator, **Delete**
- Copy URL: `/projects/:projectId?taskId=:taskId`

## How to verify
- [ ] Project **Overview** tab: header, checklist, cards layout
- [ ] Waterfall: inline add task, bulk bar, detail panel + Activities table scroll
- [ ] Task row menu: order, copy link, level-2 hides Add sub-task

## Out of scope
- Admin console (separate review)
- Backend changes (frontend-only PR)


Made with [Cursor](https://cursor.com)