### PR TITLE
chore(security): scrub smoke key from staging.env + cookie-auth docs

### DIFF
--- a/docs/ai/PROD_RBAC_ROLLOUT_RUNBOOK.md
+++ b/docs/ai/PROD_RBAC_ROLLOUT_RUNBOOK.md
@@ -55,11 +55,12 @@ Both must exit 0.
 ### 1.4 Run RBAC-critical smoke lanes
 
 ```bash
-STAGING_SMOKE_KEY=$(grep STAGING_SMOKE_KEY docs/ai/environments/staging.env | cut -d= -f2) \
-  bash scripts/smoke/run.sh org-invites
+# Export STAGING_SMOKE_KEY from your secret store or GitHub Actions — never from a committed file.
+export STAGING_SMOKE_KEY='…'
+bash scripts/smoke/run.sh org-invites
 
-STAGING_SMOKE_KEY=$(grep STAGING_SMOKE_KEY docs/ai/environments/staging.env | cut -d= -f2) \
-  bash scripts/smoke/run.sh customer-journey
+export STAGING_SMOKE_KEY='…'
+bash scripts/smoke/run.sh customer-journey
 ```
 
 Both must exit 0. Verify proof artifacts:

--- a/docs/ai/environments/staging.env
+++ b/docs/ai/environments/staging.env
@@ -8,10 +8,19 @@
 # verifying in the dashboard often yields Railway edge 404 (no service at that host).
 STAGING_BACKEND_BASE=https://zephix-backend-staging-staging.up.railway.app
 STAGING_BACKEND_API=https://zephix-backend-staging-staging.up.railway.app/api
-STAGING_SMOKE_KEY=83cd663a9f80c7bcc3227203d3af1b9dd5ef17f294579557a81c16c8bd4846f3
 STAGING_FRONTEND_BASE=https://zephix-frontend-staging.up.railway.app
-# STAGING_FRONTEND_BASE is not sensitive — set it here.
-# This file is the single source of truth for both local and CI runs.
-# CI reads it from this file via the shell runner (no GitHub secret needed).
-# Example: STAGING_FRONTEND_BASE=https://zephix-frontend-staging.up.railway.app
+#
+# ── Secrets (NEVER commit real values in this file) ─────────────────────────
+#
+# STAGING_SMOKE_KEY — shared secret for X-Smoke-Key bypass paths (Railway backend env).
+#   Rotate in Railway after any repo exposure; mirror in GitHub Actions as secret STAGING_SMOKE_KEY.
+#   Local runs: export STAGING_SMOKE_KEY='…' (do not paste into committed files).
+#
+# Wave 9 governance smoke (scripts/smoke/wave9-governance-rules-smoke.sh) — prefer cookie auth:
+#   export SMOKE_EMAIL='your-test-admin@example.com'
+#   export SMOKE_PASSWORD='…'
+#   bash scripts/smoke/wave9-governance-rules-smoke.sh
+# Optional: SMOKE_TOKEN (short-lived JWT) if you must use Bearer mode; still never commit it.
+#
+# This file may list public URLs only. CI should inject STAGING_SMOKE_KEY from GitHub secrets.
 NOTES=Set STAGING_FRONTEND_BASE above when frontend domain is stable.

--- a/scripts/smoke/lib/smoke-common.sh
+++ b/scripts/smoke/lib/smoke-common.sh
@@ -9,7 +9,8 @@
 #   source "$(dirname "$0")/lib/smoke-common.sh"
 #
 # Provides:
-#   - Dual auth: cookie mode (default) or Bearer mode via SMOKE_TOKEN
+#   - Dual auth: cookie mode (default; SMOKE_EMAIL + SMOKE_PASSWORD) or Bearer via SMOKE_TOKEN
+#   - Prefer email/password for staging smokes; never commit tokens or passwords in repo files.
 #   - CSRF + cookie jar handling
 #   - apicurl() — curl wrapper that injects auth automatically
 #   - PASS / FAIL / TOTAL counters

--- a/scripts/smoke/wave9-governance-rules-smoke.sh
+++ b/scripts/smoke/wave9-governance-rules-smoke.sh
@@ -7,8 +7,10 @@
 # Usage:
 #   bash scripts/smoke/wave9-governance-rules-smoke.sh [BASE_URL]
 #
-# Env vars:
-#   SMOKE_TOKEN / SMOKE_EMAIL / SMOKE_PASSWORD
+# Env vars (prefer cookie auth — survives JWT rotation):
+#   SMOKE_EMAIL / SMOKE_PASSWORD — recommended; cookie login via smoke-common.sh
+#   SMOKE_TOKEN — optional Bearer JWT (short-lived)
+# Never commit real credentials; export in your shell or CI secrets.
 ###############################################################################
 set -euo pipefail
 


### PR DESCRIPTION
## What
- **Removes** the committed `STAGING_SMOKE_KEY` value from `docs/ai/environments/staging.env` (rotate the live key in **Railway** and mirror in **GitHub Actions** `STAGING_SMOKE_KEY` — cannot be done from this PR).
- **Documents** preferred **`SMOKE_EMAIL` / `SMOKE_PASSWORD`** for Wave 9 governance smoke (cookie login) and never committing secrets.
- **Updates** `smoke-common.sh` and `PROD_RBAC_ROLLOUT_RUNBOOK.md\** to match (no grepping keys from the env file).

## Operator checklist
1. Railway backend: set new `STAGING_SMOKE_KEY`, redeploy.
2. GitHub: update secret `STAGING_SMOKE_KEY` to the same value.
3. Local / CI Wave 9: `export SMOKE_EMAIL=… SMOKE_PASSWORD=…` then `bash scripts/smoke/wave9-governance-rules-smoke.sh`.

Made with [Cursor](https://cursor.com)