### PR TITLE
fix(governance): stabilize toggles, nine-policy catalog, honest tiers

### DIFF
--- a/zephix-backend/src/migrations/18000000000067-SeedGovernancePolicyCatalog.ts
+++ b/zephix-backend/src/migrations/18000000000067-SeedGovernancePolicyCatalog.ts
@@ -164,7 +164,7 @@ export class SeedGovernancePolicyCatalog18000000000067
           scopeId: null,
           entityType,
           name: setName,
-          description: `PMBOK 7+8 aligned governance policies for ${entityType} entities.`,
+          description: `Governance policy catalog for ${entityType} entities.`,
           enforcementMode: EnforcementMode.OFF,
           isActive: true,
           createdBy: null,

--- a/zephix-backend/src/migrations/18000000000070-RemovePmbokGovernanceRuleSetDescriptions.ts
+++ b/zephix-backend/src/migrations/18000000000070-RemovePmbokGovernanceRuleSetDescriptions.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Replace governance_rule_sets.description values that reference external
+ * methodology branding with neutral Zephix copy. Idempotent on re-run.
+ */
+export class RemovePmbokGovernanceRuleSetDescriptions18000000000070
+  implements MigrationInterface
+{
+  name = 'RemovePmbokGovernanceRuleSetDescriptions18000000000070';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE governance_rule_sets
+      SET description = CONCAT('Governance policy catalog for ', entity_type, ' entities.')
+      WHERE description IS NOT NULL
+        AND description ILIKE '%pmbok%'
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    /* Branding removal is not restored on rollback. */
+  }
+}

--- a/zephix-backend/src/migrations/18000000000071-GovernanceCatalogNinePolicies.ts
+++ b/zephix-backend/src/migrations/18000000000071-GovernanceCatalogNinePolicies.ts
@@ -1,0 +1,187 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+  GovernanceEntityType,
+  ScopeType,
+} from '../modules/governance-rules/entities/governance-rule-set.entity';
+import { GovernanceRuleSet } from '../modules/governance-rules/entities/governance-rule-set.entity';
+import { GovernanceRule } from '../modules/governance-rules/entities/governance-rule.entity';
+import { GovernanceRuleActiveVersion } from '../modules/governance-rules/entities/governance-rule-active-version.entity';
+
+const SYSTEM_FILTER = `rule_set_id IN (SELECT id FROM governance_rule_sets WHERE scope_type = 'SYSTEM')`;
+
+const SCOPE_CHANGE = {
+  when: { creationOnly: true },
+  conditions: [
+    {
+      type: 'ROLE_ALLOWED',
+      params: { roles: ['ADMIN', 'workspace_owner', 'workspace_admin'] },
+    },
+  ],
+  message:
+    'Only organization or workspace admins may create tasks when this policy is enabled on the project template.',
+  severity: 'ERROR',
+};
+
+const TASK_SIGNOFF = {
+  when: { toStatus: 'DONE' },
+  conditions: [{ type: 'FIELD_NOT_EMPTY', field: 'assigneeUserId' }],
+  message: 'Task must have an assignee before marking as Done.',
+  severity: 'ERROR',
+};
+
+const PHASE_GATE = {
+  when: {},
+  conditions: [],
+  message:
+    'Phase advancement requires approval (configure approvals in a future release).',
+  severity: 'ERROR',
+};
+
+const DELIVERABLE_DOC = {
+  when: {},
+  conditions: [],
+  message: 'At least one document must be attached before closing phase.',
+  severity: 'ERROR',
+};
+
+const WIP_LIMITS = {
+  when: { toStatus: 'IN_PROGRESS' },
+  conditions: [],
+  message: 'Work in progress limit exceeded (enforcement in a future release).',
+  severity: 'WARNING',
+};
+
+const RISK_ALERT = {
+  when: {},
+  conditions: [],
+  message:
+    'High-priority task threshold exceeded (enforcement in a future release).',
+  severity: 'WARNING',
+};
+
+const BUDGET = {
+  when: {},
+  conditions: [],
+  message:
+    'Project budget threshold exceeded (enforcement in a future release).',
+  severity: 'WARNING',
+};
+
+const SCHEDULE_TOLERANCE = {
+  when: {},
+  conditions: [],
+  message: 'Schedule variance escalation (enforcement in a future release).',
+  severity: 'WARNING',
+};
+
+const RESOURCE_CAPACITY = {
+  when: {},
+  conditions: [],
+  message: 'Resource allocation governance (enforcement in a future release).',
+  severity: 'WARNING',
+};
+
+/**
+ * Nine-policy SYSTEM catalog: honest evaluable definitions, two PROJECT placeholders,
+ * remove mandatory-fields. All rule_definition UPDATEs scoped to SYSTEM sets only.
+ */
+export class GovernanceCatalogNinePolicies18000000000071
+  implements MigrationInterface
+{
+  name = 'GovernanceCatalogNinePolicies18000000000071';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const upd = async (code: string, def: Record<string, unknown>) => {
+      await queryRunner.query(
+        `UPDATE governance_rules SET rule_definition = $1::jsonb
+         WHERE code = $2 AND version = 1 AND ${SYSTEM_FILTER}`,
+        [JSON.stringify(def), code],
+      );
+    };
+
+    await upd('scope-change-control', SCOPE_CHANGE);
+    await upd('task-completion-signoff', TASK_SIGNOFF);
+    await upd('phase-gate-approval', PHASE_GATE);
+    await upd('deliverable-doc-required', DELIVERABLE_DOC);
+    await upd('wip-limits', WIP_LIMITS);
+    await upd('risk-threshold-alert', RISK_ALERT);
+    await upd('budget-threshold', BUDGET);
+
+    await queryRunner.query(
+      `DELETE FROM governance_rule_active_versions WHERE code = 'mandatory-fields'`,
+    );
+    await queryRunner.query(
+      `DELETE FROM governance_rules WHERE code = 'mandatory-fields' AND version = 1`,
+    );
+
+    const setRepo = queryRunner.manager.getRepository(GovernanceRuleSet);
+    const ruleRepo = queryRunner.manager.getRepository(GovernanceRule);
+    const avRepo = queryRunner.manager.getRepository(GovernanceRuleActiveVersion);
+
+    const projectSet = await setRepo.findOne({
+      where: {
+        scopeType: ScopeType.SYSTEM,
+        entityType: GovernanceEntityType.PROJECT,
+        name: 'System PROJECT Governance Policies',
+      },
+    });
+    if (!projectSet) {
+      return;
+    }
+
+    const ensureRule = async (
+      code: string,
+      def: Record<string, unknown>,
+    ): Promise<void> => {
+      const existing = await ruleRepo.findOne({
+        where: { ruleSetId: projectSet.id, code, version: 1 },
+      });
+      if (existing) {
+        existing.ruleDefinition = def as any;
+        await ruleRepo.save(existing);
+        const av = await avRepo.findOne({
+          where: { ruleSetId: projectSet.id, code },
+        });
+        if (av) {
+          av.activeRuleId = existing.id;
+          await avRepo.save(av);
+        } else {
+          await avRepo.save(
+            avRepo.create({
+              ruleSetId: projectSet.id,
+              code,
+              activeRuleId: existing.id,
+            }),
+          );
+        }
+        return;
+      }
+      const rule = ruleRepo.create({
+        ruleSetId: projectSet.id,
+        code,
+        version: 1,
+        isActive: true,
+        ruleDefinition: def as any,
+        createdBy: null,
+      });
+      const saved = await ruleRepo.save(rule);
+      await avRepo.save(
+        avRepo.create({
+          ruleSetId: projectSet.id,
+          code,
+          activeRuleId: saved.id,
+        }),
+      );
+    };
+
+    await ensureRule('schedule-tolerance', SCHEDULE_TOLERANCE);
+    await ensureRule(
+      'resource-capacity-governance',
+      RESOURCE_CAPACITY,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    /* Forward-only catalog alignment. */
+  }
+}

