### PR TITLE
feat(work-mgmt): completion % column with PMBOK 50/50 status-weight

### DIFF
--- a/zephix-frontend/src/features/projects/components/TaskListSection.tsx
+++ b/zephix-frontend/src/features/projects/components/TaskListSection.tsx
@@ -50,6 +50,8 @@ import {
 } from '@/features/work-management/governanceTaskUpdateErrors';
 import { invalidateStatsCache } from '@/features/work-management/workTasks.stats.api';
 import { AcceptanceCriteriaEditor } from '@/features/work-management/components/AcceptanceCriteriaEditor';
+import { CompletionBar } from '@/features/work-management/components/CompletionBar';
+import { computeTaskCompletion } from '@/features/work-management/statusWeights';
 
 // Generate temporary ID for optimistic inserts
 function tempId(): string {
@@ -152,6 +154,21 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
       return id && teamSet.has(id);
     });
   }, [workspaceMembers, projectTeamMemberIds]);
+
+  const taskChildrenByParent = useMemo(() => {
+    const m = new Map<string, WorkTask[]>();
+    for (const t of tasks) {
+      if (t.deletedAt) continue;
+      if (!t.parentTaskId) continue;
+      const arr = m.get(t.parentTaskId) ?? [];
+      arr.push(t);
+      m.set(t.parentTaskId, arr);
+    }
+    for (const arr of m.values()) {
+      arr.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+    }
+    return m;
+  }, [tasks]);
 
   // PHASE 7 MODULE 7.1 FIX: Consistent role checks
   const isAdmin = isAdminUser(user);
@@ -1349,7 +1366,21 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
                   {task.description && (
                     <p className="text-sm text-gray-600 mb-2">{task.description}</p>
                   )}
-                  <div className="flex items-center gap-4 text-xs text-gray-500">
+                  <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500">
+                    {(() => {
+                      const subs = (taskChildrenByParent.get(task.id) ?? []).filter((c) => !c.deletedAt);
+                      const subSt = subs.map((c) => c.status);
+                      const pct = computeTaskCompletion(
+                        task.status,
+                        subSt.length > 0 ? subSt : undefined,
+                      );
+                      return (
+                        <div className="flex items-center gap-2" data-testid={`activities-completion-${task.id}`}>
+                          <span className="text-gray-400">Completion</span>
+                          <CompletionBar percent={pct} />
+                        </div>
+                      );
+                    })()}
                     {task.assigneeUserId && (
                       <span>Assigned to: {getUserLabel(task.assigneeUserId)}</span>
                     )}

--- a/zephix-frontend/src/features/projects/tabs/ProjectBoardTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectBoardTab.tsx
@@ -7,7 +7,7 @@
  * WIP limit badge on column header.
  * Guest: read-only, no drag. Member: drag if canEdit. Admin/Owner: full drag.
  */
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useWorkspaceStore } from '@/state/workspace.store';
 import { useAuth } from '@/state/AuthContext';
@@ -23,6 +23,11 @@ import {
 } from '@/features/work-management/workTasks.api';
 import { LayoutGrid, User, Calendar, AlertCircle, GripVertical, Shield } from 'lucide-react';
 import { toast } from 'sonner';
+import { CompletionBar } from '@/features/work-management/components/CompletionBar';
+import {
+  computeProjectCompletionPercent,
+  computeTaskCompletion,
+} from '@/features/work-management/statusWeights';
 
 /* ─── Column Config ─────────────────────────────────────────────────── */
 
@@ -257,6 +262,22 @@ export const ProjectBoardTab: React.FC = () => {
   }
 
   const activeTasks = tasks.filter(t => !t.deletedAt);
