### PR TITLE
fix: admin templates UX, governance methodology, migration DataSource entities

### DIFF
--- a/zephix-backend/src/config/data-source-migrate.spec.ts
+++ b/zephix-backend/src/config/data-source-migrate.spec.ts
@@ -1,0 +1,23 @@
+describe('data-source-migrate', () => {
+  const originalUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    process.env.DATABASE_URL =
+      'postgresql://localhost:5432/zephix_migrate_metadata_test';
+  });
+
+  afterEach(() => {
+    process.env.DATABASE_URL = originalUrl;
+    jest.resetModules();
+  });
+
+  it('registers entity globs so repository-based migrations can resolve metadata', async () => {
+    const { default: dataSource } = await import('./data-source-migrate');
+    const entities = dataSource.options.entities;
+    expect(entities).toBeDefined();
+    expect(Array.isArray(entities)).toBe(true);
+    expect((entities as string[]).some((p) => String(p).includes('.entity'))).toBe(
+      true,
+    );
+  });
+});

--- a/zephix-backend/src/config/data-source-migrate.ts
+++ b/zephix-backend/src/config/data-source-migrate.ts
@@ -10,6 +10,9 @@ if (!url) {
 const dataSource = new DataSource({
   type: 'postgres',
   url,
+  // Migrations may use queryRunner.manager.getRepository(Entity); those entities
+  // must be registered here (CLI DataSource is separate from Nest TypeOrmModule).
+  entities: [__dirname + '/../**/*.entity{.ts,.js}'],
   ssl:
     ['production', 'staging'].includes(process.env.NODE_ENV) ||
     (url || '').includes('railway')

--- a/zephix-frontend/src/features/administration/constants/governance-policies.test.ts
+++ b/zephix-frontend/src/features/administration/constants/governance-policies.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMethodologyKey } from "./governance-policies";
+
+describe("resolveMethodologyKey", () => {
+  it("maps explicit methodology enums regardless of case", () => {
+    expect(resolveMethodologyKey({ methodology: "WATERFALL" })).toBe("waterfall");
+    expect(resolveMethodologyKey({ methodology: "Hybrid" })).toBe("hybrid");
+  });
+
+  it("uses first segment of hyphenated methodology", () => {
+    expect(resolveMethodologyKey({ methodology: "WATERFALL_PHASED" })).toBe("waterfall");
+  });
+
+  it("maps deliveryMethod slugs with version suffixes (underscore or hyphen)", () => {
+    expect(resolveMethodologyKey({ deliveryMethod: "waterfall_v1" })).toBe("waterfall");
+    expect(resolveMethodologyKey({ deliveryMethod: "SCRUM_V2" })).toBe("scrum");
+  });
+
+  it("maps predictive/traditional synonyms to waterfall", () => {
+    expect(resolveMethodologyKey({ methodology: "PREDICTIVE" })).toBe("waterfall");
+    expect(resolveMethodologyKey({ methodology: "Traditional" })).toBe("waterfall");
+  });
+
+  it("returns empty when neither field is set", () => {
+    expect(resolveMethodologyKey({})).toBe("");
+  });
+
+  it("returns custom for unknown tokens", () => {
+    expect(resolveMethodologyKey({ methodology: "LEAN" })).toBe("custom");
+  });
+});

--- a/zephix-frontend/src/features/administration/constants/governance-policies.ts
+++ b/zephix-frontend/src/features/administration/constants/governance-policies.ts
@@ -73,25 +73,43 @@ export const POLICY_UI_META: Record<string, GovernancePolicyUiMeta> = {
   },
 };
 
-export function resolveMethodologyKey(template: GovernanceTemplateMethodologySource): string {
-  const m = (template.methodology ?? "")
-    .toString()
-    .toLowerCase()
-    .replace(/_/g, "-")
-    .trim();
-  if (m) return m;
-  const d = (template.deliveryMethod ?? "")
-    .toString()
-    .toLowerCase()
-    .replace(/_/g, "-")
-    .trim();
-  const map: Record<string, string> = {
-    scrum: "scrum",
-    agile: "agile",
-    kanban: "kanban",
-    waterfall: "waterfall",
-    hybrid: "hybrid",
+const CANONICAL_METHODOLOGY: Record<string, string> = {
+  scrum: "scrum",
+  agile: "agile",
+  kanban: "kanban",
+  waterfall: "waterfall",
+  hybrid: "hybrid",
+};
+
+/** First path segment of delivery/methodology strings (e.g. waterfall-v1 → waterfall). */
+function methodologyHeadToken(raw: string): string {
+  const normalized = raw.toLowerCase().replace(/_/g, "-").trim();
+  if (!normalized) return "";
+  return normalized.split("-")[0] ?? "";
+}
+
+function canonicalFromHead(head: string): string {
+  if (!head) return "";
+  const synonyms: Record<string, string> = {
+    predictive: "waterfall",
+    traditional: "waterfall",
   };
+  const primary = synonyms[head] ?? head;
+  return CANONICAL_METHODOLOGY[primary] ?? "custom";
+}
+
+/**
+ * Normalizes template methodology for governance UI filtering.
+ * Handles uppercase enums, underscores, and delivery slugs like `waterfall_v1`.
+ */
+export function resolveMethodologyKey(template: GovernanceTemplateMethodologySource): string {
+  const m = (template.methodology ?? "").toString().trim();
+  if (m) {
+    const head = methodologyHeadToken(m);
+    return canonicalFromHead(head);
+  }
+  const d = (template.deliveryMethod ?? "").toString().trim();
   if (!d) return "";
-  return map[d] ?? "custom";
+  const head = methodologyHeadToken(d);
+  return canonicalFromHead(head);
 }

--- a/zephix-frontend/src/features/administration/layout/AdministrationLayout.tsx
+++ b/zephix-frontend/src/features/administration/layout/AdministrationLayout.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react";
+
 import { ADMINISTRATION_NAV_GROUPS } from "@/features/administration/constants";
 import { useAdminWorkspacesModalStore } from "@/stores/adminWorkspacesModalStore";
 
@@ -113,7 +114,7 @@ export default function AdministrationLayout() {
           </nav>
         </aside>
 
-        <section className="min-w-0 flex-1 overflow-auto bg-gray-50 p-6">
+        <section className="min-w-0 flex-1 select-text overflow-auto bg-gray-50 p-6">
           <Outlet />
         </section>
       </div>

--- a/zephix-frontend/src/features/administration/pages/AdministrationTemplatesPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationTemplatesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+
 import {
   administrationApi,
   type AdminTemplate,
@@ -66,7 +67,7 @@ export default function AdministrationTemplatesPage() {
                   onClick={() =>
                     setSelectedTemplate(template as unknown as TemplatePanelData)
                   }
-                  className="w-full rounded border border-gray-200 px-3 py-2 text-left text-sm text-gray-700 transition-colors hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                  className="w-full cursor-pointer rounded border border-gray-200 px-3 py-2 text-left text-sm text-gray-700 transition-colors hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
                 >
                   <span className="font-medium text-gray-900">{template.name}</span>
                   {template.status ? (


### PR DESCRIPTION
## Summary
- **Backend:** Register entity glob on `data-source-migrate` so TypeORM migrations using `getRepository()` (e.g. SeedGovernancePolicyCatalog) resolve metadata; fixes pre-deploy `db:migrate` failures.
- **Frontend:** Normalize template methodology keys (`waterfall_v1`, enums, synonyms); explicit `cursor-pointer` on admin template rows; `select-text` on administration main pane; Vitest for `resolveMethodologyKey`.

## Verification
- `npx vitest run src/features/administration/constants/governance-policies.test.ts`
- Backend: `npx jest src/config/data-source-migrate.spec.ts` (when run in zephix-backend)

Targets `staging` per repo policy.

Made with [Cursor](https://cursor.com)