--- a/zephix-backend/src/migrations/__tests__/18000000000070-RemovePmbokGovernanceRuleSetDescriptions.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000070-RemovePmbokGovernanceRuleSetDescriptions.spec.ts
@@ -1,0 +1,26 @@
+import { RemovePmbokGovernanceRuleSetDescriptions18000000000070 } from '../18000000000070-RemovePmbokGovernanceRuleSetDescriptions';
+
+describe('Migration 18000000000070 — neutralize governance_rule_sets.description branding', () => {
+  it('runs UPDATE on governance_rule_sets for legacy branded descriptions', async () => {
+    const queries: string[] = [];
+    const mockQueryRunner = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+      }),
+    };
+
+    const migration = new RemovePmbokGovernanceRuleSetDescriptions18000000000070();
+    await migration.up(mockQueryRunner as any);
+
+    expect(queries.some((q) => q.includes('UPDATE governance_rule_sets'))).toBe(true);
+    expect(queries.some((q) => q.includes('ILIKE'))).toBe(true);
+    expect(queries.some((q) => /'%pmbok%'/i.test(q))).toBe(true);
+  });
+
+  it('down is a no-op', async () => {
+    const mockQueryRunner = { query: jest.fn() };
+    const migration = new RemovePmbokGovernanceRuleSetDescriptions18000000000070();
+    await migration.down(mockQueryRunner as any);
+    expect(mockQueryRunner.query).not.toHaveBeenCalled();
+  });
+});

--- a/zephix-backend/src/migrations/__tests__/18000000000071-GovernanceCatalogNinePolicies.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000071-GovernanceCatalogNinePolicies.spec.ts
@@ -1,0 +1,49 @@
+import { GovernanceCatalogNinePolicies18000000000071 } from '../18000000000071-GovernanceCatalogNinePolicies';
+import { GovernanceRuleSet } from '../../modules/governance-rules/entities/governance-rule-set.entity';
+import { GovernanceRule } from '../../modules/governance-rules/entities/governance-rule.entity';
+import { GovernanceRuleActiveVersion } from '../../modules/governance-rules/entities/governance-rule-active-version.entity';
+
+describe('Migration 18000000000071 — nine-policy SYSTEM catalog alignment', () => {
+  it('runs scoped UPDATEs for known catalog codes', async () => {
+    const mockQueryRunner = {
+      query: jest.fn(async () => undefined),
+      manager: {
+        getRepository: jest.fn(),
+      },
+    };
+
+    const mockProjectSet = { id: 'proj-set-1' };
+    const setRepo = {
+      findOne: jest.fn().mockResolvedValue(mockProjectSet),
+    };
+    const ruleRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((x: unknown) => x),
+      save: jest.fn().mockResolvedValue({ id: 'new-rule' }),
+    };
+    const avRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((x: unknown) => x),
+      save: jest.fn().mockResolvedValue({}),
+    };
+
+    (mockQueryRunner.manager.getRepository as jest.Mock).mockImplementation(
+      (Entity: unknown) => {
+        if (Entity === GovernanceRuleSet) return setRepo;
+        if (Entity === GovernanceRule) return ruleRepo;
+        if (Entity === GovernanceRuleActiveVersion) return avRepo;
+        return {};
+      },
+    );
+
+    const migration = new GovernanceCatalogNinePolicies18000000000071();
+    await migration.up(mockQueryRunner as any);
+
+    const calls = (mockQueryRunner.query as jest.Mock).mock.calls as unknown[][];
+    expect(calls.some((c) => Array.isArray(c[1]) && c[1][1] === 'scope-change-control')).toBe(
+      true,
+    );
+    expect(calls.some((c) => String(c[0]).includes('mandatory-fields'))).toBe(true);
+    expect(setRepo.findOne).toHaveBeenCalled();
+  });
+});