+  const boardCompletionPercent = useMemo(
+    () => computeProjectCompletionPercent(tasks.filter((t) => !t.deletedAt)),
+    [tasks],
+  );
+
+  const subtaskStatusesByParent = useMemo(() => {
+    const m = new Map<string, WorkTaskStatus[]>();
+    for (const t of tasks) {
+      if (t.deletedAt || !t.parentTaskId) continue;
+      const arr = m.get(t.parentTaskId) ?? [];
+      arr.push(t.status);
+      m.set(t.parentTaskId, arr);
+    }
+    return m;
+  }, [tasks]);
+
   const grouped = BOARD_COLUMNS.map(col => ({
     ...col,
     tasks: activeTasks
@@ -268,15 +289,20 @@ export const ProjectBoardTab: React.FC = () => {
   return (
     <div data-testid="board-root">
       {/* Header */}
-      <div className="mb-4 flex items-center gap-2">
-        <LayoutGrid className="h-5 w-5 text-slate-700" />
-        <h2 className="text-lg font-semibold text-slate-900">Board</h2>
-        <span className="text-sm text-slate-500 ml-2">{activeTasks.length} tasks</span>
-        {!isDragAllowed && (
-          <span className="ml-auto inline-flex items-center gap-1 text-xs text-slate-400 bg-slate-100 px-2 py-1 rounded" data-testid="board-readonly-badge">
-            <Shield className="h-3 w-3" /> Read-only
-          </span>
-        )}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <LayoutGrid className="h-5 w-5 text-slate-700" />
+          <h2 className="text-lg font-semibold text-slate-900">Board</h2>
+          <span className="text-sm text-slate-500">{activeTasks.length} tasks</span>
+          {!isDragAllowed && (
+            <span className="inline-flex items-center gap-1 text-xs text-slate-400 bg-slate-100 px-2 py-1 rounded" data-testid="board-readonly-badge">
+              <Shield className="h-3 w-3" /> Read-only
+            </span>
+          )}
+        </div>
+        <div className="shrink-0" data-testid="board-project-completion">
+          <CompletionBar percent={boardCompletionPercent} size="md" />
+        </div>
       </div>
 
       {taskListMayBeIncomplete && (
@@ -346,7 +372,9 @@ export const ProjectBoardTab: React.FC = () => {
                   col.tasks.map(task => (
                     <TaskCard
                       key={task.id}
+                      projectId={projectId!}
                       task={task}
+                      childStatuses={subtaskStatusesByParent.get(task.id)}
                       currentStatus={col.status}
                       isDragging={draggedTaskId === task.id}
                       canDrag={isDragAllowed}
@@ -428,7 +456,10 @@ const priorityLabels: Record<string, string> = {
 };
 
 interface TaskCardProps {
+  projectId: string;
   task: WorkTask;
+  /** Subtask statuses for completion rollup (optional). */
+  childStatuses?: WorkTaskStatus[];
   currentStatus: WorkTaskStatus;
   isDragging: boolean;
   canDrag: boolean;
@@ -438,7 +469,9 @@ interface TaskCardProps {
 }
 
 function TaskCard({
+  projectId,
   task,
+  childStatuses,
   currentStatus,
   isDragging,
   canDrag,
@@ -446,6 +479,12 @@ function TaskCard({
   onDragEnd,
   onStatusChange,
 }: TaskCardProps) {
+  const navigate = useNavigate();
+  const cardCompletion = computeTaskCompletion(
+    task.status,
+    childStatuses && childStatuses.length > 0 ? childStatuses : undefined,
+  );
+
   return (
     <div
       draggable={canDrag}
@@ -510,6 +549,10 @@ function TaskCard({
             {task.estimateHours}h
           </span>
         )}
+      </div>
+
+      <div className="mt-2" data-testid={`board-card-completion-${task.id}`}>
+        <CompletionBar percent={cardCompletion} />
       </div>
 
       {/* Dropdown fallback for status change (visible for write users) */}

--- a/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectOverviewTab.tsx
@@ -3,7 +3,7 @@
  * Project name + description are in the persistent header (ProjectPageLayout).
  */
 
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { AlertCircle, CheckCircle } from 'lucide-react';
 import { useWorkspaceStore } from '@/state/workspace.store';
@@ -12,6 +12,11 @@ import { useProjectContext } from '../layout/ProjectPageLayout';
 import { EmptyState } from '@/components/ui/feedback/EmptyState';
 import { ProjectOverviewCards } from '../components/ProjectOverviewCards';
 import type { ProjectOverview } from '../model/projectOverview';
+import { listTasks, type WorkTask } from '@/features/work-management/workTasks.api';
+import { CompletionBar } from '@/features/work-management/components/CompletionBar';
+import { computeProjectCompletionPercent } from '@/features/work-management/statusWeights';
+
+const WORK_TASK_LIST_PAGE_SIZE = 200;
 
 const healthConfig: Record<string, { bg: string; text: string; icon: typeof CheckCircle }> = {
   HEALTHY: { bg: 'bg-green-50', text: 'text-green-700', icon: CheckCircle },
@@ -34,6 +39,31 @@ export const ProjectOverviewTab: React.FC = () => {
   const effectiveWorkspaceId = project?.workspaceId ?? workspaceId ?? '';
 
   const overview: ProjectOverview | null = overviewSnapshot;
+
+  const [rollupTasks, setRollupTasks] = useState<WorkTask[]>([]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await listTasks({ projectId, limit: WORK_TASK_LIST_PAGE_SIZE });
+        if (!cancelled) {
+          setRollupTasks(Array.isArray(r.items) ? r.items : []);
+        }
+      } catch {
+        if (!cancelled) setRollupTasks([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const projectCompletionPercent = useMemo(
+    () => computeProjectCompletionPercent(rollupTasks),
+    [rollupTasks],
+  );
 
   useEffect(() => {
     const taskId = searchParams.get('taskId');
@@ -84,6 +114,21 @@ export const ProjectOverviewTab: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      <div
+        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        data-testid="overview-project-completion"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900">Project completion</h3>
+            <p className="mt-0.5 text-xs text-slate-500">
+              Status-weighted progress across tasks (subtasks roll up to parents).
+            </p>
+          </div>
+          <CompletionBar percent={projectCompletionPercent} size="md" />
+        </div>
+      </div>
+
       {/* Three styled cards */}
       {project && effectiveWorkspaceId && (
         <ProjectOverviewCards

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -94,11 +94,9 @@ import {
 // fields on `WorkTask` are still patched via the backend when the
 // detail-panel surface lands.
 //
-import {
-  computeCompletionPercent,
-  computeDurationDays,
-  isClosedStatus,
-} from '@/features/work-management/statusBucket';
+import { computeDurationDays } from '@/features/work-management/statusBucket';
+import { CompletionBar } from '@/features/work-management/components/CompletionBar';
+import { computeTaskCompletion } from '@/features/work-management/statusWeights';
 import { getPhaseColor } from './phaseColors';
 import { computePhaseRollup } from './phaseRollups';
 import { CustomizeViewPanel } from './CustomizeViewPanel';
@@ -243,10 +241,9 @@ interface WaterfallPhase {
  * default. They will be opt-in via the column picker (Phase 4+).
  *
  * `completion` and `duration` are read-only computed columns. Completion
- * derives from status bucket (`computeCompletionPercent` over the row's
- * own status); duration derives from start_date / due_date
- * (`computeDurationDays`). Both come from the shared statusBucket helper
- * which mirrors the backend status-bucket.helper.ts contract.
+ * uses PMBOK-style status weights (`computeTaskCompletion`, including
+ * subtask rollups when children exist). Duration derives from start_date /
+ * due_date (`computeDurationDays` in statusBucket).
  * ────────────────────────────────────────────────────────────────── */
 type ColumnKey =
   | 'title'
@@ -509,6 +506,21 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   // Each rendered row carries its `level` so the title cell can indent.
   type FlatRenderRow = { task: WorkTask; level: 0 | 1 | 2 };
 
+  const taskChildrenMap = useMemo(() => {
+    const childrenOf = new Map<string, WorkTask[]>();
+    for (const t of tasks) {
+      if (t.deletedAt) continue;
+      const key = t.parentTaskId ?? '__ROOT__';
+      const arr = childrenOf.get(key) ?? [];
+      arr.push(t);
+      childrenOf.set(key, arr);
+    }
+    for (const arr of childrenOf.values()) {
+      arr.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+    }
+    return childrenOf;
+  }, [tasks]);
+
   const grouped = useMemo(() => {
     // Phase 12 (2026-04-08) — Sort phases by `sortOrder` (the durable
     // database column), not by name match against a hardcoded canonical
@@ -518,19 +530,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
       (a, b) => a.sortOrder - b.sortOrder,
     );
 
-    // Index tasks by parent for fast nesting.
-    const childrenOf = new Map<string, WorkTask[]>();
-    for (const t of tasks) {
-      if (t.deletedAt) continue;
-      const key = t.parentTaskId ?? '__ROOT__';
-      const arr = childrenOf.get(key) ?? [];
-      arr.push(t);
-      childrenOf.set(key, arr);
-    }
-    // Stable rank sort within each parent bucket.
-    for (const arr of childrenOf.values()) {
-      arr.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
-    }
+    const childrenOf = taskChildrenMap;
 
     return sortedPhases.map((phase) => {
       const flat: FlatRenderRow[] = [];
@@ -550,7 +550,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
       }
       return { phase, rows: flat };
     });
-  }, [phases, tasks]);
+  }, [phases, taskChildrenMap]);
 
   // Flat list of rendered rows in display order — used by keyboard nav.
   const flatRows = useMemo(() => {
@@ -1218,7 +1218,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
             const directChildren = rows
               .filter((r) => r.level === 0)
               .map((r) => r.task);
-            const rollup = computePhaseRollup(directChildren);
+            const rollup = computePhaseRollup(directChildren, tasks);
             const phaseColor = getPhaseColor(phase);
             return (
             <React.Fragment key={phase.id}>
@@ -1323,23 +1323,8 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                       <Plus className="h-3 w-3 shrink-0" aria-hidden />
                       Add task
                     </button>
-                    <div className="flex items-center gap-2 ml-auto min-w-[140px]">
-                      <div className="h-1.5 flex-1 max-w-[120px] rounded-full bg-slate-200 overflow-hidden">
-                        <div
-                          className="h-full rounded-full transition-all"
-                          style={{
-                            width: `${rollup.completionPercent}%`,
-                            backgroundColor: phaseColor,
-                          }}
-                          aria-hidden
-                        />
-                      </div>
-                      <span
-                        className="text-[11px] tabular-nums text-slate-600 w-9 text-right"
-                        data-testid={`phase-completion-${phase.name}`}
-                      >
-                        {rollup.completionPercent}%
-                      </span>
+                    <div className="ml-auto shrink-0" data-testid={`phase-completion-${phase.name}`}>
+                      <CompletionBar percent={rollup.completionPercent} size="md" />
                     </div>
                   </div>
                 </td>
@@ -1349,6 +1334,9 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                   <WaterfallRow
                     task={task}
                     level={level}
+                    subtaskStatuses={(taskChildrenMap.get(task.id) ?? [])
+                      .filter((c) => !c.deletedAt)
+                      .map((c) => c.status)}
                     members={members}
                     statusGroups={statusGroups}
                     hiddenColumns={hiddenColumnSet}
@@ -1754,6 +1742,8 @@ interface RowProps {
   task: WorkTask;
   /** Phase 5B.1A — 0=top, 1=child, 2=sub-child */
   level: 0 | 1 | 2;
+  /** Direct child tasks of this row — used for completion % rollup. */
+  subtaskStatuses: readonly WorkTaskStatus[];
   members: WorkspaceMember[];
   statusGroups: WaterfallStatusGroup[];
   /** Phase 13 — set of column keys hidden via Customize View. */
@@ -1785,6 +1775,7 @@ interface RowProps {
 const WaterfallRow: React.FC<RowProps> = ({
   task,
   level,
+  subtaskStatuses,
   members,
   statusGroups,
   hiddenColumns,
@@ -1823,11 +1814,11 @@ const WaterfallRow: React.FC<RowProps> = ({
   }, [menuOpen]);
   const statusOpt = findStatusOption(statusGroups, task.status);
 
-  // Phase 3 — computed read-only column values.
-  // Completion: per-task today (uses bucket-based single-status compute).
-  // When Phase 4 introduces phase-rows-as-derived-task-rows, the same
-  // function is called with the phase's children's statuses for rollup.
-  const completionPercent = computeCompletionPercent([task.status]);
+  // Phase 3 — computed read-only column values (completion = PMBOK weights + subtasks).
+  const completionPercent = computeTaskCompletion(
+    task.status,
+    subtaskStatuses.length > 0 ? subtaskStatuses : undefined,
+  );
   const durationDays = computeDurationDays(task.startDate, task.dueDate);
 
   const memberLabel = (id: string | null): string => {
@@ -2044,20 +2035,7 @@ const WaterfallRow: React.FC<RowProps> = ({
        */}
       {!hiddenColumns.has('completion') && (
       <Td focused={focused} testId={`cell-completion-${task.id}`}>
-        <div className="flex items-center gap-2">
-          <div className="h-1.5 flex-1 max-w-[80px] rounded-full bg-slate-100 overflow-hidden">
-            <div
-              className={`h-full rounded-full transition-all ${
-                completionPercent === 100 ? 'bg-emerald-500' : 'bg-emerald-400'
-              }`}
-              style={{ width: `${completionPercent}%` }}
-              aria-hidden
-            />
-          </div>
-          <span className="text-[11px] tabular-nums text-slate-600">
-            {completionPercent}%
-          </span>
-        </div>
+        <CompletionBar percent={completionPercent} />
       </Td>
       )}
 

--- a/zephix-frontend/src/features/projects/waterfall/__tests__/phaseRollups.test.ts
+++ b/zephix-frontend/src/features/projects/waterfall/__tests__/phaseRollups.test.ts
@@ -14,6 +14,7 @@ import type { WorkTask } from '../../../work-management/workTasks.api';
 function makeTask(overrides: Partial<WorkTask>): WorkTask {
   return {
     id: 't-' + Math.random().toString(36).slice(2, 8),
+    organizationId: 'org-1',
     projectId: 'p',
     workspaceId: 'w',
     title: 'task',
@@ -83,14 +84,27 @@ describe('computePhaseRollup', () => {
     expect(r.durationDays).toBe(5);
   });
 
-  it('rolls up completion from the closed status bucket', () => {
-    // 2 of 3 closed → 67%
+  it('rolls up completion with PMBOK weights (CANCELED excluded from average)', () => {
     const r = computePhaseRollup([
       makeTask({ status: 'DONE' }),
       makeTask({ status: 'CANCELED' }),
       makeTask({ status: 'IN_PROGRESS' }),
     ]);
-    expect(r.completionPercent).toBe(67);
+    // DONE(100) + IN_PROGRESS(50) → /2 = 75
+    expect(r.completionPercent).toBe(75);
+  });
+
+  it('uses subtask statuses when allProjectTasks is provided', () => {
+    const parentId = 'parent-1';
+    const r = computePhaseRollup(
+      [makeTask({ id: parentId, status: 'TODO' })],
+      [
+        makeTask({ id: parentId, status: 'TODO' }),
+        makeTask({ id: 'c1', parentTaskId: parentId, status: 'DONE' }),
+        makeTask({ id: 'c2', parentTaskId: parentId, status: 'TODO' }),
+      ],
+    );
+    expect(r.completionPercent).toBe(50);
   });
 
   it('matches the operator mockup: Ideation Phase 5/6 closed = 83%', () => {

--- a/zephix-frontend/src/features/projects/waterfall/phaseRollups.ts
+++ b/zephix-frontend/src/features/projects/waterfall/phaseRollups.ts
@@ -12,10 +12,10 @@
  *   2. Duration      — span from earliest child start_date to latest
  *                      child due_date, inclusive day count. Returns 0
  *                      when no child has both dates.
- *   3. Completion %  — `computeCompletionPercent` over the direct
- *                      children's statuses. Closed bucket counts as
- *                      done; everything else as not done. Empty children
- *                      → 0%.
+ *   3. Completion %  — PMBOK-style status weights over direct children.
+ *                      When `allProjectTasks` is passed, each direct child
+ *                      uses subtask rollups (`computeTaskCompletion`).
+ *                      Empty children → 0%.
  *
  * All three are computed at render time from the same source-of-truth
  * task list. There is no persisted "phase status" or "phase progress"
@@ -30,6 +30,22 @@ import {
   computeCompletionPercent,
   computeDurationDays,
 } from '../../work-management/statusBucket';
+import { computeTaskCompletion } from '../../work-management/statusWeights';
+
+function childrenByParentId(tasks: readonly WorkTask[]): Map<string, WorkTask[]> {
+  const m = new Map<string, WorkTask[]>();
+  for (const t of tasks) {
+    if (t.deletedAt) continue;
+    const key = t.parentTaskId ?? '__ROOT__';
+    const arr = m.get(key) ?? [];
+    arr.push(t);
+    m.set(key, arr);
+  }
+  for (const arr of m.values()) {
+    arr.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+  }
+  return m;
+}
 
 export interface PhaseRollup {
   /** Direct child count (level-0 rows under this phase). */
@@ -49,6 +65,7 @@ export interface PhaseRollup {
  */
 export function computePhaseRollup(
   directChildren: readonly WorkTask[],
+  allProjectTasks?: readonly WorkTask[],
 ): PhaseRollup {
   const taskCount = directChildren.length;
 
@@ -77,8 +94,25 @@ export function computePhaseRollup(
   const durationDays =
     earliestStart && latestDue ? computeDurationDays(earliestStart, latestDue) : 0;
 
-  const statuses: WorkTaskStatus[] = directChildren.map((t) => t.status);
-  const completionPercent = computeCompletionPercent(statuses);
+  let completionPercent: number;
+  if (allProjectTasks && allProjectTasks.length > 0) {
+    const byParent = childrenByParentId(allProjectTasks);
+    const each: number[] = [];
+    for (const t of directChildren) {
+      const subs = (byParent.get(t.id) ?? []).filter((c) => !c.deletedAt);
+      const subSt = subs.map((c) => c.status);
+      each.push(
+        computeTaskCompletion(t.status, subSt.length > 0 ? subSt : undefined),
+      );
+    }
+    completionPercent =
+      each.length > 0
+        ? Math.round(each.reduce((sum, v) => sum + v, 0) / each.length)
+        : 0;
+  } else {
+    const statuses: WorkTaskStatus[] = directChildren.map((t) => t.status);
+    completionPercent = computeCompletionPercent(statuses);
+  }
 
   return { taskCount, durationDays, completionPercent };
 }

--- a/zephix-frontend/src/features/work-management/__tests__/statusBucket.test.ts
+++ b/zephix-frontend/src/features/work-management/__tests__/statusBucket.test.ts
@@ -65,22 +65,18 @@ describe('statusBucket helper (frontend mirror)', () => {
       expect(computeCompletionPercent([])).toBe(0);
     });
 
-    it('returns 100 when every child is closed', () => {
+    it('returns 100 when every countable child is done (CANCELED excluded)', () => {
       expect(computeCompletionPercent(['DONE', 'CANCELED'])).toBe(100);
     });
 
-    it('returns 0 when no child is closed', () => {
+    it('uses status weights when no child is fully done', () => {
       expect(
         computeCompletionPercent(['TODO', 'IN_PROGRESS', 'IN_REVIEW']),
-      ).toBe(0);
+      ).toBe(42);
     });
 
-    it('rounds to nearest whole percent', () => {
-      // 1 of 3 closed → 33.33% → 33
-      expect(computeCompletionPercent(['DONE', 'TODO', 'IN_PROGRESS'])).toBe(
-        33,
-      );
-      // 2 of 3 closed → 66.66% → 67
+    it('rounds to nearest whole percent (weighted)', () => {
+      expect(computeCompletionPercent(['DONE', 'TODO', 'IN_PROGRESS'])).toBe(50);
       expect(computeCompletionPercent(['DONE', 'DONE', 'TODO'])).toBe(67);
     });
 

--- a/zephix-frontend/src/features/work-management/__tests__/statusWeights.spec.ts
+++ b/zephix-frontend/src/features/work-management/__tests__/statusWeights.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getTaskStatusWeight,
+  computeWeightedCompletionPercent,
+  computeTaskCompletion,
+  computeProjectCompletionPercent,
+} from '../statusWeights';
+import type { WorkTask } from '../workTasks.api';
+
+function baseTask(overrides: Partial<WorkTask>): WorkTask {
+  return {
+    id: 't1',
+    organizationId: 'o1',
+    workspaceId: 'w1',
+    projectId: 'p1',
+    parentTaskId: null,
+    phaseId: null,
+    title: 'Task',
+    description: null,
+    status: 'TODO',
+    type: 'TASK',
+    priority: 'MEDIUM',
+    assigneeUserId: null,
+    reporterUserId: null,
+    startDate: null,
+    dueDate: null,
+    completedAt: null,
+    estimatePoints: null,
+    estimateHours: null,
+    remainingHours: null,
+    actualHours: null,
+    actualStartDate: null,
+    actualEndDate: null,
+    iterationId: null,
+    committed: false,
+    rank: 0,
+    tags: null,
+    metadata: null,
+    acceptanceCriteria: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    deletedAt: null,
+    deletedByUserId: null,
+    approvalStatus: 'not_required',
+    documentRequired: false,
+    remarks: null,
+    isMilestone: false,
+    ...overrides,
+  };
+}
+
+describe('statusWeights', () => {
+  describe('getTaskStatusWeight', () => {
+    it('returns 0 for BACKLOG and TODO', () => {
+      expect(getTaskStatusWeight('BACKLOG')).toBe(0);
+      expect(getTaskStatusWeight('TODO')).toBe(0);
+    });
+
+    it('returns 50 for IN_PROGRESS and BLOCKED', () => {
+      expect(getTaskStatusWeight('IN_PROGRESS')).toBe(50);
+      expect(getTaskStatusWeight('BLOCKED')).toBe(50);
+    });
+
+    it('returns 75 for IN_REVIEW', () => {
+      expect(getTaskStatusWeight('IN_REVIEW')).toBe(75);
+    });
+
+    it('returns 100 for DONE', () => {
+      expect(getTaskStatusWeight('DONE')).toBe(100);
+    });
+
+    it('returns -1 for CANCELED (excluded)', () => {
+      expect(getTaskStatusWeight('CANCELED')).toBe(-1);
+    });
+
+    it('returns 0 for unknown status', () => {
+      expect(getTaskStatusWeight('UNKNOWN')).toBe(0);
+    });
+  });
+
+  describe('computeWeightedCompletionPercent', () => {
+    it('returns 0 for empty array', () => {
+      expect(computeWeightedCompletionPercent([])).toBe(0);
+    });
+
+    it('returns 0 for all TODO tasks', () => {
+      expect(computeWeightedCompletionPercent(['TODO', 'TODO', 'TODO'])).toBe(0);
+    });
+
+    it('returns 100 for all DONE tasks', () => {
+      expect(computeWeightedCompletionPercent(['DONE', 'DONE', 'DONE'])).toBe(100);
+    });
+
+    it('returns 50 for mixed TODO/DONE', () => {
+      expect(computeWeightedCompletionPercent(['TODO', 'DONE'])).toBe(50);
+    });
+
+    it('calculates weighted average correctly', () => {
+      expect(computeWeightedCompletionPercent(['TODO', 'IN_PROGRESS', 'DONE'])).toBe(50);
+    });
+
+    it('handles IN_REVIEW weight', () => {
+      expect(computeWeightedCompletionPercent(['IN_REVIEW', 'DONE'])).toBe(88);
+    });
+
+    it('excludes CANCELED from calculation', () => {
+      expect(computeWeightedCompletionPercent(['TODO', 'DONE', 'CANCELED'])).toBe(50);
+    });
+
+    it('returns 0 when all tasks are CANCELED', () => {
+      expect(computeWeightedCompletionPercent(['CANCELED', 'CANCELED'])).toBe(0);
+    });
+
+    it('matches ClickUp 83% scenario — 5 of 6 DONE, 1 TODO', () => {
+      const statuses = ['DONE', 'DONE', 'DONE', 'DONE', 'DONE', 'TODO'];
+      expect(computeWeightedCompletionPercent(statuses)).toBe(83);
+    });
+
+    it('shows advantage over 0/100 — IN_PROGRESS gives partial credit', () => {
+      const statuses = ['TODO', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'];
+      expect(computeWeightedCompletionPercent(statuses)).toBe(56);
+    });
+  });
+
+  describe('computeTaskCompletion', () => {
+    it('uses task status when no subtasks', () => {
+      expect(computeTaskCompletion('IN_PROGRESS')).toBe(50);
+    });
+
+    it('uses subtask average when subtasks exist', () => {
+      expect(computeTaskCompletion('TODO', ['DONE', 'TODO'])).toBe(50);
+    });
+
+    it('ignores parent status when subtasks exist', () => {
+      expect(computeTaskCompletion('TODO', ['DONE', 'DONE'])).toBe(100);
+    });
+  });
+
+  describe('computeProjectCompletionPercent', () => {
+    it('returns 0 for empty tasks', () => {
+      expect(computeProjectCompletionPercent([])).toBe(0);
+    });
+
+    it('averages root tasks with subtask rollups', () => {
+      const parent = baseTask({ id: 'p', status: 'TODO' });
+      const c1 = baseTask({ id: 'c1', parentTaskId: 'p', status: 'DONE' });
+      const c2 = baseTask({ id: 'c2', parentTaskId: 'p', status: 'TODO' });
+      expect(computeProjectCompletionPercent([parent, c1, c2])).toBe(50);
+    });
+  });
+});

--- a/zephix-frontend/src/features/work-management/components/CompletionBar.tsx
+++ b/zephix-frontend/src/features/work-management/components/CompletionBar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export interface CompletionBarProps {
+  percent: number;
+  size?: 'sm' | 'md';
+}
+
+/**
+ * Horizontal progress bar + right-aligned percentage (ClickUp-style).
+ * Green ≥75%, amber 25–74%, gray 0–24% (locked PR colors).
+ */
+export function CompletionBar({ percent, size = 'sm' }: CompletionBarProps) {
+  const clamped = Math.max(0, Math.min(100, Math.round(percent)));
+  const barHeight = size === 'sm' ? 'h-2' : 'h-2.5';
+
+  const barColorClass =
+    clamped >= 75 ? 'bg-[#22C55E]' : clamped >= 25 ? 'bg-[#F59E0B]' : 'bg-[#D1D5DB]';
+
+  const textColorClass =
+    clamped >= 75 ? 'text-[#16A34A]' : clamped >= 25 ? 'text-[#D97706]' : 'text-gray-400';
+
+  return (
+    <div className="flex min-w-[100px] max-w-[160px] items-center gap-2">
+      <div className={`flex-1 overflow-hidden rounded-full bg-gray-100 ${barHeight}`}>
+        <div
+          className={`${barHeight} rounded-full transition-all duration-300 ${barColorClass}`}
+          style={{ width: `${clamped}%` }}
+          aria-hidden
+        />
+      </div>
+      <span className={`w-9 shrink-0 text-right text-xs font-medium tabular-nums ${textColorClass}`}>
+        {clamped}%
+      </span>
+    </div>
+  );
+}

--- a/zephix-frontend/src/features/work-management/statusBucket.ts
+++ b/zephix-frontend/src/features/work-management/statusBucket.ts
@@ -24,6 +24,7 @@
  * implementation will not require call-site changes.
  */
 import type { WorkTaskStatus } from './workTasks.api';
+import { computeWeightedCompletionPercent } from './statusWeights';
 
 export type StatusBucket = 'not_started' | 'active' | 'closed';
 
@@ -62,21 +63,17 @@ export function isNotStartedStatus(status: WorkTaskStatus): boolean {
 }
 
 /**
- * Compute a Progress (Auto) percentage for a parent row from its children's
- * statuses. Closed children count as 100% done; all others count as 0%.
- * Empty input returns 0 — caller decides whether to show "0%" or "—" for
- * childless rows.
+ * Progress (Auto) % from child statuses using PMBOK-style status weights
+ * (50/50 partial credit for IN_PROGRESS, etc.). CANCELED children are
+ * excluded. Empty input returns 0.
  *
- * Mirrors `computeCompletionPercent` in the backend helper. Used by the
- * Completion% column for both task rows (when a task has subtasks) and
- * phase rows (rolled up across the phase's direct task children).
+ * Note: Backend `status-bucket.helper` may still use binary completion;
+ * this frontend helper is intentionally richer for Waterfall / Activities UI.
  */
 export function computeCompletionPercent(
   childStatuses: readonly WorkTaskStatus[],
 ): number {
-  if (childStatuses.length === 0) return 0;
-  const closedCount = childStatuses.filter(isClosedStatus).length;
-  return Math.round((closedCount / childStatuses.length) * 100);
+  return computeWeightedCompletionPercent(childStatuses);
 }
 
 /**

--- a/zephix-frontend/src/features/work-management/statusWeights.ts
+++ b/zephix-frontend/src/features/work-management/statusWeights.ts
@@ -1,0 +1,84 @@
+import type { WorkTask, WorkTaskStatus } from './workTasks.api';
+
+/**
+ * PMBOK-style status weights for earned value / completion % (frontend-only).
+ * CANCELED uses sentinel -1 and is excluded from rollups.
+ */
+export const STATUS_WEIGHTS: Record<WorkTaskStatus, number> = {
+  BACKLOG: 0,
+  TODO: 0,
+  IN_PROGRESS: 50,
+  IN_REVIEW: 75,
+  BLOCKED: 50,
+  DONE: 100,
+  CANCELED: -1,
+};
+
+/** Sentinel: excluded from weighted averages. */
+const EXCLUDED = -1;
+
+export function getTaskStatusWeight(status: string): number {
+  if (status in STATUS_WEIGHTS) {
+    return STATUS_WEIGHTS[status as WorkTaskStatus];
+  }
+  return 0;
+}
+
+export function computeWeightedCompletionPercent(statuses: readonly string[]): number {
+  const countable = statuses.filter((s) => getTaskStatusWeight(s) !== EXCLUDED);
+  if (countable.length === 0) return 0;
+  const totalWeight = countable.reduce((sum, status) => {
+    const w = getTaskStatusWeight(status);
+    return sum + (w === EXCLUDED ? 0 : w);
+  }, 0);
+  return Math.round(totalWeight / countable.length);
+}
+
+/**
+ * Single task completion: average of subtask weights when subtasks exist;
+ * otherwise this task's status weight. CANCELED parent with no subtasks → 0.
+ */
+export function computeTaskCompletion(
+  taskStatus: string,
+  subtaskStatuses?: readonly string[],
+): number {
+  if (subtaskStatuses && subtaskStatuses.length > 0) {
+    return computeWeightedCompletionPercent(subtaskStatuses);
+  }
+  const weight = getTaskStatusWeight(taskStatus);
+  return weight === EXCLUDED ? 0 : weight;
+}
+
+function childrenByParentId(tasks: readonly WorkTask[]): Map<string, WorkTask[]> {
+  const m = new Map<string, WorkTask[]>();
+  for (const t of tasks) {
+    if (t.deletedAt) continue;
+    const key = t.parentTaskId ?? '__ROOT__';
+    const arr = m.get(key) ?? [];
+    arr.push(t);
+    m.set(key, arr);
+  }
+  for (const arr of m.values()) {
+    arr.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+  }
+  return m;
+}
+
+/**
+ * Project-level %: average completion of root tasks (no parent), each using
+ * subtasks when present. If there are no roots, averages all active tasks
+ * by their own status weight (flat list).
+ */
+export function computeProjectCompletionPercent(tasks: readonly WorkTask[]): number {
+  const active = tasks.filter((t) => !t.deletedAt);
+  if (active.length === 0) return 0;
+  const byParent = childrenByParentId(active);
+  const roots = active.filter((t) => !t.parentTaskId);
+  const targets = roots.length > 0 ? roots : active;
+  const each = targets.map((t) => {
+    const subs = (byParent.get(t.id) ?? []).filter((c) => !c.deletedAt);
+    const subSt = subs.map((c) => c.status);
+    return computeTaskCompletion(t.status, subSt.length > 0 ? subSt : undefined);
+  });
+  return Math.round(each.reduce((s, v) => s + v, 0) / each.length);
+}

--- a/zephix-frontend/src/features/work-management/workTasks.api.ts
+++ b/zephix-frontend/src/features/work-management/workTasks.api.ts
@@ -114,6 +114,8 @@ export interface WorkTask {
   remarks: string | null;
   /** Row-level milestone flag (already on backend; surfaced for the table). */
   isMilestone: boolean;
+  /** Persisted column (optional in API); UI prefers status-weight computation. */
+  percentComplete?: number;
 }
 
 export interface AcceptanceCriteriaItem {


### PR DESCRIPTION
## Summary
PMBOK-style weighted completion percentage across all project views.

- **statusWeights.ts** — 50/50 status-weight model, `computeWeightedCompletionPercent`, `computeTaskCompletion`, `computeProjectCompletionPercent`
- **CompletionBar.tsx** — Visual bar with `#22C55E` / `#F59E0B` / `#D1D5DB` and matching text tones
- **statusBucket.ts** — `computeCompletionPercent` now delegates to weighted version
- **phaseRollups.ts** — Optional `allProjectTasks` arg for subtask-aware phase rollup
- **WaterfallTable** — Shared `taskChildrenMap`, phase header + task cells use CompletionBar
- **TaskListSection** — CompletionBar per task card
- **ProjectOverviewTab** — Project completion card
- **ProjectBoardTab** — Header project completion + per-card bars; fixes `navigate`/`projectId` TS errors
- **workTasks.api.ts** — Optional `percentComplete` on WorkTask

## Test plan
- [ ] Vitest passes for statusWeights, statusBucket, phaseRollups
- [ ] `tsc --noEmit` clean (22 pre-existing errors, 0 new)
- [ ] WaterfallTable: phase headers show weighted completion bar
- [ ] WaterfallTable: task rows show individual completion
- [ ] Board: project completion in header, per-card bars
- [ ] Activities (TaskListSection): completion bar per task
- [ ] Overview: project completion card

🤖 Generated with [Claude Code](https://claude.com/claude-code)