### PR TITLE
fix(api): stop masking login validation errors in API filter

### DIFF
--- a/zephix-backend/src/shared/utils/__tests__/build-validation-error.spec.ts
+++ b/zephix-backend/src/shared/utils/__tests__/build-validation-error.spec.ts
@@ -1,0 +1,34 @@
+import { BadRequestException } from '@nestjs/common';
+import { buildValidationError } from '../build-validation-error';
+
+describe('buildValidationError', () => {
+  it('does not replace ValidationPipe message for non-whitelist errors (e.g. IsEmail)', () => {
+    const ex = new BadRequestException({
+      code: 'VALIDATION_ERROR',
+      message: 'email must be an email',
+      errors: [
+        {
+          property: 'email',
+          constraints: { isEmail: 'email must be an email' },
+        },
+      ],
+    });
+    expect(buildValidationError(ex).message).toBe('email must be an email');
+  });
+
+  it('uses whitelist wording when forbidNonWhitelisted fires', () => {
+    const ex = new BadRequestException({
+      code: 'VALIDATION_ERROR',
+      message: 'some pipe message',
+      errors: [
+        {
+          property: 'extraField',
+          constraints: { whitelistValidation: 'property extraField should not exist' },
+        },
+      ],
+    });
+    expect(buildValidationError(ex).message).toBe(
+      "property 'extraField' should not exist",
+    );
+  });
+});

--- a/zephix-backend/src/shared/utils/build-validation-error.ts
+++ b/zephix-backend/src/shared/utils/build-validation-error.ts
@@ -28,11 +28,12 @@ export function buildValidationError(exception: any): {
         }
       }
 
-      // If message contains "property" and we have errors array, extract property name
+      // forbidNonWhitelisted: override with an explicit message.
+      // Otherwise keep `message` from ValidationPipe (exceptionFactory already
+      // uses the first constraint text — do not replace with a generic label).
       if (responseObj.errors && Array.isArray(responseObj.errors)) {
         const firstError = responseObj.errors[0];
         if (firstError && firstError.property) {
-          // Check if it's a whitelist validation error (forbidNonWhitelisted)
           const isWhitelistError =
             firstError.constraints &&
             Object.keys(firstError.constraints).some((key) =>
@@ -40,8 +41,6 @@ export function buildValidationError(exception: any): {
             );
           if (isWhitelistError) {
             message = `property '${firstError.property}' should not exist`;
-          } else {
-            message = `property '${firstError.property}' is not allowed`;
           }
         }
       }


### PR DESCRIPTION
## Problem
`buildValidationError` replaced the ValidationPipe’s real message with `property 'email' is not allowed` whenever `errors[]` was present, so invalid login bodies (e.g. bad email) looked like a schema whitelist issue.

## Change
Only override the client-facing message for **whitelist** (`forbidNonWhitelisted`) errors. Otherwise keep the pipe’s first constraint message.

## Tests
- `src/shared/utils/__tests__/build-validation-error.spec.ts`

Made with [Cursor](https://cursor.com)