--- a/zephix-backend/src/modules/governance-rules/services/__tests__/governance-template.service.spec.ts
+++ b/zephix-backend/src/modules/governance-rules/services/__tests__/governance-template.service.spec.ts
@@ -84,8 +84,8 @@ describe('GovernanceTemplateService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('GOVERNANCE_POLICY_CODES has 8 entries', () => {
-    expect(GOVERNANCE_POLICY_CODES.length).toBe(8);
+  it('GOVERNANCE_POLICY_CODES has 9 entries', () => {
+    expect(GOVERNANCE_POLICY_CODES.length).toBe(9);
   });
 
   it('getTemplateGovernance returns empty when no system rules resolve', async () => {
@@ -121,7 +121,7 @@ describe('GovernanceTemplateService', () => {
       addSelect: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([
         {
-          code: 'mandatory-fields',
+          code: 'scope-change-control',
           ruleSetId: 'ts-1',
           enforcementMode: 'BLOCK',
         },
@@ -142,21 +142,17 @@ describe('GovernanceTemplateService', () => {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
-      getOne: jest.fn().mockImplementation(() => {
-        const i = (ruleQb.getOne as jest.Mock).mock.calls.length - 1;
-        const code = GOVERNANCE_POLICY_CODES[i];
-        if (code === 'mandatory-fields') return Promise.resolve(systemRule);
-        return Promise.resolve(null);
-      }),
+      getOne: jest.fn().mockResolvedValue(systemRule),
     };
     (ruleRepo.createQueryBuilder as jest.Mock).mockReturnValue(ruleQb);
 
     const rows = await svc().getTemplateGovernance('tpl-1', 'org-1');
-    expect(rows).toHaveLength(1);
-    expect(rows[0].code).toBe('mandatory-fields');
-    expect(rows[0].enabled).toBe(true);
-    expect(rows[0].templateRuleSetId).toBe('ts-1');
-    expect(rows[0].enforcementMode).toBe('BLOCK');
+    expect(rows.length).toBe(GOVERNANCE_POLICY_CODES.length);
+    const enabled = rows.filter((r) => r.enabled);
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].code).toBe('scope-change-control');
+    expect(enabled[0].templateRuleSetId).toBe('ts-1');
+    expect(enabled[0].enforcementMode).toBe('BLOCK');
   });
 
   it('snapshotTemplateGovernanceToProject deletes PROJECT sets and returns when template has none', async () => {

--- a/zephix-backend/src/modules/governance-rules/services/__tests__/governance-template.service.spec.ts
+++ b/zephix-backend/src/modules/governance-rules/services/__tests__/governance-template.service.spec.ts
@@ -5,6 +5,12 @@ import {
   GOVERNANCE_POLICY_CODES,
 } from '../governance-template.service';
 import { GovernanceRuleResolverService } from '../governance-rule-resolver.service';
+import {
+  GovernanceRuleSet,
+  ScopeType,
+} from '../../entities/governance-rule-set.entity';
+import { GovernanceRule } from '../../entities/governance-rule.entity';
+import { GovernanceRuleActiveVersion } from '../../entities/governance-rule-active-version.entity';
 
 describe('GovernanceTemplateService', () => {
   const resolver = {
@@ -151,5 +157,68 @@ describe('GovernanceTemplateService', () => {
     expect(rows[0].enabled).toBe(true);
     expect(rows[0].templateRuleSetId).toBe('ts-1');
     expect(rows[0].enforcementMode).toBe('BLOCK');
+  });
+
+  it('snapshotTemplateGovernanceToProject deletes PROJECT sets and returns when template has none', async () => {
+    const setRepo = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    const manager = {
+      getRepository: jest.fn((E: unknown) => {
+        if (E === GovernanceRuleSet) return setRepo;
+        throw new Error('unexpected repository');
+      }),
+    };
+    await svc().snapshotTemplateGovernanceToProject(manager as any, 'tpl-1', {
+      id: 'proj-1',
+      organizationId: 'org-1',
+      workspaceId: 'ws-1',
+    });
+    expect(setRepo.delete).toHaveBeenCalledWith({
+      scopeType: ScopeType.PROJECT,
+      scopeId: 'proj-1',
+    });
+    expect(setRepo.find).toHaveBeenCalled();
+  });
+
+  it('snapshotTemplateGovernanceToProject clones template rules onto PROJECT', async () => {
+    const setRepo = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      find: jest.fn().mockResolvedValue([
+        { id: 'tpl-set-1', entityType: 'TASK', enforcementMode: 'WARN' },
+      ]),
+      create: jest.fn((x: unknown) => x),
+      save: jest.fn().mockResolvedValue({ id: 'new-set' }),
+    };
+    const avRepo = {
+      find: jest.fn().mockResolvedValue([{ code: 'c1', activeRuleId: 'r1' }]),
+      create: jest.fn((x: unknown) => x),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const ruleRepo = {
+      findOne: jest.fn().mockResolvedValue({
+        id: 'r1',
+        ruleDefinition: { conditions: [] },
+      }),
+      create: jest.fn((x: unknown) => x),
+      save: jest.fn().mockResolvedValue({ id: 'new-rule' }),
+    };
+    const manager = {
+      getRepository: jest.fn((E: unknown) => {
+        if (E === GovernanceRuleSet) return setRepo;
+        if (E === GovernanceRule) return ruleRepo;
+        if (E === GovernanceRuleActiveVersion) return avRepo;
+        throw new Error('unexpected repository');
+      }),
+    };
+    await svc().snapshotTemplateGovernanceToProject(manager as any, 'tpl-1', {
+      id: 'proj-1',
+      organizationId: 'org-1',
+      workspaceId: 'ws-1',
+    });
+    expect(setRepo.save).toHaveBeenCalled();
+    expect(ruleRepo.save).toHaveBeenCalled();
+    expect(avRepo.save).toHaveBeenCalled();
   });
 });

--- a/zephix-backend/src/modules/governance-rules/services/governance-template.service.ts
+++ b/zephix-backend/src/modules/governance-rules/services/governance-template.service.ts
@@ -35,7 +35,7 @@ export type GovernanceProjectSnapshotRef = {
   workspaceId: string;
 };
 
-/** Stable catalog codes seeded by migrations `18000000000067` + definition stabilization `18000000000068`. */
+/** Stable catalog codes: seed `18000000000067` + stabilization `68`–`71` (nine policies). */
 export const GOVERNANCE_POLICY_CODES: readonly string[] = [
   'phase-gate-approval',
   'deliverable-doc-required',
@@ -43,8 +43,9 @@ export const GOVERNANCE_POLICY_CODES: readonly string[] = [
   'task-completion-signoff',
   'wip-limits',
   'risk-threshold-alert',
-  'mandatory-fields',
   'budget-threshold',
+  'schedule-tolerance',
+  'resource-capacity-governance',
 ] as const;
 
 const POLICY_TITLES: Record<string, string> = {
@@ -54,8 +55,9 @@ const POLICY_TITLES: Record<string, string> = {
   'task-completion-signoff': 'Task completion sign-off',
   'wip-limits': 'WIP limits',
   'risk-threshold-alert': 'Risk threshold alert',
-  'mandatory-fields': 'Mandatory fields',
   'budget-threshold': 'Budget threshold',
+  'schedule-tolerance': 'Schedule tolerance',
+  'resource-capacity-governance': 'Resource capacity governance',
 };
 
 const POLICY_DESCRIPTIONS: Record<string, string> = {
@@ -70,10 +72,11 @@ const POLICY_DESCRIPTIONS: Record<string, string> = {
   'wip-limits': 'Maximum tasks in progress per assignee or column.',
   'risk-threshold-alert':
     'Alert when high-priority task count exceeds threshold.',
-  'mandatory-fields':
-    'Required fields must be filled before task leaves To Do.',
   'budget-threshold':
     'Alert when project costs exceed percentage of allocated budget.',
+  'schedule-tolerance': 'Schedule variance escalation when thresholds are exceeded.',
+  'resource-capacity-governance':
+    'Resource allocation governance against capacity limits.',
 };
 
 function governanceEnforcementRank(mode: string): number {

--- a/zephix-backend/src/modules/governance-rules/services/governance-template.service.ts
+++ b/zephix-backend/src/modules/governance-rules/services/governance-template.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, EntityManager } from 'typeorm';
 import { Template } from '../../templates/entities/template.entity';
 import {
   GovernanceRuleSet,
@@ -26,6 +26,13 @@ export type PolicyCatalogItem = {
   systemRuleSetId: string;
   templateRuleSetId: string | null;
   ruleDefinition: Record<string, unknown>;
+};
+
+/** Minimal project fields required to snapshot TEMPLATE governance onto PROJECT scope. */
+export type GovernanceProjectSnapshotRef = {
+  id: string;
+  organizationId: string;
+  workspaceId: string;
 };
 
 /** Stable catalog codes seeded by migrations `18000000000067` + definition stabilization `18000000000068`. */
@@ -116,6 +123,80 @@ export class GovernanceTemplateService {
       });
     }
     return tpl;
+  }
+
+  /**
+   * Snapshot TEMPLATE-scoped governance rule sets onto PROJECT scope inside the
+   * caller's transaction so template edits do not mutate running projects.
+   * Removes existing PROJECT-scoped sets for the project first.
+   */
+  async snapshotTemplateGovernanceToProject(
+    manager: EntityManager,
+    templateId: string,
+    project: GovernanceProjectSnapshotRef,
+  ): Promise<void> {
+    const setRepo = manager.getRepository(GovernanceRuleSet);
+    await setRepo.delete({
+      scopeType: ScopeType.PROJECT,
+      scopeId: project.id,
+    });
+
+    const templateSets = await setRepo.find({
+      where: {
+        scopeType: ScopeType.TEMPLATE,
+        scopeId: templateId,
+        isActive: true,
+      },
+    });
+    if (templateSets.length === 0) {
+      return;
+    }
+
+    const ruleRepo = manager.getRepository(GovernanceRule);
+    const avRepo = manager.getRepository(GovernanceRuleActiveVersion);
+
+    for (const templateSet of templateSets) {
+      const projectSet = setRepo.create({
+        organizationId: project.organizationId,
+        workspaceId: project.workspaceId,
+        scopeType: ScopeType.PROJECT,
+        scopeId: project.id,
+        entityType: templateSet.entityType,
+        name: `Project governance (${templateSet.entityType})`,
+        description: `Copied from template ${templateId}`,
+        enforcementMode: templateSet.enforcementMode,
+        isActive: true,
+        createdBy: null,
+      });
+      const savedSet = await setRepo.save(projectSet);
+
+      const avs = await avRepo.find({
+        where: { ruleSetId: templateSet.id },
+      });
+      for (const av of avs) {
+        const sourceRule = await ruleRepo.findOne({
+          where: { id: av.activeRuleId },
+        });
+        if (!sourceRule) continue;
+
+        const projectRule = ruleRepo.create({
+          ruleSetId: savedSet.id,
+          code: av.code,
+          version: 1,
+          isActive: true,
+          ruleDefinition: sourceRule.ruleDefinition,
+          createdBy: null,
+        });
+        const savedRule = await ruleRepo.save(projectRule);
+        await avRepo.save(
+          avRepo.create({
+            ruleSetId: savedSet.id,
+            code: av.code,
+            activeRuleId: savedRule.id,
+          }),
+        );
+      }
+    }
   }
 
   async getTemplateGovernance(

--- a/zephix-backend/src/modules/kpis/engine/kpi-calculators.ts
+++ b/zephix-backend/src/modules/kpis/engine/kpi-calculators.ts
@@ -4,8 +4,7 @@
  * Each calculator takes typed inputs and returns a KpiComputeResult.
  * No database access — data is fetched by the compute service and passed in.
  *
- * Every result includes engineVersion in valueJson for audit traceability
- * (PMBOK governance principle: auditable performance measurement).
+ * Every result includes engineVersion in valueJson for audit traceability.
  */
 
 export const KPI_ENGINE_VERSION = '1.0.0';

--- a/zephix-backend/src/modules/templates/services/__tests__/template-authoring.spec.ts
+++ b/zephix-backend/src/modules/templates/services/__tests__/template-authoring.spec.ts
@@ -6,6 +6,10 @@
 
 import { TemplatesService } from '../templates.service';
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Template } from '../../entities/template.entity';
+import { Workspace } from '../../../workspaces/entities/workspace.entity';
+import { Project } from '../../../projects/entities/project.entity';
+import { Task } from '../../../projects/entities/task.entity';
 import {
   VALID_TAB_IDS,
   VALID_DELIVERY_METHODS,
@@ -51,6 +55,7 @@ const createMockDataSource = (mockRepo: any) => ({
 const createMockKpisService = () => ({
   listTemplateKpis: jest.fn().mockResolvedValue([]),
   copyBindings: jest.fn().mockResolvedValue(3),
+  autoActivateForProject: jest.fn().mockResolvedValue(undefined),
 });
 
 describe('Wave 6: Template Authoring', () => {
@@ -58,6 +63,8 @@ describe('Wave 6: Template Authoring', () => {
   let mockRepo: any;
   let mockDataSource: any;
   let mockKpisService: any;
+  let mockGovernanceTemplate: { snapshotTemplateGovernanceToProject: jest.Mock };
+  let mockGovernanceResolver: { invalidateCache: jest.Mock };
 
   beforeEach(() => {
     mockRepo = {
@@ -69,6 +76,10 @@ describe('Wave 6: Template Authoring', () => {
 
     mockDataSource = createMockDataSource(mockRepo);
     mockKpisService = createMockKpisService();
+    mockGovernanceTemplate = {
+      snapshotTemplateGovernanceToProject: jest.fn().mockResolvedValue(undefined),
+    };
+    mockGovernanceResolver = { invalidateCache: jest.fn() };
 
     service = new TemplatesService(
       {} as any, // legacy ProjectTemplate repo (unused in unified methods)
@@ -76,6 +87,8 @@ describe('Wave 6: Template Authoring', () => {
       mockDataSource as any,
       { assertOrganizationId: () => 'org-1' } as any, // tenantContextService
       mockKpisService as any,
+      mockGovernanceTemplate as any,
+      mockGovernanceResolver as any,
     );
   });
 
@@ -288,6 +301,66 @@ describe('Wave 6: Template Authoring', () => {
       const waterfall = rows.filter((r: { name: string }) => r.name === 'Waterfall Project');
       expect(waterfall).toHaveLength(1);
       expect(waterfall[0].id).toBe('sys-wf');
+    });
+  });
+
+  describe('applyTemplateUnified governance snapshot', () => {
+    it('snapshots template governance after save and busts resolver cache', async () => {
+      const tplRepo = {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'sys-tpl-1',
+          isSystem: true,
+          isActive: true,
+          organizationId: null,
+          methodology: 'agile',
+          defaultGovernanceFlags: {},
+          taskTemplates: [],
+        }),
+      };
+      const workspaceRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'ws-1', organizationId: 'org-1' }),
+      };
+      const projectRepo = {
+        create: jest.fn((p: Record<string, unknown>) => p),
+        save: jest.fn().mockResolvedValue({
+          id: 'proj-new',
+          organizationId: 'org-1',
+          workspaceId: 'ws-1',
+          templateId: 'sys-tpl-1',
+        }),
+      };
+      const taskRepo = { count: jest.fn().mockResolvedValue(0) };
+
+      mockDataSource.transaction = jest.fn(async (cb: (m: unknown) => Promise<unknown>) => {
+        const manager = {
+          getRepository: jest.fn((ent: unknown) => {
+            if (ent === Template) return tplRepo;
+            if (ent === Workspace) return workspaceRepo;
+            if (ent === Project) return projectRepo;
+            if (ent === Task) return taskRepo;
+            return {};
+          }),
+          query: jest.fn().mockResolvedValue(undefined),
+        };
+        return cb(manager);
+      });
+
+      const out = await service.applyTemplateUnified(
+        'sys-tpl-1',
+        { name: 'P1', workspaceId: 'ws-1' },
+        'org-1',
+        'user-1',
+      );
+
+      expect(
+        mockGovernanceTemplate.snapshotTemplateGovernanceToProject,
+      ).toHaveBeenCalledWith(expect.anything(), 'sys-tpl-1', {
+        id: 'proj-new',
+        organizationId: 'org-1',
+        workspaceId: 'ws-1',
+      });
+      expect(mockGovernanceResolver.invalidateCache).toHaveBeenCalled();
+      expect(out.id).toBe('proj-new');
     });
   });
 

--- a/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
+++ b/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource, EntityManager } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { Template } from '../entities/template.entity';
 import { Project, ProjectState } from '../../projects/entities/project.entity';
 import { WorkPhase } from '../../work-management/entities/work-phase.entity';
@@ -26,13 +26,8 @@ import {
 } from '../dto/template-origin-metadata';
 import { normalizeTemplateStructure } from './template-structure-normalizer';
 import { normalizeTemplateTaskPriorityOrDefault } from './template-task-priority-normalizer';
-import {
-  GovernanceRuleSet,
-  ScopeType,
-} from '../../governance-rules/entities/governance-rule-set.entity';
-import { GovernanceRule } from '../../governance-rules/entities/governance-rule.entity';
-import { GovernanceRuleActiveVersion } from '../../governance-rules/entities/governance-rule-active-version.entity';
 import { GovernanceRuleResolverService } from '../../governance-rules/services/governance-rule-resolver.service';
+import { GovernanceTemplateService } from '../../governance-rules/services/governance-template.service';
 
 /**
  * Sprint 2.5: Phase 5.1 compliant template instantiation
@@ -57,6 +52,7 @@ export class TemplatesInstantiateV51Service {
     private readonly workspaceAccessService: WorkspaceAccessService,
     private readonly structureGuard: ProjectStructureGuardService,
     private readonly governanceRuleResolver: GovernanceRuleResolverService,
+    private readonly governanceTemplateService: GovernanceTemplateService,
   ) {}
 
   /**
@@ -543,7 +539,11 @@ export class TemplatesInstantiateV51Service {
         project.governanceSource = 'TEMPLATE';
       }
 
-      await this.copyTemplateGovernanceToProject(manager, template.id, project);
+      await this.governanceTemplateService.snapshotTemplateGovernanceToProject(
+        manager,
+        template.id,
+        project,
+      );
 
       await projectRepo.save(project);
 
@@ -558,79 +558,6 @@ export class TemplatesInstantiateV51Service {
     });
     this.governanceRuleResolver.invalidateCache();
     return result;
-  }
-
-  /**
-   * Snapshot TEMPLATE-scoped governance rule sets onto PROJECT scope so
-   * template edits do not mutate running projects.
-   */
-  private async copyTemplateGovernanceToProject(
-    manager: EntityManager,
-    templateId: string,
-    project: Project,
-  ): Promise<void> {
-    const setRepo = manager.getRepository(GovernanceRuleSet);
-    await setRepo.delete({
-      scopeType: ScopeType.PROJECT,
-      scopeId: project.id,
-    });
-
-    const templateSets = await setRepo.find({
-      where: {
-        scopeType: ScopeType.TEMPLATE,
-        scopeId: templateId,
-        isActive: true,
-      },
-    });
-    if (templateSets.length === 0) {
-      return;
-    }
-
-    const ruleRepo = manager.getRepository(GovernanceRule);
-    const avRepo = manager.getRepository(GovernanceRuleActiveVersion);
-
-    for (const templateSet of templateSets) {
-      const projectSet = setRepo.create({
-        organizationId: project.organizationId,
-        workspaceId: project.workspaceId,
-        scopeType: ScopeType.PROJECT,
-        scopeId: project.id,
-        entityType: templateSet.entityType,
-        name: `Project governance (${templateSet.entityType})`,
-        description: `Copied from template ${templateId}`,
-        enforcementMode: templateSet.enforcementMode,
-        isActive: true,
-        createdBy: null,
-      });
-      const savedSet = await setRepo.save(projectSet);
-
-      const avs = await avRepo.find({
-        where: { ruleSetId: templateSet.id },
-      });
-      for (const av of avs) {
-        const sourceRule = await ruleRepo.findOne({
-          where: { id: av.activeRuleId },
-        });
-        if (!sourceRule) continue;
-
-        const projectRule = ruleRepo.create({
-          ruleSetId: savedSet.id,
-          code: av.code,
-          version: 1,
-          isActive: true,
-          ruleDefinition: sourceRule.ruleDefinition,
-          createdBy: null,
-        });
-        const savedRule = await ruleRepo.save(projectRule);
-        await avRepo.save(
-          avRepo.create({
-            ruleSetId: savedSet.id,
-            code: av.code,
-            activeRuleId: savedRule.id,
-          }),
-        );
-      }
-    }
   }
 
   /**

--- a/zephix-backend/src/modules/templates/services/templates.service.ts
+++ b/zephix-backend/src/modules/templates/services/templates.service.ts
@@ -31,6 +31,8 @@ import {
   isAdminRole,
 } from '../../../shared/enums/platform-roles.enum';
 import { TemplateKpisService } from '../../kpis/services/template-kpis.service';
+import { GovernanceTemplateService } from '../../governance-rules/services/governance-template.service';
+import { GovernanceRuleResolverService } from '../../governance-rules/services/governance-rule-resolver.service';
 
 type LockState = 'UNLOCKED' | 'LOCKED';
 
@@ -66,6 +68,8 @@ export class TemplatesService {
     private readonly dataSource: DataSource,
     private readonly tenantContextService: TenantContextService,
     private readonly templateKpisService: TemplateKpisService,
+    private readonly governanceTemplateService: GovernanceTemplateService,
+    private readonly governanceRuleResolver: GovernanceRuleResolverService,
   ) {}
 
   /**
@@ -563,6 +567,7 @@ export class TemplatesService {
   /**
    * Wave 6: Apply a template from `templates` table to create a project.
    * This replaces the legacy `applyTemplate` for admin use.
+   * Declarative governance is snapshotted onto the project (same as v5.1 instantiate).
    */
   async applyTemplateUnified(
     templateId: string,
@@ -575,7 +580,7 @@ export class TemplatesService {
     organizationId: string,
     userId: string,
   ): Promise<Project> {
-    return this.dataSource.transaction(async (manager) => {
+    const saved = await this.dataSource.transaction(async (manager) => {
       const tplRepo = manager.getRepository(Template);
       const workspaceRepo = manager.getRepository(Workspace);
       const projectRepo = manager.getRepository(Project);
@@ -642,6 +647,16 @@ export class TemplatesService {
 
       const savedProject = await projectRepo.save(project);
 
+      await this.governanceTemplateService.snapshotTemplateGovernanceToProject(
+        manager,
+        template.id,
+        {
+          id: savedProject.id,
+          organizationId: savedProject.organizationId,
+          workspaceId: savedProject.workspaceId,
+        },
+      );
+
       // 4. Create tasks from template
       if (template.taskTemplates && template.taskTemplates.length > 0) {
         const existingTaskCount = await manager
@@ -698,6 +713,8 @@ export class TemplatesService {
 
       return savedProject;
     });
+    this.governanceRuleResolver.invalidateCache();
+    return saved;
   }
 
   /**

--- a/zephix-backend/src/modules/work-management/services/work-tasks.service.spec.ts
+++ b/zephix-backend/src/modules/work-management/services/work-tasks.service.spec.ts
@@ -22,6 +22,7 @@ import { WorkspaceMember } from '../../workspaces/entities/workspace-member.enti
 import { GovernanceRuleEngineService } from '../../governance-rules/services/governance-rule-engine.service';
 import { GovernanceExceptionsService } from '../../governance-exceptions/governance-exceptions.service';
 import { EvaluationDecision } from '../../governance-rules/entities/governance-evaluation.entity';
+import { WorkspaceRoleGuardService } from '../../workspace-access/workspace-role-guard.service';
 
 describe('WorkTasksService', () => {
   let service: WorkTasksService;
@@ -154,6 +155,10 @@ describe('WorkTasksService', () => {
             create: mockGovernanceExceptionsCreate,
             findPendingGovernanceRuleForTaskTransition: mockGovernanceFindPending,
           },
+        },
+        {
+          provide: WorkspaceRoleGuardService,
+          useValue: { getWorkspaceRole: jest.fn().mockResolvedValue(null) },
         },
       ],
     }).compile();

--- a/zephix-backend/src/modules/work-management/services/work-tasks.service.ts
+++ b/zephix-backend/src/modules/work-management/services/work-tasks.service.ts
@@ -117,6 +117,7 @@ import { DOMAIN_EVENTS } from '../../kpi-queue/constants/queue.constants';
 import { User } from '../../users/entities/user.entity';
 import { WorkspaceMember } from '../../workspaces/entities/workspace-member.entity';
 import { OrgPolicyService } from '../../../organizations/services/org-policy.service';
+import { WorkspaceRoleGuardService } from '../../workspace-access/workspace-role-guard.service';
 import { v5 as uuidv5 } from 'uuid';
 
 interface AuthContext {
@@ -158,6 +159,7 @@ export class WorkTasksService {
     @InjectRepository(Project)
     private readonly projectRepository: Repository<Project>,
     private readonly auditService: AuditService,
+    private readonly workspaceRoleGuard: WorkspaceRoleGuardService,
     @Optional()
     private readonly governanceEngine?: GovernanceRuleEngineService,
     @Optional()
@@ -208,6 +210,24 @@ export class WorkTasksService {
     }
 
     return workspaceId;
+  }
+
+  private async governanceActor(
+    auth: AuthContext,
+    workspaceId: string,
+  ): Promise<{
+    userId: string;
+    platformRole: string;
+    workspaceRole?: string;
+  }> {
+    const platformRole = auth.platformRole ?? 'MEMBER';
+    let workspaceRole: string | undefined;
+    const r = await this.workspaceRoleGuard.getWorkspaceRole(
+      workspaceId,
+      auth.userId,
+    );
+    if (r) workspaceRole = r;
+    return { userId: auth.userId, platformRole, workspaceRole };
   }
 
   /**
@@ -565,10 +585,7 @@ export class WorkTasksService {
           projectState: projectForGov?.state,
           parentTaskId: dto.parentTaskId ?? null,
         },
-        actor: {
-          userId: auth.userId,
-          platformRole: auth.platformRole ?? 'MEMBER',
-        },
+        actor: await this.governanceActor(auth, workspaceId),
         projectId: dto.projectId,
         templateId: projectForGov?.templateId ?? undefined,
       });
@@ -882,10 +899,7 @@ export class WorkTasksService {
           fromStatus: task.status,
           toStatus: dto.status,
           task: task as any,
-          actor: {
-            userId: auth.userId,
-            platformRole: auth.platformRole ?? 'MEMBER',
-          },
+          actor: await this.governanceActor(auth, workspaceId),
           projectId: task.projectId,
           templateId: templateIdForGov,
           overrideReason: (dto as any).governanceOverrideReason,
@@ -1384,6 +1398,8 @@ export class WorkTasksService {
         templateRows.map((p) => [p.id, p.templateId]),
       );
 
+      const govActor = await this.governanceActor(auth, workspaceId);
+
       const blockedTasks: Array<{
         taskId: string;
         taskTitle: string;
@@ -1399,10 +1415,7 @@ export class WorkTasksService {
           fromStatus: task.status,
           toStatus: dto.status,
           task: task as unknown as Record<string, unknown>,
-          actor: {
-            userId: auth.userId,
-            platformRole: auth.platformRole ?? 'MEMBER',
-          },
+          actor: govActor,
           projectId: task.projectId,
           templateId: templateByProject.get(task.projectId) ?? undefined,
         });

--- a/zephix-frontend/src/features/administration/components/TemplateDetailPanel.tsx
+++ b/zephix-frontend/src/features/administration/components/TemplateDetailPanel.tsx
@@ -455,7 +455,6 @@ function TemplateGovernanceTab({ template }: { template: TemplatePanelData }) {
                   ) : null}
                 </div>
                 <p className="mt-0.5 text-xs text-slate-500">{meta.description}</p>
-                <p className="mt-1 text-[10px] text-slate-400">{meta.pmbok}</p>
                 <div className="mt-2 flex flex-wrap gap-1">
                   {meta.methodologies.map((m) => (
                     <span

--- a/zephix-frontend/src/features/administration/constants/governance-policies.ts
+++ b/zephix-frontend/src/features/administration/constants/governance-policies.ts
@@ -9,7 +9,6 @@ export type GovernancePolicyUiMeta = {
   description: string;
   tier: 1 | 2 | 3;
   methodologies: string[];
-  pmbok: string;
 };
 
 /** Display-only metadata; policy codes must match backend SYSTEM catalog. */
@@ -20,7 +19,6 @@ export const POLICY_UI_META: Record<string, GovernancePolicyUiMeta> = {
       "Block phase advancement until deliverables reviewed and approved.",
     tier: 2,
     methodologies: ["waterfall", "hybrid"],
-    pmbok: "PMBOK 8: Governance domain — Focus Areas (phase gates)",
   },
   "scope-change-control": {
     displayName: "Scope change control",
@@ -28,49 +26,42 @@ export const POLICY_UI_META: Record<string, GovernancePolicyUiMeta> = {
       "When enabled on a template, only organization admins can create tasks on projects from that template.",
     tier: 1,
     methodologies: ["waterfall", "hybrid"],
-    pmbok: "PMBOK 8: Governance + Scope domains — Integrated Change Control",
   },
   "task-completion-signoff": {
     displayName: "Task completion sign-off",
     description: "Tasks cannot move to Done without an assignee.",
     tier: 1,
     methodologies: ["waterfall", "agile", "kanban", "hybrid", "scrum"],
-    pmbok: "PMBOK 8: Governance domain — Quality principle",
   },
   "wip-limits": {
     displayName: "WIP limits",
     description: "Maximum tasks in progress per assignee or column.",
     tier: 2,
     methodologies: ["kanban", "agile", "scrum"],
-    pmbok: "PMBOK 8: Resources domain — flow governance",
   },
   "risk-threshold-alert": {
     displayName: "Risk threshold alert",
     description: "Alert when high-priority task count exceeds threshold.",
     tier: 2,
     methodologies: ["waterfall", "agile", "kanban", "hybrid", "scrum"],
-    pmbok: "PMBOK 8: Risk domain — governance escalation",
   },
   "budget-threshold": {
     displayName: "Budget threshold",
     description: "Alert when project costs exceed percentage of budget.",
     tier: 3,
     methodologies: ["waterfall", "hybrid"],
-    pmbok: "PMBOK 8: Finance domain",
   },
   "deliverable-doc-required": {
     displayName: "Deliverable document required",
     description: "Phase cannot close without attached documents.",
     tier: 2,
     methodologies: ["waterfall", "hybrid"],
-    pmbok: "PMBOK 8: Governance domain — evidence-based gates",
   },
   "mandatory-fields": {
     displayName: "Mandatory fields",
     description: "Required fields must be filled before task leaves To Do.",
     tier: 1,
     methodologies: ["waterfall", "agile", "kanban", "hybrid", "scrum"],
-    pmbok: "PMBOK 8: Governance domain — data governance",
   },
 };
 

--- a/zephix-frontend/src/features/administration/constants/governance-policies.ts
+++ b/zephix-frontend/src/features/administration/constants/governance-policies.ts
@@ -11,57 +11,62 @@ export type GovernancePolicyUiMeta = {
   methodologies: string[];
 };
 
-/** Display-only metadata; policy codes must match backend SYSTEM catalog. */
+/** Display-only metadata; policy codes must match backend SYSTEM catalog (nine policies). */
 export const POLICY_UI_META: Record<string, GovernancePolicyUiMeta> = {
-  "phase-gate-approval": {
-    displayName: "Phase gate approval",
-    description:
-      "Block phase advancement until deliverables reviewed and approved.",
-    tier: 2,
-    methodologies: ["waterfall", "hybrid"],
-  },
   "scope-change-control": {
-    displayName: "Scope change control",
+    displayName: "Integrated change control",
     description:
-      "When enabled on a template, only organization admins can create tasks on projects from that template.",
+      "Task creation requires organization or workspace admin approval when this policy is active on the template.",
     tier: 1,
     methodologies: ["waterfall", "hybrid"],
   },
   "task-completion-signoff": {
     displayName: "Task completion sign-off",
-    description: "Tasks cannot move to Done without an assignee.",
+    description: "Task must have an assignee before marking as Done.",
     tier: 1,
     methodologies: ["waterfall", "agile", "kanban", "hybrid", "scrum"],
   },
+  "phase-gate-approval": {
+    displayName: "Phase gate approval",
+    description: "Phase advancement requires approval (enforcement wiring in a future release).",
+    tier: 2,
+    methodologies: ["waterfall", "hybrid"],
+  },
+  "deliverable-doc-required": {
+    displayName: "Deliverable document required",
+    description: "Documents required before phase closure (enforcement wiring in a future release).",
+    tier: 2,
+    methodologies: ["waterfall", "hybrid"],
+  },
   "wip-limits": {
     displayName: "WIP limits",
-    description: "Maximum tasks in progress per assignee or column.",
+    description: "Maximum tasks in progress (enforcement wiring in a future release).",
     tier: 2,
     methodologies: ["kanban", "agile", "scrum"],
   },
   "risk-threshold-alert": {
     displayName: "Risk threshold alert",
-    description: "Alert when high-priority task count exceeds threshold.",
+    description: "High-priority task count alert (enforcement wiring in a future release).",
     tier: 2,
     methodologies: ["waterfall", "agile", "kanban", "hybrid", "scrum"],
   },
   "budget-threshold": {
     displayName: "Budget threshold",
-    description: "Alert when project costs exceed percentage of budget.",
+    description: "Budget governance when project costs exceed thresholds (coming soon).",
     tier: 3,
     methodologies: ["waterfall", "hybrid"],
   },
-  "deliverable-doc-required": {
-    displayName: "Deliverable document required",
-    description: "Phase cannot close without attached documents.",
-    tier: 2,
+  "schedule-tolerance": {
+    displayName: "Schedule tolerance",
+    description: "Schedule variance escalation (coming soon).",
+    tier: 3,
     methodologies: ["waterfall", "hybrid"],
   },
-  "mandatory-fields": {
-    displayName: "Mandatory fields",
-    description: "Required fields must be filled before task leaves To Do.",
-    tier: 1,
-    methodologies: ["waterfall", "agile", "kanban", "hybrid", "scrum"],
+  "resource-capacity-governance": {
+    displayName: "Resource capacity governance",
+    description: "Resource allocation governance (coming soon).",
+    tier: 3,
+    methodologies: ["waterfall", "agile", "hybrid", "scrum"],
   },
 };
 

--- a/zephix-frontend/src/features/administration/pages/AdministrationGovernancePage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationGovernancePage.tsx
@@ -128,7 +128,6 @@ function PoliciesTab() {
                     <p className="mt-1 text-[10px] font-medium uppercase tracking-wide text-gray-500">
                       {policy.entityType}
                     </p>
-                    <p className="mt-1 text-[10px] text-gray-400">{meta.pmbok}</p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {meta.methodologies.map((m) => (
                         <span

--- a/zephix-frontend/src/features/projects/tabs/ProjectGanttTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectGanttTab.tsx
@@ -283,8 +283,8 @@ export const ProjectGanttTab: React.FC = () => {
           <p className="font-medium text-slate-700">No bars on the timeline yet</p>
           <p className="text-sm text-slate-500 mt-2 max-w-lg mx-auto">
             Gantt charts plot work against time. Tasks need at least a planned or actual
-            start/end (or due date) before they appear here — consistent with schedule
-            practice in PMBOK-style planning.
+            start/end (or due date) before they appear here — consistent with common
+            schedule and baseline planning practice.
           </p>
           {unscheduledCount > 0 && projectId && (
             <div className="mt-6 text-left max-w-md mx-auto border border-slate-100 rounded-lg p-4 bg-slate-50/80">


### PR DESCRIPTION
Governance stabilization: workspace role in governance actor, migration 71 (nine SYSTEM policies), removed mandatory-fields, added schedule-tolerance and resource-capacity-governance, honest tier labels in admin UI, template governance snapshot on applyTemplateUnified, external methodology branding removed from product surfaces.

Made with [Cursor](https://cursor.com)