### PR TITLE
feat(admin): Audit Trail + People + Templates Columns (PR2)

### DIFF
--- a/zephix-backend/src/admin/admin.controller.spec.ts
+++ b/zephix-backend/src/admin/admin.controller.spec.ts
@@ -6,6 +6,8 @@ import { WorkspacesService } from '../modules/workspaces/workspaces.service';
 import { TeamsService } from '../modules/teams/teams.service';
 import { AttachmentsService } from '../modules/attachments/services/attachments.service';
 import { AuditService } from '../modules/audit/services/audit.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from '../modules/users/entities/user.entity';
 
 // Jest types are available via @types/jest in package.json
 
@@ -53,6 +55,10 @@ describe('AdminController - Contract Tests', () => {
         {
           provide: AuditService,
           useValue: {},
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: { find: jest.fn().mockResolvedValue([]) },
         },
       ],
     }).compile();

--- a/zephix-backend/src/admin/admin.controller.ts
+++ b/zephix-backend/src/admin/admin.controller.ts
@@ -14,6 +14,8 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
 import {
   ApiTags,
   ApiOperation,
@@ -34,6 +36,7 @@ import { AuthRequest } from '../common/http/auth-request';
 import { getAuthContext } from '../common/http/get-auth-context';
 import { AuditService } from '../modules/audit/services/audit.service';
 import { toAuditEventDto } from '../modules/audit/dto/audit-event.dto';
+import { User } from '../modules/users/entities/user.entity';
 
 type AdminUserRow = {
   id: string;
@@ -63,6 +66,8 @@ export class AdminController {
     private readonly teamsService: TeamsService,
     private readonly attachmentsService: AttachmentsService,
     private readonly auditService: AuditService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
   ) {}
 
   // Helper to map frontend visibility to backend enum
@@ -330,25 +335,63 @@ export class AdminController {
     @Query('limit') limit?: string,
     @Query('action') action?: string,
     @Query('userId') userId?: string,
+    @Query('actorId') actorId?: string,
+    @Query('dateRange') dateRange?: string,
+    @Query('eventCategory') eventCategory?: string,
+    @Query('search') search?: string,
   ) {
     const pageNum = Math.max(1, parseInt(page || '1', 10) || 1);
-    const pageSize = Math.min(200, Math.max(1, parseInt(limit || '50', 10) || 50));
+    const pageSize = Math.min(100, Math.max(1, parseInt(limit || '25', 10) || 25));
     const { organizationId } = getAuthContext(req);
+
+    const { from, to } = this.auditDateRangeToBounds(dateRange);
+    const entityTypes = this.auditEventCategoryToEntityTypes(eventCategory);
 
     const result = await this.auditService.query({
       organizationId,
       action,
-      actorUserId: userId,
+      actorUserId: actorId || userId,
+      from,
+      to,
+      entityTypes,
+      search,
       page: pageNum,
       pageSize,
     });
 
+    const actorIds = [
+      ...new Set(result.items.map((e) => e.actorUserId).filter(Boolean)),
+    ] as string[];
+    const users =
+      actorIds.length > 0
+        ? await this.userRepository.find({
+            where: { id: In(actorIds) },
+            select: ['id', 'firstName', 'lastName', 'email'],
+          })
+        : [];
+    const nameById = new Map(
+      users.map((u) => {
+        const label =
+          `${u.firstName || ''} ${u.lastName || ''}`.trim() || u.email || u.id;
+        return [u.id, label] as const;
+      }),
+    );
+
     return {
-      data: result.items.map(toAuditEventDto),
+      data: result.items.map((e) =>
+        toAuditEventDto(e, {
+          actorName:
+            nameById.get(e.actorUserId) ||
+            (String(e.actorPlatformRole || '').toUpperCase() === 'SYSTEM'
+              ? 'System'
+              : null),
+        }),
+      ),
       meta: {
         page: pageNum,
         limit: pageSize,
         total: result.total,
+        totalPages: Math.max(1, Math.ceil(result.total / pageSize)),
       },
     };
   }
@@ -365,48 +408,84 @@ export class AdminController {
     @Query('status') _status?: string,
   ) {
     try {
-      const pageNum = page ? parseInt(page, 10) : 1;
-      const limitNum = limit ? parseInt(limit, 10) : 20;
+      const pageNum = Math.max(1, parseInt(page ?? '1', 10) || 1);
+      const limitNum = Math.min(100, Math.max(1, parseInt(limit ?? '25', 10) || 25));
       const offset = (pageNum - 1) * limitNum;
 
       const { organizationId } = getAuthContext(req);
+
+      const peopleFilter: 'all' | 'active' | 'suspended' | 'invited' =
+        _status === 'active'
+          ? 'active'
+          : _status === 'suspended'
+            ? 'suspended'
+            : _status === 'invited'
+              ? 'invited'
+              : 'all';
+
+      const platformRole: 'all' | 'admin' | 'member' | 'viewer' =
+        !_role || _role === 'all'
+          ? 'all'
+          : _role === 'admin' || _role === 'member' || _role === 'viewer'
+            ? _role
+            : 'all';
+
       const result = await this.organizationsService.getOrganizationUsers(
         organizationId,
         {
           limit: limitNum,
           offset,
           search,
+          peopleFilter,
+          platformRole,
         },
       );
 
-      // Apply role and status filters client-side for now
-      let filteredUsers = result.users;
-      if (_role && _role !== 'all') {
-        filteredUsers = filteredUsers.filter((u: AdminUserRow) => u.role === _role);
-      }
-      if (_status && _status !== 'all') {
-        // Map status based on isActive or other criteria
-        // For now, we'll assume all users in the result are active
-        // This can be enhanced based on actual status field
-      }
+      const org = await this.organizationsService
+        .findOne(organizationId)
+        .catch(() => null);
+      const rawMeta =
+        org?.planMetadata && typeof org.planMetadata === 'object'
+          ? (org.planMetadata as Record<string, unknown>)
+          : null;
+      const seatRaw = rawMeta?.['seatLimit'] ?? rawMeta?.['maxSeats'];
+      const seatLimit =
+        seatRaw !== undefined &&
+        seatRaw !== null &&
+        Number.isFinite(Number(seatRaw))
+          ? Number(seatRaw)
+          : null;
 
-      const totalPages = Math.ceil(result.total / limitNum);
+      const teamMap = await this.teamsService.listTeamLabelsByUserIds(
+        result.users.map((u: { id: string }) => u.id),
+      );
+
+      const rows = result.users.map((u: any) => ({
+        id: String(u.id),
+        email: u.email,
+        firstName: u.firstName || '',
+        lastName: u.lastName || '',
+        role: u.role,
+        membershipRole: u.role,
+        platformRole: this.membershipRoleToPlatformRole(String(u.role)),
+        uiRole: this.membershipRoleToAdminUiRole(String(u.role)),
+        teams: teamMap[u.id] ?? [],
+        status: this.mapDirectoryPeopleStatus(u),
+        lastActive: u.lastActive
+          ? new Date(u.lastActive).toISOString()
+          : null,
+        joinedAt: u.joinedAt
+          ? new Date(u.joinedAt).toISOString()
+          : new Date().toISOString(),
+        isOwner: String(u.role || '').toLowerCase() === 'owner',
+      }));
+
+      const totalPages = Math.max(1, Math.ceil(result.total / limitNum));
 
       return {
-        users: filteredUsers.map((u: AdminUserRow) => ({
-          id: String(u.id),
-          email: u.email,
-          firstName: u.firstName || '',
-          lastName: u.lastName || '',
-          role: u.role,
-          status: 'active', // Default to active for now
-          lastActive: u.lastActive
-            ? new Date(u.lastActive).toISOString()
-            : null,
-          joinedAt: u.joinedAt
-            ? new Date(u.joinedAt).toISOString()
-            : new Date().toISOString(),
-        })),
+        users: rows,
+        memberCount: result.total,
+        seatLimit,
         pagination: {
           page: pageNum,
           limit: limitNum,
@@ -446,7 +525,7 @@ export class AdminController {
       const { organizationId } = getAuthContext(req);
       const result = await this.organizationsService.getOrganizationUsers(
         organizationId,
-        { limit: 1000, offset: 0 },
+        { limit: 1000, offset: 0, peopleFilter: 'all' },
       );
       const user = result.users.find((u: AdminUserRow) => u.id === userId);
       if (!user) {
@@ -458,7 +537,7 @@ export class AdminController {
         firstName: user.firstName || '',
         lastName: user.lastName || '',
         role: user.role,
-        status: 'active', // Default to active for now
+        status: this.mapDirectoryPeopleStatus(user as any),
         lastActive: user.lastActive
           ? new Date(user.lastActive).toISOString()
           : null,
@@ -1228,6 +1307,101 @@ export class AdminController {
       },
     });
     return { data: { success: true } };
+  }
+
+  private mapDirectoryPeopleStatus(u: {
+    membershipActive?: boolean;
+    userAccountActive?: boolean;
+    isEmailVerified?: boolean;
+  }): 'active' | 'suspended' | 'invited' {
+    const mem = u.membershipActive !== false;
+    const acc = u.userAccountActive !== false;
+    if (!mem || !acc) {
+      return 'suspended';
+    }
+    if (u.isEmailVerified === false) {
+      return 'invited';
+    }
+    return 'active';
+  }
+
+  private membershipRoleToPlatformRole(
+    role: string,
+  ): 'admin' | 'member' | 'viewer' {
+    const r = String(role || '').toLowerCase();
+    if (r === 'owner' || r === 'admin') {
+      return 'admin';
+    }
+    if (r === 'viewer') {
+      return 'viewer';
+    }
+    return 'member';
+  }
+
+  private membershipRoleToAdminUiRole(
+    role: string,
+  ): 'owner' | 'admin' | 'member' | 'viewer' {
+    const r = String(role || '').toLowerCase();
+    if (r === 'owner') {
+      return 'owner';
+    }
+    if (r === 'admin') {
+      return 'admin';
+    }
+    if (r === 'viewer') {
+      return 'viewer';
+    }
+    return 'member';
+  }
+
+  private auditEventCategoryToEntityTypes(
+    category?: string,
+  ): string[] | undefined {
+    const c = String(category || 'all').toLowerCase();
+    if (!c || c === 'all') {
+      return undefined;
+    }
+    if (c === 'auth') {
+      return ['user', 'email_verification'];
+    }
+    if (c === 'task') {
+      return ['work_task', 'board_move'];
+    }
+    if (c === 'project') {
+      return ['project', 'portfolio'];
+    }
+    if (c === 'governance') {
+      return [
+        'work_risk',
+        'entitlement',
+        'billing_plan',
+        'scenario_plan',
+        'scenario_action',
+        'scenario_result',
+        'baseline',
+        'capacity_calendar',
+      ];
+    }
+    if (c === 'admin') {
+      return ['organization', 'workspace', 'webhook', 'attachment', 'doc'];
+    }
+    return undefined;
+  }
+
+  private auditDateRangeToBounds(dateRange?: string): {
+    from?: string;
+    to?: string;
+  } {
+    const r = String(dateRange || '30d').toLowerCase();
+    if (r === 'all') {
+      return {};
+    }
+    const now = new Date();
+    const to = now.toISOString();
+    const days =
+      r === '7d' ? 7 : r === '90d' ? 90 : r === '30d' ? 30 : 30;
+    const from = new Date(now.getTime() - days * 86400000).toISOString();
+    return { from, to };
   }
 
   // ==================== Phase 3C: Attachment Retention Purge ====================

--- a/zephix-backend/src/modules/audit/__tests__/audit-dto.spec.ts
+++ b/zephix-backend/src/modules/audit/__tests__/audit-dto.spec.ts
@@ -36,6 +36,8 @@ describe('toAuditEventDto', () => {
     expect(dto.afterJson).toEqual({ status: 'done' });
     expect(dto.metadataJson).toEqual({ source: 'board' });
     expect(dto.createdAt).toBe('2026-01-15T10:00:00.000Z');
+    expect(dto.description).toBe('update on work_task');
+    expect(dto.actorName).toBeNull();
   });
 
   it('handles null optional fields', () => {
@@ -61,5 +63,27 @@ describe('toAuditEventDto', () => {
     expect(dto.beforeJson).toBeNull();
     expect(dto.afterJson).toBeNull();
     expect(dto.metadataJson).toBeNull();
+    expect(dto.description).toBe('presign create on attachment');
+    expect(dto.actorName).toBeNull();
+  });
+
+  it('uses metadata.summary for description when present', () => {
+    const event = new AuditEvent();
+    event.id = 'evt-3';
+    event.organizationId = 'org-1';
+    event.workspaceId = null;
+    event.actorUserId = 'u-1';
+    event.actorPlatformRole = 'ADMIN';
+    event.actorWorkspaceRole = null;
+    event.entityType = 'project';
+    event.entityId = 'p-1';
+    event.action = 'update';
+    event.beforeJson = null;
+    event.afterJson = null;
+    event.metadataJson = { summary: 'Renamed project Alpha' };
+    event.createdAt = new Date('2026-03-01T08:00:00Z');
+
+    const dto = toAuditEventDto(event);
+    expect(dto.description).toBe('Renamed project Alpha');
   });
 });

--- a/zephix-backend/src/modules/audit/controllers/audit.controller.ts
+++ b/zephix-backend/src/modules/audit/controllers/audit.controller.ts
@@ -85,7 +85,7 @@ export class AuditController {
 
     return {
       data: {
-        items: result.items.map(toAuditEventDto),
+        items: result.items.map((e) => toAuditEventDto(e)),
         page: pg,
         pageSize: ps,
         total: result.total,
@@ -134,7 +134,7 @@ export class AuditController {
 
     return {
       data: {
-        items: result.items.map(toAuditEventDto),
+        items: result.items.map((e) => toAuditEventDto(e)),
         page: pg,
         pageSize: ps,
         total: result.total,

--- a/zephix-backend/src/modules/audit/dto/audit-event.dto.ts
+++ b/zephix-backend/src/modules/audit/dto/audit-event.dto.ts
@@ -14,9 +14,36 @@ export interface AuditEventDto {
   afterJson: Record<string, any> | null;
   metadataJson: Record<string, any> | null;
   createdAt: string;
+  /** Resolved display label for admin audit table (not persisted on entity). */
+  actorName: string | null;
+  /** Human-readable summary for admin UI. */
+  description: string;
 }
 
-export function toAuditEventDto(event: AuditEvent): AuditEventDto {
+/**
+ * Build a non-empty description for audit rows (metadata.summary wins when present).
+ */
+export function buildAuditDescription(event: AuditEvent): string {
+  const meta = event.metadataJson;
+  if (meta && typeof meta === 'object') {
+    const summary = (meta as Record<string, unknown>)['summary'];
+    if (typeof summary === 'string' && summary.trim()) {
+      return summary.trim();
+    }
+  }
+  const action = String(event.action || 'event').replace(/_/g, ' ');
+  const entity = String(event.entityType || 'record');
+  return `${action} on ${entity}`;
+}
+
+export function toAuditEventDto(
+  event: AuditEvent,
+  extras?: { actorName?: string | null },
+): AuditEventDto {
+  const actorName =
+    extras?.actorName != null && String(extras.actorName).trim()
+      ? String(extras.actorName).trim()
+      : null;
   return {
     id: event.id,
     organizationId: event.organizationId,
@@ -31,5 +58,7 @@ export function toAuditEventDto(event: AuditEvent): AuditEventDto {
     afterJson: event.afterJson,
     metadataJson: event.metadataJson,
     createdAt: event.createdAt?.toISOString?.() ?? String(event.createdAt),
+    actorName,
+    description: buildAuditDescription(event),
   };
 }

--- a/zephix-backend/src/modules/audit/services/audit.service.ts
+++ b/zephix-backend/src/modules/audit/services/audit.service.ts
@@ -25,11 +25,15 @@ export interface AuditQueryOpts {
   organizationId: string;
   workspaceId?: string;
   entityType?: string;
+  /** When set, restricts to any of these entity types (takes precedence over entityType). */
+  entityTypes?: string[];
   entityId?: string;
   action?: string;
   actorUserId?: string;
   from?: string;
   to?: string;
+  /** Case-insensitive match on action, entity type, or entity id text. */
+  search?: string;
   page: number;
   pageSize: number;
 }
@@ -99,7 +103,11 @@ export class AuditService {
     if (opts.workspaceId) {
       qb.andWhere('ae.workspaceId = :workspaceId', { workspaceId: opts.workspaceId });
     }
-    if (opts.entityType) {
+    if (opts.entityTypes?.length) {
+      qb.andWhere('ae.entityType IN (:...entityTypes)', {
+        entityTypes: opts.entityTypes,
+      });
+    } else if (opts.entityType) {
       qb.andWhere('ae.entityType = :entityType', { entityType: opts.entityType });
     }
     if (opts.entityId) {
@@ -116,6 +124,14 @@ export class AuditService {
     }
     if (opts.to) {
       qb.andWhere('ae.createdAt <= :to', { to: opts.to });
+    }
+    if (opts.search?.trim()) {
+      const raw = opts.search.trim().replace(/\\/g, '').replace(/%/g, '');
+      const s = `%${raw}%`;
+      qb.andWhere(
+        '(CAST(ae.action AS text) ILIKE :auditSearch OR CAST(ae.entityType AS text) ILIKE :auditSearch OR CAST(ae.entityId AS text) ILIKE :auditSearch)',
+        { auditSearch: s },
+      );
     }
 
     qb.orderBy('ae.createdAt', 'DESC');

--- a/zephix-backend/src/modules/teams/teams.service.ts
+++ b/zephix-backend/src/modules/teams/teams.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   Inject,
 } from '@nestjs/common';
-import { FindOptionsWhere } from 'typeorm';
+import { FindOptionsWhere, In } from 'typeorm';
 import { Team } from './entities/team.entity';
 import { TeamMember } from './entities/team-member.entity';
 import { CreateTeamDto } from './dto/create-team.dto';
@@ -124,6 +124,36 @@ export class TeamsService {
       teams: teamsWithCounts as any,
       total,
     };
+  }
+
+  /**
+   * Org-scoped team name pills for admin directory / People table.
+   */
+  async listTeamLabelsByUserIds(
+    userIds: string[],
+  ): Promise<Record<string, Array<{ id: string; name: string }>>> {
+    if (!userIds.length) {
+      return {};
+    }
+    const distinctIds = [...new Set(userIds)];
+    const memberships = await this.teamMemberRepository.find({
+      where: { userId: In(distinctIds) } as FindOptionsWhere<TeamMember>,
+      relations: ['team'],
+    });
+    const out: Record<string, Array<{ id: string; name: string }>> = {};
+    for (const m of memberships) {
+      const t = m.team;
+      if (!t?.id) {
+        continue;
+      }
+      if (!out[m.userId]) {
+        out[m.userId] = [];
+      }
+      if (!out[m.userId].some((x) => x.id === t.id)) {
+        out[m.userId].push({ id: t.id, name: t.name });
+      }
+    }
+    return out;
   }
 
   /**

--- a/zephix-backend/src/modules/templates/dto/update-org-template.dto.ts
+++ b/zephix-backend/src/modules/templates/dto/update-org-template.dto.ts
@@ -41,4 +41,9 @@ export class UpdateOrgTemplateDto {
   @IsOptional()
   @IsObject()
   defaultGovernanceFlags?: Record<string, boolean>;
+
+  /** P-2: Tier-2 / methodology column toggles persisted on the template row. */
+  @IsOptional()
+  @IsObject()
+  columnConfig?: Record<string, boolean>;
 }

--- a/zephix-backend/src/modules/templates/services/__tests__/template-authoring.spec.ts
+++ b/zephix-backend/src/modules/templates/services/__tests__/template-authoring.spec.ts
@@ -215,6 +215,21 @@ describe('Wave 6: Template Authoring', () => {
         }),
       );
     });
+
+    it('persists columnConfig when provided', async () => {
+      const tpl = { ...ORG_TEMPLATE, columnConfig: { labels: true } };
+      mockRepo.findOne.mockResolvedValue(tpl);
+
+      await service.updateOrgTemplate('org-tpl-1', 'org-1', {
+        columnConfig: { labels: false, phase: true },
+      });
+
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columnConfig: { labels: false, phase: true },
+        }),
+      );
+    });
   });
 
   // ── Archive ────────────────────────────────────────────────────────

--- a/zephix-backend/src/modules/templates/services/templates.service.ts
+++ b/zephix-backend/src/modules/templates/services/templates.service.ts
@@ -479,6 +479,7 @@ export class TemplatesService {
       deliveryMethod?: string;
       defaultTabs?: string[];
       defaultGovernanceFlags?: Record<string, boolean>;
+      columnConfig?: Record<string, boolean>;
     },
   ): Promise<Template> {
     const tpl = await this.findOneUnified(templateId, organizationId);
@@ -500,6 +501,9 @@ export class TemplatesService {
     if (patch.defaultTabs !== undefined) tpl.defaultTabs = patch.defaultTabs;
     if (patch.defaultGovernanceFlags !== undefined)
       tpl.defaultGovernanceFlags = patch.defaultGovernanceFlags;
+    if (patch.columnConfig !== undefined) {
+      tpl.columnConfig = patch.columnConfig;
+    }
 
     return this.dataSource.getRepository(Template).save(tpl);
   }

--- a/zephix-backend/src/organizations/services/organizations.service.ts
+++ b/zephix-backend/src/organizations/services/organizations.service.ts
@@ -352,18 +352,60 @@ export class OrganizationsService {
 
   async getOrganizationUsers(
     organizationId: string,
-    options?: { limit?: number; offset?: number; search?: string },
+    options?: {
+      limit?: number;
+      offset?: number;
+      search?: string;
+      /** Admin People pills: all memberships, or segmented by lifecycle state. */
+      peopleFilter?: 'all' | 'active' | 'suspended' | 'invited';
+      /** Maps UI platform role to `user_organizations.role` (owner/admin, pm, viewer). */
+      platformRole?: 'all' | 'admin' | 'member' | 'viewer';
+    },
   ): Promise<{ users: any[]; total: number }> {
     const limit = options?.limit || 100;
     const offset = options?.offset || 0;
     const search = options?.search?.toLowerCase();
+    const peopleFilter = options?.peopleFilter;
+    const platformRole = options?.platformRole ?? 'all';
 
     // Build query
     const queryBuilder = this.userOrganizationRepository
       .createQueryBuilder('uo')
       .leftJoinAndSelect('uo.user', 'user')
-      .where('uo.organizationId = :organizationId', { organizationId })
-      .andWhere('uo.isActive = :isActive', { isActive: true });
+      .where('uo.organizationId = :organizationId', { organizationId });
+
+    if (peopleFilter === undefined) {
+      queryBuilder.andWhere('uo.isActive = :uoLegacyActive', {
+        uoLegacyActive: true,
+      });
+    } else if (peopleFilter === 'all') {
+      // Admin People — show every membership row (active + inactive).
+    } else if (peopleFilter === 'active') {
+      queryBuilder
+        .andWhere('uo.isActive = :uoActive', { uoActive: true })
+        .andWhere('user.isActive = :uActive', { uActive: true })
+        .andWhere('user.isEmailVerified = :ev', { ev: true });
+    } else if (peopleFilter === 'suspended') {
+      queryBuilder.andWhere(
+        '(uo.isActive = :uoInact OR user.isActive = :uInact)',
+        { uoInact: false, uInact: false },
+      );
+    } else if (peopleFilter === 'invited') {
+      queryBuilder
+        .andWhere('uo.isActive = :uoActive', { uoActive: true })
+        .andWhere('user.isActive = :uActive', { uActive: true })
+        .andWhere('user.isEmailVerified = :ev', { ev: false });
+    }
+
+    if (platformRole === 'admin') {
+      queryBuilder.andWhere('uo.role IN (:...adminRoles)', {
+        adminRoles: ['owner', 'admin'],
+      });
+    } else if (platformRole === 'member') {
+      queryBuilder.andWhere('uo.role = :pmRole', { pmRole: 'pm' });
+    } else if (platformRole === 'viewer') {
+      queryBuilder.andWhere('uo.role = :viewerRole', { viewerRole: 'viewer' });
+    }
 
     // Add search filter if provided
     if (search) {
@@ -389,6 +431,9 @@ export class OrganizationsService {
       firstName: uo.user.firstName,
       lastName: uo.user.lastName,
       role: uo.role,
+      membershipActive: uo.isActive,
+      userAccountActive: uo.user.isActive,
+      isEmailVerified: uo.user.isEmailVerified,
       joinedAt: uo.joinedAt,
       lastActive: uo.lastAccessAt || uo.joinedAt,
     }));

--- a/zephix-frontend/src/features/administration/api/administration.api.ts
+++ b/zephix-frontend/src/features/administration/api/administration.api.ts
@@ -1,7 +1,12 @@
 import { request } from "@/lib/api";
 
 type Envelope<T> = { data: T; meta?: PageMeta };
-export type PageMeta = { page: number; limit: number; total: number };
+export type PageMeta = {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages?: number;
+};
 
 export type GovernanceDecision = {
   id: string;
@@ -120,9 +125,16 @@ export type AdminDirectoryUser = {
   id: string;
   name: string;
   email: string;
+  /** UI dropdown value (owner/admin → admin, pm → member, viewer). */
   role: "admin" | "member" | "viewer" | "owner";
-  status: "active" | "inactive";
+  membershipRole?: string;
+  platformRole?: "admin" | "member" | "viewer";
+  teams: Array<{ id: string; name: string }>;
+  status: "active" | "suspended" | "invited";
   workspaceAccess: UserWorkspaceAccess[];
+  lastActiveAt?: string | null;
+  joinedAt?: string | null;
+  isOwner?: boolean;
 };
 
 export type AdminTemplate = {
@@ -195,7 +207,10 @@ export type AdminAuditEvent = {
   id: string;
   createdAt: string;
   actorUserId: string | null;
+  actorName?: string | null;
   action: string;
+  entityType?: string;
+  entityId?: string;
   description: string;
 };
 
@@ -217,14 +232,20 @@ export type OrgMemberOption = {
   status: string;
 };
 
-function unwrapData<T>(payload: T | Envelope<T>): T {
+function unwrapData<T>(payload: T | Envelope<T> | { __zephixInner: T }): T {
+  if (payload && typeof payload === "object" && "__zephixInner" in (payload as any)) {
+    return (payload as { __zephixInner: T }).__zephixInner;
+  }
   if (payload && typeof payload === "object" && "data" in (payload as any)) {
     return (payload as Envelope<T>).data;
   }
   return payload as T;
 }
 
-function unwrapMeta<T>(payload: T | Envelope<T>): PageMeta | null {
+function unwrapMeta<T>(payload: T | Envelope<T> | { __zephixMeta: PageMeta }): PageMeta | null {
+  if (payload && typeof payload === "object" && "__zephixMeta" in (payload as any)) {
+    return ((payload as { __zephixMeta: PageMeta }).__zephixMeta || null) as PageMeta | null;
+  }
   if (payload && typeof payload === "object" && "meta" in (payload as any)) {
     return ((payload as Envelope<T>).meta || null) as PageMeta | null;
   }
@@ -344,7 +365,12 @@ export const administrationApi = {
     search?: string;
     role?: string;
     status?: string;
-  }): Promise<{ data: AdminDirectoryUser[]; meta: PageMeta | null }> {
+  }): Promise<{
+    data: AdminDirectoryUser[];
+    meta: PageMeta | null;
+    seatLimit: number | null;
+    memberCount: number;
+  }> {
     // MVP-2.1 fix: The backend GET /admin/users returns
     // { users: [{id, email, firstName, lastName, role, status, ...}], pagination: {...} }
     // NOT { data: [...] }. The response interceptor passes it through as-is
@@ -361,21 +387,65 @@ export const administrationApi = {
         ? rawPayload
         : asArray(unwrapData(rawPayload));
 
-    const data: AdminDirectoryUser[] = usersArr.map((u: any) => ({
-      id: String(u.id ?? ""),
-      name: [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.email || "Unknown",
-      email: u.email ?? "",
-      role: (u.role ?? "member").toLowerCase() as AdminDirectoryUser["role"],
-      status: (u.status ?? "active") as AdminDirectoryUser["status"],
-      workspaceAccess: Array.isArray(u.workspaceAccess) ? u.workspaceAccess : [],
-    }));
+    const data: AdminDirectoryUser[] = usersArr.map((u: any) => {
+      const ui = String(u.uiRole || "").toLowerCase();
+      const pr = String(u.platformRole || "member").toLowerCase();
+      const platformOk =
+        pr === "admin" || pr === "viewer" || pr === "member" ? pr : "member";
+      const roleForRow: AdminDirectoryUser["role"] =
+        ui === "owner"
+          ? "owner"
+          : platformOk === "admin"
+            ? "admin"
+            : platformOk === "viewer"
+              ? "viewer"
+              : "member";
+      return {
+        id: String(u.id ?? ""),
+        name: [u.firstName, u.lastName].filter(Boolean).join(" ").trim() || u.email || "Unknown",
+        email: u.email ?? "",
+        role: roleForRow,
+        membershipRole: u.membershipRole,
+        platformRole: platformOk as "admin" | "member" | "viewer",
+        teams: Array.isArray(u.teams) ? u.teams : [],
+        status: (u.status ?? "active") as AdminDirectoryUser["status"],
+        workspaceAccess: Array.isArray(u.workspaceAccess) ? u.workspaceAccess : [],
+        lastActiveAt: u.lastActive ?? null,
+        joinedAt: u.joinedAt ?? null,
+        isOwner: Boolean(u.isOwner),
+      };
+    });
 
     const pag = rawPayload.pagination;
     const meta: PageMeta | null = pag
-      ? { page: pag.page ?? 1, limit: pag.limit ?? 20, total: pag.total ?? data.length }
+      ? {
+          page: pag.page ?? 1,
+          limit: pag.limit ?? 20,
+          total: pag.total ?? data.length,
+          totalPages: pag.totalPages,
+        }
       : null;
 
-    return { data, meta };
+    const seatRaw = rawPayload.seatLimit;
+    const seatLimit =
+      seatRaw !== undefined && seatRaw !== null && Number.isFinite(Number(seatRaw))
+        ? Number(seatRaw)
+        : null;
+    const memberCount =
+      typeof rawPayload.memberCount === "number" ? rawPayload.memberCount : meta?.total ?? data.length;
+
+    return { data, meta, seatLimit, memberCount };
+  },
+
+  async getOrgTemplate(templateId: string): Promise<Record<string, unknown>> {
+    return request.get(`/admin/templates/${templateId}`);
+  },
+
+  async patchOrgTemplate(
+    templateId: string,
+    patch: { columnConfig?: Record<string, boolean> },
+  ): Promise<Record<string, unknown>> {
+    return request.patch(`/admin/templates/${templateId}`, patch);
   },
 
   async changeUserRole(
@@ -462,11 +532,27 @@ export const administrationApi = {
     limit?: number;
     action?: string;
     userId?: string;
+    actorId?: string;
+    dateRange?: string;
+    eventCategory?: string;
+    search?: string;
   }): Promise<{ data: AdminAuditEvent[]; meta: PageMeta | null }> {
-    const payload = await request.get<Envelope<AdminAuditEvent[]>>(
-      `/admin/audit${buildQuery(params || {})}`,
-    );
-    return { data: asArray(unwrapData(payload)), meta: unwrapMeta(payload) };
+    const payload = await request.get<any>(`/admin/audit${buildQuery(params || {})}`);
+    const rawRows = asArray<any>(unwrapData(payload));
+    const data: AdminAuditEvent[] = rawRows.map((row) => ({
+      id: String(row.id ?? ""),
+      createdAt: String(row.createdAt ?? ""),
+      actorUserId: row.actorUserId ?? null,
+      actorName: row.actorName ?? null,
+      action: String(row.action ?? ""),
+      entityType: String(row.entityType ?? ""),
+      entityId: String(row.entityId ?? ""),
+      description:
+        typeof row.description === "string" && row.description.trim()
+          ? row.description.trim()
+          : `${String(row.action ?? "event")} on ${String(row.entityType ?? "record")}`,
+    }));
+    return { data, meta: unwrapMeta(payload) };
   },
 
   // ── MVP-3A: Workspace Member Management ──────────────────────────

--- a/zephix-frontend/src/features/administration/components/TemplateDetailPanel.tsx
+++ b/zephix-frontend/src/features/administration/components/TemplateDetailPanel.tsx
@@ -13,6 +13,10 @@ import {
   resolveMethodologyKey,
   type GovernancePolicyUiMeta,
 } from "@/features/administration/constants/governance-policies";
+import {
+  COLUMN_CATEGORIES,
+  TEMPLATE_COLUMNS,
+} from "@/features/administration/constants/templateColumns";
 
 /**
  * List payload from GET /admin/templates is the unified Template entity shape;
@@ -23,6 +27,7 @@ export type TemplatePanelData = AdminTemplate & {
   deliveryMethod?: string | null;
   description?: string | null;
   isActive?: boolean;
+  isSystem?: boolean;
   phases?: Array<{
     name: string;
     description?: string;
@@ -39,6 +44,7 @@ type GovernancePolicyWithMeta = GovernancePolicyItem & {
 export interface TemplateDetailPanelProps {
   template: TemplatePanelData;
   onClose: () => void;
+  onTemplateUpdate?: (template: TemplatePanelData) => void;
 }
 
 /** App shell header is `h-14`; drawer is fixed so it must start below it on Admin + main app. */
@@ -48,6 +54,7 @@ const CHROME_HEIGHT_CLASS = "h-[calc(100dvh-3.5rem)]";
 export function TemplateDetailPanel({
   template,
   onClose,
+  onTemplateUpdate,
 }: TemplateDetailPanelProps) {
   const methodologyLabel = resolveMethodologyKey(template);
   const deliveryMethodRaw = template.deliveryMethod?.toString().trim() ?? "";
@@ -148,7 +155,10 @@ export function TemplateDetailPanel({
             <TemplateGovernanceTab template={template} />
           ) : null}
           {activeTab === "columns" ? (
-            <TemplateColumnsTab template={template} />
+            <TemplateColumnsTab
+              template={template}
+              onSaved={(next) => onTemplateUpdate?.(next)}
+            />
           ) : null}
         </div>
       </aside>
@@ -497,30 +507,95 @@ function TemplateGovernanceTab({ template }: { template: TemplatePanelData }) {
   );
 }
 
-function TemplateColumnsTab({ template }: { template: TemplatePanelData }) {
-  const cfg = template.columnConfig;
-  const keys = cfg ? Object.keys(cfg).filter((k) => cfg[k]) : [];
+function TemplateColumnsTab({
+  template,
+  onSaved,
+}: {
+  template: TemplatePanelData;
+  onSaved?: (next: TemplatePanelData) => void;
+}) {
+  const isSystem = Boolean(template.isSystem);
+  const [config, setConfig] = useState<Record<string, boolean>>(() => ({
+    ...(template.columnConfig || {}),
+  }));
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    setConfig({ ...(template.columnConfig || {}) });
+  }, [template.id, template.columnConfig]);
+
+  const handleToggle = async (key: string, alwaysVisible?: boolean) => {
+    if (alwaysVisible || isSystem) return;
+    const next = { ...config, [key]: !config[key] };
+    setConfig(next);
+    setSavingKey(key);
+    try {
+      await administrationApi.patchOrgTemplate(template.id, { columnConfig: next });
+      onSaved?.({ ...template, columnConfig: next });
+      toast.success("Column settings saved");
+    } catch {
+      setConfig({ ...(template.columnConfig || {}) });
+      toast.error("Could not save column settings");
+    } finally {
+      setSavingKey(null);
+    }
+  };
 
   return (
-    <div className="space-y-3 py-4 text-center text-sm text-slate-500">
-      <p>Column configuration for this template.</p>
-      {keys.length > 0 ? (
-        <div className="mx-auto max-w-sm text-left">
-          <p className="text-xs font-medium text-slate-500">
-            Enabled columns (from API)
-          </p>
-          <ul className="mt-2 list-inside list-disc text-xs text-slate-600">
-            {keys.map((k) => (
-              <li key={k}>{k}</li>
-            ))}
-          </ul>
-        </div>
+    <div className="space-y-6">
+      <p className="text-sm text-slate-500">
+        Column configuration for this template. Changes apply to new projects created from this
+        template.
+      </p>
+      {isSystem ? (
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950">
+          System templates cannot be edited here. Clone this template to an organization-owned copy
+          to customize columns.
+        </p>
       ) : (
-        <p className="text-xs text-slate-400">
-          No column defaults on this template row. Defaults can be edited when
-          authoring the template in Template Center.
+        <p className="text-xs text-slate-500">
+          Changes are saved automatically when you toggle a column (same pattern as the Governance
+          tab).
         </p>
       )}
+
+      {COLUMN_CATEGORIES.map((category) => (
+        <div key={category.key}>
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            {category.label}
+          </h4>
+          <div className="space-y-1">
+            {TEMPLATE_COLUMNS.filter((col) => col.category === category.key).map((col) => (
+              <div
+                key={col.key}
+                className="flex items-center justify-between rounded px-3 py-2 hover:bg-slate-50"
+              >
+                <span className="text-sm text-slate-700">{col.label}</span>
+                {col.alwaysVisible ? (
+                  <span className="text-xs text-slate-400">Always visible</span>
+                ) : (
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={Boolean(config[col.key])}
+                    disabled={isSystem || savingKey === col.key}
+                    onClick={() => void handleToggle(col.key, col.alwaysVisible)}
+                    className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
+                      isSystem || savingKey === col.key ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+                    } ${config[col.key] ? "bg-blue-600" : "bg-slate-200"}`}
+                  >
+                    <span
+                      className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                        config[col.key] ? "translate-x-4" : "translate-x-0.5"
+                      }`}
+                    />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/zephix-frontend/src/features/administration/constants/templateColumns.ts
+++ b/zephix-frontend/src/features/administration/constants/templateColumns.ts
@@ -1,0 +1,69 @@
+/**
+ * Admin Templates → Columns tab: catalog of keys persisted on `Template.columnConfig`
+ * and/or surfaced on the work-task row model. Keys must stay backward-compatible with
+ * existing template seeds (`phase`, `labels`, `storyPoints`, …) and `work_tasks` fields.
+ */
+export interface ColumnDefinition {
+  key: string;
+  label: string;
+  category: "core" | "schedule" | "effort" | "agile" | "governance" | "meta";
+  alwaysVisible?: boolean;
+}
+
+export const TEMPLATE_COLUMNS: ColumnDefinition[] = [
+  { key: "title", label: "Task name", category: "core", alwaysVisible: true },
+  { key: "status", label: "Status", category: "core", alwaysVisible: true },
+  { key: "assignee", label: "Assignee", category: "core" },
+  { key: "priority", label: "Priority", category: "core" },
+  { key: "type", label: "Task type", category: "core" },
+  { key: "completion", label: "Completion %", category: "core" },
+  { key: "remarks", label: "Remarks", category: "core" },
+  { key: "description", label: "Description", category: "core" },
+
+  { key: "startDate", label: "Start date", category: "schedule" },
+  { key: "dueDate", label: "Due date", category: "schedule" },
+  { key: "duration", label: "Duration (days)", category: "schedule" },
+  { key: "plannedStartAt", label: "Planned start", category: "schedule" },
+  { key: "plannedEndAt", label: "Planned end", category: "schedule" },
+  { key: "actualStartAt", label: "Actual start", category: "schedule" },
+  { key: "actualEndAt", label: "Actual end", category: "schedule" },
+  { key: "constraintType", label: "Constraint type", category: "schedule" },
+  { key: "constraintDate", label: "Constraint date", category: "schedule" },
+  { key: "isMilestone", label: "Milestone", category: "schedule" },
+  { key: "wbsCode", label: "WBS code", category: "schedule" },
+  { key: "phase", label: "Phase", category: "schedule" },
+  { key: "milestone", label: "Milestone (template flag)", category: "schedule" },
+  { key: "dependency", label: "Dependencies", category: "schedule" },
+
+  { key: "estimateHours", label: "Estimate hours", category: "effort" },
+  { key: "actualHours", label: "Actual hours", category: "effort" },
+  { key: "remainingHours", label: "Remaining hours", category: "effort" },
+
+  { key: "estimatePoints", label: "Story points", category: "agile" },
+  { key: "storyPoints", label: "Story points (template flag)", category: "agile" },
+  { key: "committed", label: "Committed", category: "agile" },
+  { key: "iteration", label: "Sprint / iteration", category: "agile" },
+  { key: "sprint", label: "Sprint (template flag)", category: "agile" },
+  { key: "epic", label: "Epic", category: "agile" },
+  { key: "wipLimit", label: "WIP limit", category: "agile" },
+  { key: "cycleTime", label: "Cycle time", category: "agile" },
+  { key: "leadTime", label: "Lead time", category: "agile" },
+  { key: "labels", label: "Labels", category: "agile" },
+
+  { key: "approvalStatus", label: "Approval status", category: "governance" },
+  { key: "documentRequired", label: "Document required", category: "governance" },
+
+  { key: "reporter", label: "Reporter", category: "meta" },
+  { key: "createdAt", label: "Created", category: "meta" },
+  { key: "updatedAt", label: "Updated", category: "meta" },
+  { key: "tags", label: "Tags", category: "meta" },
+];
+
+export const COLUMN_CATEGORIES: Array<{ key: ColumnDefinition["category"]; label: string }> = [
+  { key: "core", label: "Core" },
+  { key: "schedule", label: "Schedule" },
+  { key: "effort", label: "Effort tracking" },
+  { key: "agile", label: "Agile" },
+  { key: "governance", label: "Governance" },
+  { key: "meta", label: "Metadata" },
+];

--- a/zephix-frontend/src/features/administration/pages/AdministrationAuditLogPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationAuditLogPage.tsx
@@ -1,58 +1,130 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
 import {
   administrationApi,
   type AdminAuditEvent,
 } from "@/features/administration/api/administration.api";
 
-function formatDate(value?: string): string {
+function formatAbsolute(value?: string): string {
   if (!value) return "Unknown time";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Unknown time";
   return date.toLocaleString();
 }
 
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "Unknown";
+  const diff = Date.now() - t;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} minute${min === 1 ? "" : "s"} ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} hour${hr === 1 ? "" : "s"} ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day} day${day === 1 ? "" : "s"} ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo} month${mo === 1 ? "" : "s"} ago`;
+  const yr = Math.floor(mo / 12);
+  return `${yr} year${yr === 1 ? "" : "s"} ago`;
+}
+
+function initialsFromName(name: string, fallbackId: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase().slice(0, 2);
+  }
+  if (parts.length === 1 && parts[0].length >= 2) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return (fallbackId || "?").replace(/-/g, "").slice(0, 2).toUpperCase() || "?";
+}
+
+function eventCategoryBadgeClass(category: string): string {
+  const c = category.toLowerCase();
+  if (c === "auth") return "bg-sky-100 text-sky-800";
+  if (c === "task") return "bg-emerald-100 text-emerald-800";
+  if (c === "project") return "bg-indigo-100 text-indigo-800";
+  if (c === "governance") return "bg-violet-100 text-violet-800";
+  if (c === "admin") return "bg-slate-200 text-slate-800";
+  return "bg-slate-100 text-slate-600";
+}
+
+function inferEventCategory(entityType: string): string {
+  const et = entityType.toLowerCase();
+  if (et === "user" || et === "email_verification") return "Auth";
+  if (et === "work_task" || et === "board_move") return "Task";
+  if (et === "project" || et === "portfolio") return "Project";
+  if (
+    [
+      "work_risk",
+      "entitlement",
+      "billing_plan",
+      "scenario_plan",
+      "scenario_action",
+      "scenario_result",
+      "baseline",
+      "capacity_calendar",
+    ].includes(et)
+  ) {
+    return "Governance";
+  }
+  if (["organization", "workspace", "webhook", "attachment", "doc"].includes(et)) {
+    return "Admin";
+  }
+  return "Other";
+}
+
 export default function AdministrationAuditLogPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [query, setQuery] = useState("");
   const [events, setEvents] = useState<AdminAuditEvent[]>([]);
+  const [meta, setMeta] = useState<{ page: number; limit: number; total: number; totalPages?: number } | null>(
+    null,
+  );
+  const [dateRange, setDateRange] = useState<string>("30d");
+  const [eventCategory, setEventCategory] = useState<string>("all");
+  const [searchInput, setSearchInput] = useState("");
+  const [searchApplied, setSearchApplied] = useState("");
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await administrationApi.listAuditEvents({
+        page,
+        limit: 25,
+        dateRange,
+        eventCategory: eventCategory === "all" ? undefined : eventCategory.toLowerCase(),
+        search: searchApplied.trim() || undefined,
+      });
+      setEvents(result.data);
+      setMeta(result.meta);
+    } catch {
+      setError("Failed to load audit events.");
+      setEvents([]);
+      setMeta(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, dateRange, eventCategory, searchApplied]);
 
   useEffect(() => {
-    let active = true;
-    (async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const result = await administrationApi.listAuditEvents({ page: 1, limit: 50 });
-        if (active) setEvents(result.data);
-      } catch {
-        if (active) {
-          setError("Failed to load audit events.");
-          setEvents([]);
-        }
-      } finally {
-        if (active) setLoading(false);
-      }
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
+    void load();
+  }, [load]);
 
-  const filtered = useMemo(() => {
-    if (!query.trim()) return events;
-    const normalized = query.toLowerCase();
-    return events.filter((event) => {
-      const action = String(event.action || "").toLowerCase();
-      const actor = String(event.actorUserId || "").toLowerCase();
-      const description = String(event.description || "").toLowerCase();
-      return (
-        action.includes(normalized) ||
-        actor.includes(normalized) ||
-        description.includes(normalized)
-      );
-    });
-  }, [events, query]);
+  const totalPages = useMemo(() => {
+    if (!meta) return 1;
+    if (meta.totalPages && meta.totalPages > 0) return meta.totalPages;
+    const lim = meta.limit || 25;
+    return Math.max(1, Math.ceil((meta.total || 0) / lim));
+  }, [meta]);
+
+  const showingFrom = meta && meta.total > 0 ? (meta.page - 1) * meta.limit + 1 : 0;
+  const showingTo =
+    meta && meta.total > 0 ? Math.min(meta.page * meta.limit, meta.total) : 0;
 
   return (
     <div className="space-y-6">
@@ -63,19 +135,81 @@ export default function AdministrationAuditLogPage() {
         </p>
       </header>
 
-      <section className="rounded-lg border border-gray-200 bg-white p-4">
-        <label htmlFor="audit-filter" className="block text-xs font-medium uppercase tracking-wide text-gray-500">
-          Filter
-        </label>
-        <input
-          id="audit-filter"
-          type="text"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Filter by actor, event type, or description"
-          className="mt-2 w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-700 outline-none focus:border-gray-500"
-        />
+      <section className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4 md:flex-row md:items-end">
+        <div className="flex-1">
+          <label className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+            Date range
+          </label>
+          <select
+            value={dateRange}
+            onChange={(e) => {
+              setPage(1);
+              setDateRange(e.target.value);
+            }}
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-800 md:max-w-xs"
+          >
+            <option value="7d">Last 7 days</option>
+            <option value="30d">Last 30 days</option>
+            <option value="90d">Last 90 days</option>
+            <option value="all">All</option>
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+            Event type
+          </label>
+          <select
+            value={eventCategory}
+            onChange={(e) => {
+              setPage(1);
+              setEventCategory(e.target.value);
+            }}
+            className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-800 md:max-w-xs"
+          >
+            <option value="all">All</option>
+            <option value="auth">Auth</option>
+            <option value="task">Task</option>
+            <option value="project">Project</option>
+            <option value="governance">Governance</option>
+            <option value="admin">Admin</option>
+          </select>
+        </div>
+        <div className="min-w-0 flex-[2]">
+          <label
+            htmlFor="audit-search"
+            className="block text-xs font-medium uppercase tracking-wide text-gray-500"
+          >
+            Search
+          </label>
+          <div className="mt-1 flex gap-2">
+            <input
+              id="audit-search"
+              type="text"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  setPage(1);
+                  setSearchApplied(searchInput);
+                }
+              }}
+              placeholder="Description, action, or entity…"
+              className="min-w-0 flex-1 rounded border border-gray-300 px-3 py-2 text-sm text-gray-800"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setPage(1);
+                setSearchApplied(searchInput);
+              }}
+              className="rounded-md bg-slate-800 px-3 py-2 text-sm font-medium text-white hover:bg-slate-900"
+            >
+              Apply
+            </button>
+          </div>
+        </div>
       </section>
+
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
 
       <section className="rounded-lg border border-gray-200 bg-white">
@@ -85,7 +219,7 @@ export default function AdministrationAuditLogPage() {
               <tr className="text-left text-xs uppercase tracking-wide text-gray-500">
                 <th className="px-4 py-3">Timestamp</th>
                 <th className="px-4 py-3">Actor</th>
-                <th className="px-4 py-3">Event Type</th>
+                <th className="px-4 py-3">Event type</th>
                 <th className="px-4 py-3">Description</th>
               </tr>
             </thead>
@@ -93,28 +227,85 @@ export default function AdministrationAuditLogPage() {
               {loading ? (
                 <tr>
                   <td className="px-4 py-6 text-sm text-gray-500" colSpan={4}>
-                    Loading audit events...
+                    Loading audit events…
                   </td>
                 </tr>
-              ) : filtered.length === 0 ? (
+              ) : events.length === 0 ? (
                 <tr>
                   <td className="px-4 py-6 text-sm text-gray-500" colSpan={4}>
-                    No audit events available.
+                    No audit events match your filters.
                   </td>
                 </tr>
               ) : (
-                filtered.map((event) => (
-                  <tr key={event.id} className="border-t border-gray-200 text-sm text-gray-700">
-                    <td className="px-4 py-3">{formatDate(event.createdAt)}</td>
-                    <td className="px-4 py-3">{event.actorUserId || "System"}</td>
-                    <td className="px-4 py-3">{event.action || "Unknown event"}</td>
-                    <td className="px-4 py-3">{event.description || "—"}</td>
-                  </tr>
-                ))
+                events.map((event) => {
+                  const actorLabel =
+                    (event.actorName && String(event.actorName).trim()) ||
+                    (event.actorUserId ? String(event.actorUserId) : "System");
+                  const cat = inferEventCategory(event.entityType || "");
+                  return (
+                    <tr key={event.id} className="border-t border-gray-200 text-sm text-gray-700">
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <span title={formatAbsolute(event.createdAt)} className="cursor-default">
+                          {formatRelative(event.createdAt)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-semibold text-white"
+                            aria-hidden
+                          >
+                            {initialsFromName(actorLabel, event.actorUserId || "")}
+                          </div>
+                          <span className="font-medium text-gray-900">{actorLabel}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${eventCategoryBadgeClass(cat)}`}
+                        >
+                          {cat}
+                        </span>
+                        <div className="mt-0.5 text-[11px] text-gray-400">
+                          {event.action}
+                          {event.entityType ? ` · ${event.entityType}` : ""}
+                        </div>
+                      </td>
+                      <td className="max-w-md px-4 py-3 text-gray-800">
+                        {event.description}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>
         </div>
+        {meta && meta.total > 0 ? (
+          <div className="flex flex-col items-start justify-between gap-3 border-t border-gray-100 px-4 py-3 text-sm text-gray-600 sm:flex-row sm:items-center">
+            <p>
+              Showing {showingFrom}-{showingTo} of {meta.total}
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={page <= 1 || loading}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                className="rounded border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                disabled={page >= totalPages || loading}
+                onClick={() => setPage((p) => p + 1)}
+                className="rounded border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        ) : null}
       </section>
     </div>
   );

--- a/zephix-frontend/src/features/administration/pages/AdministrationTemplatesPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationTemplatesPage.tsx
@@ -95,6 +95,7 @@ export default function AdministrationTemplatesPage() {
         <TemplateDetailPanel
           template={selectedTemplate}
           onClose={() => setSelectedTemplate(null)}
+          onTemplateUpdate={(tpl) => setSelectedTemplate(tpl)}
         />
       ) : null}
     </div>

--- a/zephix-frontend/src/features/administration/pages/AdministrationUsersPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationUsersPage.tsx
@@ -1,9 +1,46 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+
 import {
   administrationApi,
   type AdminDirectoryUser,
 } from "@/features/administration/api/administration.api";
 import { InviteMembersDialog } from "../components/InviteMembersDialog";
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString();
+}
+
+function formatRelative(iso?: string | null): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "—";
+  const diff = Date.now() - t;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "Just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+function initials(user: AdminDirectoryUser): string {
+  const parts = user.name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase().slice(0, 2);
+  }
+  if (parts.length === 1 && parts[0].length >= 2) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return (user.email || "?").slice(0, 2).toUpperCase();
+}
+
+const STATUS_FILTERS = ["All", "Active", "Suspended", "Invited"] as const;
 
 export default function AdministrationUsersPage() {
   const [loading, setLoading] = useState(true);
@@ -11,38 +48,49 @@ export default function AdministrationUsersPage() {
   const [users, setUsers] = useState<AdminDirectoryUser[]>([]);
   const [busyUserId, setBusyUserId] = useState<string | null>(null);
   const [inviteOpen, setInviteOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeFilter, setActiveFilter] = useState<(typeof STATUS_FILTERS)[number]>("All");
+  const [menuUserId, setMenuUserId] = useState<string | null>(null);
+  const [seatLimit, setSeatLimit] = useState<number | null>(null);
+  const [memberCount, setMemberCount] = useState(0);
 
-  const loadUsers = async () => {
+  const statusParam = useMemo(() => {
+    if (activeFilter === "All") return "all";
+    return activeFilter.toLowerCase();
+  }, [activeFilter]);
+
+  const loadUsers = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const result = await administrationApi.listUsers({ page: 1, limit: 100 });
+      const result = await administrationApi.listUsers({
+        page: 1,
+        limit: 100,
+        search: searchQuery.trim() || undefined,
+        status: statusParam,
+      });
       setUsers(result.data);
+      setSeatLimit(result.seatLimit);
+      setMemberCount(result.memberCount);
     } catch {
       setError("Failed to load users.");
       setUsers([]);
+      setSeatLimit(null);
+      setMemberCount(0);
     } finally {
       setLoading(false);
     }
-  };
+  }, [searchQuery, statusParam]);
 
   useEffect(() => {
-    let active = true;
-    (async () => {
-      await loadUsers();
-      if (!active) return;
-    })();
-
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  // MVP-2: window.prompt replaced with InviteMembersDialog.
-  // The dialog handles emails, role selection, workspace assignment,
-  // and per-email result display.
+    const t = window.setTimeout(() => {
+      void loadUsers();
+    }, 300);
+    return () => window.clearTimeout(t);
+  }, [loadUsers]);
 
   const onChangeRole = async (userId: string, role: "admin" | "member" | "viewer") => {
+    if (!window.confirm(`Change this person’s role to ${role}?`)) return;
     setBusyUserId(userId);
     try {
       await administrationApi.changeUserRole(userId, role);
@@ -54,110 +102,256 @@ export default function AdministrationUsersPage() {
     }
   };
 
-  const onDeactivate = async (userId: string) => {
+  const onRemove = async (userId: string) => {
+    if (!window.confirm("Remove this person from the organization? They will lose access.")) {
+      return;
+    }
     setBusyUserId(userId);
+    setMenuUserId(null);
     try {
-      await administrationApi.deactivateUser(userId, "Deactivated from administration users page");
+      await administrationApi.deactivateUser(userId, "Removed from administration People page");
       await loadUsers();
     } catch {
-      setError("Failed to deactivate user.");
+      setError("Failed to remove user.");
     } finally {
       setBusyUserId(null);
     }
   };
 
-  const tableRows = useMemo(
-    () =>
-      users.map((user) => ({
-        id: user.id,
-        name: user.name,
-        role: user.role,
-        status: user.status,
-      })),
-    [users],
-  );
+  const onSuspend = async (userId: string) => {
+    if (
+      !window.confirm(
+        "Suspend this member’s organization access? Their seat can be reassigned.",
+      )
+    ) {
+      return;
+    }
+    setBusyUserId(userId);
+    setMenuUserId(null);
+    try {
+      await administrationApi.deactivateUser(userId, "Suspended from administration People page");
+      await loadUsers();
+    } catch {
+      setError("Failed to suspend user.");
+    } finally {
+      setBusyUserId(null);
+    }
+  };
 
   return (
     <div className="space-y-6">
-      <header className="flex items-center justify-between">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">People</h1>
+          <h1 className="text-2xl font-bold text-gray-900">People</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {memberCount} members · {seatLimit != null && Number.isFinite(seatLimit) ? seatLimit : "∞"} seats
+          </p>
           <p className="mt-1 text-sm text-gray-600">
-            Manage your organization's members, roles, and access.
+            Manage your organization&apos;s members, roles, and access.
           </p>
         </div>
         <button
           type="button"
           onClick={() => setInviteOpen(true)}
-          className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          className="shrink-0 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
         >
           Invite people
         </button>
       </header>
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
 
-      <section className="rounded-lg border border-gray-200 bg-white">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <input
+          type="text"
+          placeholder="Search by name or email…"
+          className="w-full flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 outline-none focus:border-indigo-500"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+        <div className="flex flex-wrap gap-2">
+          {STATUS_FILTERS.map((filter) => (
+            <button
+              key={filter}
+              type="button"
+              className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                activeFilter === filter
+                  ? "bg-blue-100 text-blue-800"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
+              onClick={() => setActiveFilter(filter)}
+            >
+              {filter}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <section className="overflow-hidden rounded-lg border border-gray-200 bg-white">
         <div className="overflow-x-auto">
-          <table className="min-w-full">
-            <thead className="bg-gray-50">
-              <tr className="text-left text-xs uppercase tracking-wide text-gray-500">
+          <table className="w-full min-w-[880px]">
+            <thead>
+              <tr className="border-b text-left text-xs font-medium uppercase tracking-wider text-gray-500">
                 <th className="px-4 py-3">Name</th>
+                <th className="px-4 py-3">Email</th>
                 <th className="px-4 py-3">Role</th>
+                <th className="px-4 py-3">Teams</th>
                 <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Last active</th>
+                <th className="px-4 py-3">Joined</th>
                 <th className="px-4 py-3 text-right">Actions</th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <td className="px-4 py-6 text-sm text-gray-500" colSpan={4}>
-                    Loading users...
+                  <td className="px-4 py-8 text-sm text-gray-500" colSpan={8}>
+                    Loading users…
                   </td>
                 </tr>
-              ) : tableRows.length === 0 ? (
+              ) : users.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-6 text-sm text-gray-500" colSpan={4}>
-                    No users available.
+                  <td className="px-4 py-8 text-sm text-gray-500" colSpan={8}>
+                    No users match your filters.
                   </td>
                 </tr>
               ) : (
-                tableRows.map((row) => (
-                  <tr key={row.id} className="border-t border-gray-200 text-sm text-gray-700">
-                    <td className="px-4 py-3 font-medium text-gray-900">{row.name}</td>
-                    <td className="px-4 py-3 uppercase">{row.role}</td>
-                    <td className="px-4 py-3 capitalize">{row.status}</td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex justify-end gap-2">
+                users.map((member) => {
+                  const dropdownRole = (member.platformRole ||
+                    (member.role === "viewer"
+                      ? "viewer"
+                      : member.role === "admin"
+                        ? "admin"
+                        : "member")) as "admin" | "member" | "viewer";
+                  return (
+                    <tr key={member.id} className="border-b border-gray-100 hover:bg-gray-50/80">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-3">
+                          <div
+                            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-semibold text-white"
+                            aria-hidden
+                          >
+                            {initials(member)}
+                          </div>
+                          <div className="min-w-0">
+                            <div className="truncate font-medium text-gray-900">{member.name}</div>
+                            {member.isOwner ? (
+                              <div className="text-[11px] font-medium text-amber-700">Organization owner</div>
+                            ) : null}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="max-w-[200px] truncate px-4 py-3 text-sm text-gray-600">{member.email}</td>
+                      <td className="px-4 py-3">
+                        {member.isOwner ? (
+                          <span className="text-sm font-medium text-gray-800">Owner</span>
+                        ) : (
+                          <select
+                            value={dropdownRole}
+                            disabled={busyUserId === member.id}
+                            onChange={(e) =>
+                              void onChangeRole(
+                                member.id,
+                                e.target.value as "admin" | "member" | "viewer",
+                              )
+                            }
+                            className="rounded border border-gray-300 px-2 py-1 text-sm text-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label={`Role for ${member.name}`}
+                          >
+                            <option value="admin">Admin</option>
+                            <option value="member">Member</option>
+                            <option value="viewer">Viewer</option>
+                          </select>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex max-w-[220px] flex-wrap gap-1">
+                          {member.teams.length === 0 ? (
+                            <span className="text-xs text-gray-400">—</span>
+                          ) : (
+                            member.teams.map((team) => (
+                              <span
+                                key={team.id}
+                                className="inline-flex max-w-[140px] truncate rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700"
+                                title={team.name}
+                              >
+                                {team.name}
+                              </span>
+                            ))
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                            member.status === "active"
+                              ? "bg-green-100 text-green-800"
+                              : member.status === "suspended"
+                                ? "bg-orange-100 text-orange-800"
+                                : "bg-blue-100 text-blue-800"
+                          }`}
+                        >
+                          {member.status}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                        {formatRelative(member.lastActiveAt)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                        {formatDate(member.joinedAt)}
+                      </td>
+                      <td className="relative px-4 py-3 text-right">
                         <button
                           type="button"
-                          disabled={busyUserId === row.id}
-                          onClick={() =>
-                            onChangeRole(
-                              row.id,
-                              row.role === "admin" ? "member" : "admin",
-                            )
-                          }
-                          className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50"
+                          disabled={Boolean(member.isOwner) || busyUserId === member.id}
+                          className="inline-flex rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                          aria-haspopup="menu"
+                          aria-expanded={menuUserId === member.id}
+                          onClick={() => setMenuUserId((id) => (id === member.id ? null : member.id))}
                         >
-                          {row.role === "admin" ? "Set member" : "Set admin"}
+                          <MoreHorizontal className="h-5 w-5" aria-hidden />
+                          <span className="sr-only">Open actions for {member.name}</span>
                         </button>
-                        <button
-                          type="button"
-                          disabled={busyUserId === row.id}
-                          onClick={() => onDeactivate(row.id)}
-                          className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-50"
-                        >
-                          Deactivate
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))
+                        {menuUserId === member.id ? (
+                          <div
+                            className="absolute right-4 z-[60] mt-1 w-48 rounded-md border border-gray-200 bg-white py-1 text-left shadow-lg"
+                            role="menu"
+                          >
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                              onClick={() => void onSuspend(member.id)}
+                            >
+                              Suspend access
+                            </button>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className="block w-full px-3 py-2 text-left text-sm text-red-700 hover:bg-red-50"
+                              onClick={() => void onRemove(member.id)}
+                            >
+                              Remove from organization
+                            </button>
+                          </div>
+                        ) : null}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>
         </div>
       </section>
+
+      {menuUserId ? (
+        <button
+          type="button"
+          className="fixed inset-0 z-[50] cursor-default bg-transparent"
+          aria-label="Close actions menu"
+          onClick={() => setMenuUserId(null)}
+        />
+      ) : null}
 
       <InviteMembersDialog
         isOpen={inviteOpen}

--- a/zephix-frontend/src/features/administration/pages/__tests__/AdministrationPages.test.tsx
+++ b/zephix-frontend/src/features/administration/pages/__tests__/AdministrationPages.test.tsx
@@ -62,6 +62,8 @@ describe("Administration pages", () => {
     vi.mocked(administrationApi.listUsers).mockResolvedValue({
       data: [],
       meta: { page: 1, limit: 20, total: 0 },
+      seatLimit: null,
+      memberCount: 0,
     });
     vi.mocked(administrationApi.listWorkspaces).mockResolvedValue([]);
     vi.mocked(administrationApi.listTemplates).mockResolvedValue([]);
@@ -98,7 +100,9 @@ describe("Administration pages", () => {
         <AdministrationUsersPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText("No users available.")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("No users match your filters.")).toBeInTheDocument(),
+    );
   });
 
   it("renders workspaces panel and templates pages with API empty states", async () => {

--- a/zephix-frontend/src/lib/__tests__/api.test.ts
+++ b/zephix-frontend/src/lib/__tests__/api.test.ts
@@ -64,9 +64,23 @@ describe('API envelope unwrapping', () => {
     const responseHandler = (api.interceptors.response as any).handlers[0]?.fulfilled;
     const unwrapped = responseHandler?.(mockResponse);
 
-    // The test verifies that the interceptor in api.ts
-    // correctly unwraps the envelope structure
-    expect(unwrapped).toEqual({ id: '123', name: 'test' });
+    // When the server sends pagination `meta`, preserve it alongside the list payload.
+    expect(unwrapped).toEqual({
+      __zephixInner: mockData,
+      __zephixMeta: { timestamp: '2024-01-01T00:00:00Z', requestId: 'req-123' },
+    });
+  });
+
+  it('should unwrap { data } envelope without meta to inner data only', async () => {
+    const mockData = { id: '456', name: 'solo' };
+    const mockResponse = {
+      data: {
+        data: mockData,
+      },
+    };
+    const responseHandler = (api.interceptors.response as any).handlers[0]?.fulfilled;
+    const unwrapped = responseHandler?.(mockResponse);
+    expect(unwrapped).toEqual(mockData);
   });
 
   it('should handle flat responses without envelope', async () => {

--- a/zephix-frontend/src/lib/api.ts
+++ b/zephix-frontend/src/lib/api.ts
@@ -214,7 +214,14 @@ api.interceptors.request.use(async (cfg) => {
 api.interceptors.response.use(
   (res) => {
     const data = res?.data;
-    if (data && typeof data === "object" && "data" in data) return (data as any).data;
+    if (data && typeof data === "object" && "data" in data) {
+      const inner = (data as any).data;
+      const meta = (data as any).meta;
+      if (meta != null && typeof meta === "object") {
+        return { __zephixInner: inner, __zephixMeta: meta };
+      }
+      return inner;
+    }
     return data;
   },
   async (err) => {


### PR DESCRIPTION
## Summary
Session 5 / Admin Console Design Lock — PR 2: audit data quality, People table redesign, template column toggles.

### Audit Trail
- Actor display names (user lookup), human-readable descriptions
- Pagination, date range + event category filters, search
- Default page size 25

### People
- Full table: Name, Email, Role, Teams, Status, Last Active, Joined, Actions
- Search + status pills; member count + seat hint in header
- Role change with confirmation; owner protected

### Templates
- `columnConfig` on PATCH org template; Columns tab toggle grid + categories
- System templates: read-only notice

### Notes
- Axios: responses with `{ data, meta }` preserve meta via `__zephixInner` / `__zephixMeta` — watch non-admin callers after deploy.

Targets **staging**.

Made with [Cursor](https://cursor.com)