### PR TITLE
fix(work-management): list parity, cap banner, cascade delete, board quick create

### DIFF
--- a/zephix-backend/src/modules/work-management/services/work-tasks.service.spec.ts
+++ b/zephix-backend/src/modules/work-management/services/work-tasks.service.spec.ts
@@ -831,12 +831,67 @@ describe('WorkTasksService', () => {
         metadata: { archived: false },
       } as unknown as WorkTask;
       taskRepo.findOne.mockResolvedValue(task);
+      taskRepo.find.mockResolvedValue([]);
       taskRepo.save.mockImplementation(async (savedTask) => savedTask);
 
       await service.deleteTask(auth, workspaceId, task.id);
 
       expect(task.deletedAt).toBeInstanceOf(Date);
       expect(task.deletedByUserId).toBe(auth.userId);
+    });
+
+    it('delete action soft-deletes descendant subtasks', async () => {
+      const parentId = 'task-delete-parent';
+      const task = {
+        id: parentId,
+        workspaceId,
+        projectId: 'proj-1',
+        status: TaskStatus.TODO,
+        title: 'parent',
+        deletedAt: null,
+        deletedByUserId: null,
+        metadata: null,
+      } as unknown as WorkTask;
+      const child1 = {
+        id: 'child-1',
+        workspaceId,
+        projectId: 'proj-1',
+        parentTaskId: parentId,
+        title: 'c1',
+        deletedAt: null,
+        deletedByUserId: null,
+      } as unknown as WorkTask;
+      const child2 = {
+        id: 'child-2',
+        workspaceId,
+        projectId: 'proj-1',
+        parentTaskId: parentId,
+        title: 'c2',
+        deletedAt: null,
+        deletedByUserId: null,
+      } as unknown as WorkTask;
+
+      taskRepo.findOne.mockResolvedValue(task);
+      taskRepo.find.mockImplementation((opts: any) => {
+        const pid = opts?.where?.parentTaskId;
+        if (pid === parentId) {
+          return Promise.resolve([child1, child2]);
+        }
+        if (pid === 'child-1' || pid === 'child-2') {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+      taskRepo.save.mockImplementation(async (savedTask) => savedTask);
+
+      await service.deleteTask(auth, workspaceId, parentId);
+
+      expect(task.deletedAt).toBeInstanceOf(Date);
+      expect(child1.deletedAt).toBeInstanceOf(Date);
+      expect(child1.deletedByUserId).toBe(auth.userId);
+      expect(child2.deletedAt).toBeInstanceOf(Date);
+      expect(child2.deletedByUserId).toBe(auth.userId);
+      expect(taskRepo.save).toHaveBeenCalledTimes(3);
     });
 
     it('archived and deleted states remain distinct', async () => {
@@ -855,6 +910,7 @@ describe('WorkTasksService', () => {
       } as WorkTask;
 
       taskRepo.findOne.mockResolvedValue(task);
+      taskRepo.find.mockResolvedValue([]);
       taskRepo.save.mockImplementation(async (savedTask) => savedTask);
 
       await service.updateTask(auth, workspaceId, task.id, {

--- a/zephix-backend/src/modules/work-management/services/work-tasks.service.ts
+++ b/zephix-backend/src/modules/work-management/services/work-tasks.service.ts
@@ -1579,6 +1579,44 @@ export class WorkTasksService {
     return result;
   }
 
+  /**
+   * When a parent task is soft-deleted, soft-delete all descendants so
+   * subtasks are not left active with a deleted parent (workspace UX + data hygiene).
+   */
+  private async cascadeSoftDeleteDescendants(
+    auth: AuthContext,
+    workspaceId: string,
+    parentId: string,
+  ): Promise<void> {
+    const children = await this.taskRepo.find({
+      where: {
+        workspaceId,
+        parentTaskId: parentId,
+        deletedAt: IsNull(),
+      },
+    });
+    for (const child of children) {
+      child.deletedAt = new Date();
+      child.deletedByUserId = auth.userId;
+      await this.taskRepo.save(child);
+
+      if (this.domainEventEmitter) {
+        const organizationId = this.tenantContext.assertOrganizationId();
+        this.domainEventEmitter
+          .emit(DOMAIN_EVENTS.TASK_DELETED, {
+            workspaceId,
+            organizationId,
+            projectId: child.projectId,
+            entityId: child.id,
+            entityType: 'TASK',
+          })
+          .catch((err) => this.logger.warn(`Domain event emit failed: ${err}`));
+      }
+
+      await this.cascadeSoftDeleteDescendants(auth, workspaceId, child.id);
+    }
+  }
+
   async deleteTask(
     auth: AuthContext,
     workspaceId: string,
@@ -1607,6 +1645,8 @@ export class WorkTasksService {
     task.deletedAt = new Date();
     task.deletedByUserId = auth.userId;
     await this.taskRepo.save(task);
+
+    await this.cascadeSoftDeleteDescendants(auth, workspaceId, id);
 
     // Emit activity for audit trail
     await this.activityService.record(

--- a/zephix-frontend/src/features/projects/components/TaskListSection.tsx
+++ b/zephix-frontend/src/features/projects/components/TaskListSection.tsx
@@ -60,6 +60,9 @@ function tempId(): string {
 const ERR_WORKSPACE_REQUIRED = 'WORKSPACE_REQUIRED';
 const ERR_VALIDATION_ERROR = 'VALIDATION_ERROR';
 
+/** Matches backend list cap and Waterfall/Board loads (see work-tasks MAX_LIMIT). */
+const WORK_TASK_LIST_PAGE_SIZE = 200;
+
 // Extract error details from API response
 function getErrorDetails(error: any): { code?: string; message?: string; invalidTransitions?: any[] } {
   const data = error?.response?.data || error;
@@ -91,6 +94,8 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
   const { isReadOnly } = useWorkspaceRole(workspaceId);
   const { getWorkspaceMembers, setWorkspaceMembers, activeWorkspaceId } = useWorkspaceStore();
   const [tasks, setTasks] = useState<WorkTask[]>([]);
+  /** True when server reports more tasks than fit in one page at WORK_TASK_LIST_PAGE_SIZE. */
+  const [taskListMayBeIncomplete, setTaskListMayBeIncomplete] = useState(false);
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -238,9 +243,10 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
 
     if (!silent) setLoading(true);
     try {
-      const result = await listTasks({ projectId });
+      const result = await listTasks({ projectId, limit: WORK_TASK_LIST_PAGE_SIZE });
       const items = Array.isArray(result.items) ? result.items : [];
       setTasks(items);
+      setTaskListMayBeIncomplete(result.total > items.length);
       // Preserve selections: filter to only IDs that still exist
       setSelectedTaskIds((prev) => new Set([...prev].filter((id) => items.some((task) => task.id === id))));
     } catch (error: any) {
@@ -699,8 +705,9 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
         // Refresh task list to reflect changes
         invalidateStatsCache(projectId);
         window.dispatchEvent(new CustomEvent('task:changed', { detail: { projectId } }));
-        const refreshed = await listTasks({ projectId });
+        const refreshed = await listTasks({ projectId, limit: WORK_TASK_LIST_PAGE_SIZE });
         setTasks(refreshed.items);
+        setTaskListMayBeIncomplete(refreshed.total > refreshed.items.length);
       } catch (bulkError: any) {
         const { code, message, invalidTransitions } = getErrorDetails(bulkError);
 
@@ -779,11 +786,14 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
         window.dispatchEvent(new CustomEvent('task:changed', { detail: { projectId } }));
         // Refresh deleted panel if open to show newly deleted tasks
         refreshDeletedPanelIfOpen();
+        // Reload from server so cascaded child deletes and caps stay consistent
+        await loadTasks(true);
       }
 
       if (failedIds.size > 0) {
-        // FIX #2: Restore from snapshot, keeping original order, filtering out succeeded
-        setTasks(snapshotBeforeDelete.filter(t => !succeededIds.has(t.id)));
+        if (succeededIds.size === 0) {
+          setTasks(snapshotBeforeDelete);
+        }
 
         const firstRejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
         const { code, message } = getErrorDetails(firstRejected?.reason);
@@ -825,16 +835,42 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
 
     setDeletedLoading(true);
     try {
-      // RISK #1 MITIGATION: Use high limit to get all deleted tasks for this project.
-      // Client-side filtering means we need all rows. If backend paginates,
-      // we might miss some deleted tasks. Using limit=500 as reasonable max for MVP.
-      // TODO: Add server-side deletedOnly=true support for proper pagination.
-      const result = await listTasks({ projectId, includeDeleted: true, limit: 500 });
-      // Harden: ensure items is an array before filtering
-      const items = Array.isArray(result.items) ? result.items : [];
-      // Filter to only deleted tasks (deletedAt is not null)
-      const deleted = items.filter(t => t.deletedAt !== null);
+      const PAGE = WORK_TASK_LIST_PAGE_SIZE;
+      const MAX_PAGES = 25;
+      const byId = new Map<string, WorkTask>();
+      let offset = 0;
+      let hitPageCap = false;
+      for (let p = 0; p < MAX_PAGES; p++) {
+        const result = await listTasks({
+          projectId,
+          includeDeleted: true,
+          limit: PAGE,
+          offset,
+        });
+        const items = Array.isArray(result.items) ? result.items : [];
+        for (const t of items) {
+          if (t.deletedAt) {
+            byId.set(t.id, t);
+          }
+        }
+        if (items.length < PAGE) {
+          break;
+        }
+        offset += PAGE;
+        if (p === MAX_PAGES - 1) {
+          hitPageCap = true;
+          break;
+        }
+      }
+      const deleted = Array.from(byId.values()).sort((a, b) => {
+        const ta = a.deletedAt ? new Date(a.deletedAt).getTime() : 0;
+        const tb = b.deletedAt ? new Date(b.deletedAt).getTime() : 0;
+        return tb - ta;
+      });
       setDeletedTasks(deleted);
+      if (hitPageCap) {
+        toast.info('Not all deleted tasks could be loaded in one session (page limit reached).');
+      }
     } catch (error: any) {
       console.error('Failed to load deleted tasks:', error);
       const { code } = getErrorDetails(error);
@@ -1004,6 +1040,15 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
               </span>
             )}
           </div>
+        </div>
+      )}
+
+      {taskListMayBeIncomplete && (
+        <div
+          className="mb-4 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-center text-xs text-amber-800"
+          data-testid="task-list-limit-banner"
+        >
+          Showing first {WORK_TASK_LIST_PAGE_SIZE} tasks. Some tasks may not be visible.
         </div>
       )}
 

--- a/zephix-frontend/src/features/projects/tabs/ProjectBoardTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectBoardTab.tsx
@@ -15,6 +15,7 @@ import { platformRoleFromUser } from '@/utils/roles';
 import {
   listTasks,
   updateTask,
+  createTask,
   getWorkflowConfig,
   type WorkTask,
   type WorkTaskStatus,
@@ -40,6 +41,9 @@ function canDragTask(platformRole?: string): boolean {
   return platformRole === 'ADMIN' || platformRole === 'MEMBER';
 }
 
+/** Backend listTasks max page size (matches work-tasks MAX_LIMIT). */
+const WORK_TASK_LIST_PAGE_SIZE = 200;
+
 /* ─── Board Component ───────────────────────────────────────────────── */
 
 export const ProjectBoardTab: React.FC = () => {
@@ -50,6 +54,7 @@ export const ProjectBoardTab: React.FC = () => {
   const isDragAllowed = canDragTask(platformRoleFromUser(user));
 
   const [tasks, setTasks] = useState<WorkTask[]>([]);
+  const [taskListMayBeIncomplete, setTaskListMayBeIncomplete] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [wipConfig, setWipConfig] = useState<EffectiveLimits | null>(null);
@@ -61,6 +66,9 @@ export const ProjectBoardTab: React.FC = () => {
   // WIP inline warnings
   const [wipWarning, setWipWarning] = useState<Record<string, string | null>>({});
 
+  const [creatingInColumn, setCreatingInColumn] = useState<WorkTaskStatus | null>(null);
+  const quickCreateSubmitLock = useRef(false);
+
   /* ── Load Data ─────────────────────────────────────────────────── */
 
   const loadTasks = useCallback(async () => {
@@ -68,8 +76,14 @@ export const ProjectBoardTab: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const result = await listTasks({ projectId, limit: 200, sortBy: 'rank', sortDir: 'asc' });
+      const result = await listTasks({
+        projectId,
+        limit: WORK_TASK_LIST_PAGE_SIZE,
+        sortBy: 'rank',
+        sortDir: 'asc',
+      });
       setTasks(result.items);
+      setTaskListMayBeIncomplete(result.total > result.items.length);
     } catch (err: any) {
       console.error('Board: failed to load tasks', err);
       setError(err?.message || 'Failed to load tasks');
@@ -92,6 +106,25 @@ export const ProjectBoardTab: React.FC = () => {
     loadTasks();
     loadWipConfig();
   }, [loadTasks, loadWipConfig]);
+
+  const submitBoardQuickCreate = useCallback(
+    async (status: WorkTaskStatus, rawTitle: string) => {
+      const title = rawTitle.trim();
+      if (!projectId || !title || quickCreateSubmitLock.current) return;
+      quickCreateSubmitLock.current = true;
+      try {
+        await createTask({ projectId, title, status });
+        await loadTasks();
+        setCreatingInColumn(null);
+      } catch (err: any) {
+        console.error('Board quick create failed', err);
+        toast.error(err?.response?.data?.message || err?.message || 'Failed to create task');
+      } finally {
+        quickCreateSubmitLock.current = false;
+      }
+    },
+    [projectId, loadTasks],
+  );
 
   /* ── Drag Handlers ─────────────────────────────────────────────── */
 
@@ -246,6 +279,15 @@ export const ProjectBoardTab: React.FC = () => {
         )}
       </div>
 
+      {taskListMayBeIncomplete && (
+        <div
+          className="mb-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-center text-xs text-amber-800"
+          data-testid="board-task-limit-banner"
+        >
+          Showing first {WORK_TASK_LIST_PAGE_SIZE} tasks. Some tasks may not be visible.
+        </div>
+      )}
+
       {/* Columns */}
       <div className="grid grid-cols-1 md:grid-cols-5 gap-4 min-h-[400px]">
         {grouped.map(col => {
@@ -315,6 +357,52 @@ export const ProjectBoardTab: React.FC = () => {
                   ))
                 )}
               </div>
+
+              {isDragAllowed && (
+                <div className="mt-2 px-2 pb-2">
+                  {creatingInColumn === col.status ? (
+                    <input
+                      type="text"
+                      autoFocus
+                      placeholder="Task title…"
+                      disabled={loading}
+                      className="w-full rounded border border-slate-200 px-2 py-1 text-sm"
+                      data-testid={`board-quick-create-${col.status}`}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') {
+                          e.preventDefault();
+                          setCreatingInColumn(null);
+                        }
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          void submitBoardQuickCreate(col.status, e.currentTarget.value);
+                        }
+                      }}
+                      onBlur={(e) => {
+                        if (quickCreateSubmitLock.current) {
+                          setCreatingInColumn(null);
+                          return;
+                        }
+                        const v = e.currentTarget.value.trim();
+                        if (v) {
+                          void submitBoardQuickCreate(col.status, v);
+                        } else {
+                          setCreatingInColumn(null);
+                        }
+                      }}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setCreatingInColumn(col.status)}
+                      className="w-full rounded px-2 py-1 text-left text-xs text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+                      data-testid={`board-add-task-${col.status}`}
+                    >
+                      + Add task
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           );
         })}

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -305,6 +305,9 @@ const READ_ONLY_COLUMNS: ReadonlySet<ColumnKey> = new Set([
  */
 const PHYSICAL_COLUMN_COUNT = COLUMN_ORDER.length + 2;
 
+/** Backend listTasks max page size (matches work-tasks MAX_LIMIT). */
+const WORK_TASK_LIST_PAGE_SIZE = 200;
+
 interface WaterfallTableProps {
   projectId: string;
   workspaceId: string;
@@ -327,6 +330,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
 
   const [phases, setPhases] = useState<WaterfallPhase[]>([]);
   const [tasks, setTasks] = useState<WorkTask[]>([]);
+  const [taskListMayBeIncomplete, setTaskListMayBeIncomplete] = useState(false);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -458,7 +462,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
         // 400 Bad Request the moment WaterfallTable mounted, which is the
         // root cause of the operator's `api/work/tasks?...&limit=500 → 400`
         // console error and the resulting empty / "/404" landing.
-        listTasks({ projectId, limit: 200 }),
+        listTasks({ projectId, limit: WORK_TASK_LIST_PAGE_SIZE }),
         listWorkspaceMembers(workspaceId).catch(() => [] as WorkspaceMember[]),
       ]);
 
@@ -483,6 +487,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
         })),
       );
       setTasks(taskRes.items);
+      setTaskListMayBeIncomplete(taskRes.total > taskRes.items.length);
       setMembers(memberRes ?? []);
 
       // Phase 3 (2026-04-08) — dependency fan-out removed alongside the
@@ -1487,6 +1492,15 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
        * all come back together as one cohesive feature.
        */}
       </div>
+
+      {taskListMayBeIncomplete && (
+        <div
+          className="mt-2 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-center text-xs text-amber-800"
+          data-testid="waterfall-task-limit-banner"
+        >
+          Showing first {WORK_TASK_LIST_PAGE_SIZE} tasks. Some tasks may not be visible.
+        </div>
+      )}
 
       {/*
        * Phase 7 — Task detail side panel.

--- a/zephix-frontend/src/features/work-management/workTasks.api.ts
+++ b/zephix-frontend/src/features/work-management/workTasks.api.ts
@@ -159,6 +159,8 @@ export interface ListTasksResult {
 export interface CreateTaskInput {
   projectId: string;
   title: string;
+  /** When omitted, backend defaults to TODO. */
+  status?: WorkTaskStatus;
   description?: string;
   phaseId?: string;
   /**
@@ -406,7 +408,7 @@ export async function createTask(input: CreateTaskInput): Promise<WorkTask> {
   // `estimatePoints`, `estimateHours`, `iterationId` fields are still
   // omitted because they're not used by any current caller; add them if
   // a future caller needs them.
-  const body = {
+  const body: Record<string, unknown> = {
     projectId: input.projectId,
     title: input.title,
     description: input.description,
@@ -417,6 +419,9 @@ export async function createTask(input: CreateTaskInput): Promise<WorkTask> {
     priority: input.priority,
     tags: input.tags,
   };
+  if (input.status !== undefined) {
+    body.status = input.status;
+  }
   const data = await request.post<Record<string, unknown>>("/work/tasks", body);
   return normalizeTask(data);
 }


### PR DESCRIPTION
## Summary
Stabilizes work management per audit: Activities list limit parity with Waterfall/Board (200), honest handling when the server has more tasks than one page, paginated deleted-task loading, recursive soft-delete of descendants on parent delete, and optional Kanban quick create.

## Backend
- `deleteTask`: after soft-deleting the root task, recursively soft-deletes active children in workspace scope; emits `TASK_DELETED` domain events for each descendant.

## Frontend
- `TaskListSection`: `listTasks` with limit 200; `total > items.length` cap banner; bulk delete calls `loadTasks(true)` after successes; deleted panel uses paginated `includeDeleted` fetches.
- `WaterfallTable` / `ProjectBoardTab`: same cap banner; board uses `createTask` with optional `status` (API body updated).

## Tests
- `work-tasks.service.spec.ts`: cascade delete case; existing delete tests mock `find` for cascade.

## Out of scope
- WaterfallTable refactor, WorkItemListView, dependency-on-transition rules, virtual scroll.

## Verification
- `npx tsc --noEmit` (backend + frontend)
- `npx jest work-tasks.service.spec.ts` (delete-related suite)

Made with [Cursor](https://cursor.com)