### PR TITLE
feat(admin): teams activation + governance PMBOK redesign

### DIFF
--- a/zephix-backend/src/admin/admin.controller.ts
+++ b/zephix-backend/src/admin/admin.controller.ts
@@ -12,6 +12,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -1201,6 +1202,120 @@ export class AdminController {
         throw _error;
       }
       throw new InternalServerErrorException('Failed to update team');
+    }
+  }
+
+  @Post('teams/:id/members')
+  @ApiOperation({ summary: 'Add a member to a team' })
+  @ApiResponse({ status: 201, description: 'Member added' })
+  async addTeamMember(
+    @Request() req: AuthRequest,
+    @Param('id') teamId: string,
+    @Body() body: { userId: string },
+  ) {
+    try {
+      const { organizationId } = getAuthContext(req);
+      if (!body?.userId || typeof body.userId !== 'string') {
+        throw new BadRequestException('userId is required');
+      }
+      const team = await this.teamsService.addTeamMember(
+        organizationId,
+        teamId,
+        body.userId,
+      );
+      const frontendVisibility = this.mapVisibilityToFrontend(team.visibility);
+      return {
+        id: team.id,
+        name: team.name,
+        shortCode: team.slug,
+        color: team.color,
+        visibility: frontendVisibility,
+        description: team.description,
+        workspaceId: team.workspaceId,
+        status: team.isArchived ? 'archived' : 'active',
+        memberCount: (team as any).membersCount || 0,
+        projectCount: (team as any).projectsCount || 0,
+        createdAt: team.createdAt.toISOString(),
+        updatedAt: team.updatedAt.toISOString(),
+        members:
+          team.members?.map((m) => ({
+            id: m.id,
+            userId: m.userId,
+            role: m.role,
+            user: m.user
+              ? {
+                  id: m.user.id,
+                  email: m.user.email,
+                  firstName: m.user.firstName,
+                  lastName: m.user.lastName,
+                }
+              : null,
+          })) || [],
+      };
+    } catch (error) {
+      if (
+        error instanceof NotFoundException ||
+        error instanceof BadRequestException ||
+        error instanceof ConflictException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Failed to add team member');
+    }
+  }
+
+  @Delete('teams/:id/members/:userId')
+  @ApiOperation({ summary: 'Remove a member from a team' })
+  @ApiResponse({ status: 200, description: 'Member removed' })
+  async removeTeamMember(
+    @Request() req: AuthRequest,
+    @Param('id') teamId: string,
+    @Param('userId') memberUserId: string,
+  ) {
+    try {
+      const { organizationId } = getAuthContext(req);
+      const team = await this.teamsService.removeTeamMember(
+        organizationId,
+        teamId,
+        memberUserId,
+      );
+      const frontendVisibility = this.mapVisibilityToFrontend(team.visibility);
+      return {
+        id: team.id,
+        name: team.name,
+        shortCode: team.slug,
+        color: team.color,
+        visibility: frontendVisibility,
+        description: team.description,
+        workspaceId: team.workspaceId,
+        status: team.isArchived ? 'archived' : 'active',
+        memberCount: (team as any).membersCount || 0,
+        projectCount: (team as any).projectsCount || 0,
+        createdAt: team.createdAt.toISOString(),
+        updatedAt: team.updatedAt.toISOString(),
+        members:
+          team.members?.map((m) => ({
+            id: m.id,
+            userId: m.userId,
+            role: m.role,
+            user: m.user
+              ? {
+                  id: m.user.id,
+                  email: m.user.email,
+                  firstName: m.user.firstName,
+                  lastName: m.user.lastName,
+                }
+              : null,
+          })) || [],
+      };
+    } catch (error) {
+      if (
+        error instanceof NotFoundException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Failed to remove team member');
     }
   }
 

--- a/zephix-backend/src/modules/teams/teams.service.ts
+++ b/zephix-backend/src/modules/teams/teams.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
   Inject,
 } from '@nestjs/common';
@@ -341,6 +342,60 @@ export class TeamsService {
     // Soft delete by archiving
     team.isArchived = true;
     await this.teamRepository.save(team);
+
+    return this.getTeamById(organizationId, teamId);
+  }
+
+  /**
+   * Add a user to a team (org-scoped). New members are always MEMBER; owner is set at team creation only.
+   */
+  async addTeamMember(
+    organizationId: string,
+    teamId: string,
+    userId: string,
+  ): Promise<Team & { membersCount: number; projectsCount: number }> {
+    await this.getTeamById(organizationId, teamId);
+
+    const existing = await this.teamMemberRepository.findOne({
+      where: { teamId, userId },
+    });
+    if (existing) {
+      throw new ConflictException('User is already a member of this team');
+    }
+
+    const member = this.teamMemberRepository.create({
+      teamId,
+      userId,
+      role: TeamMemberRole.MEMBER,
+    });
+    await this.teamMemberRepository.save(member);
+
+    return this.getTeamById(organizationId, teamId);
+  }
+
+  /**
+   * Remove a user from a team. Team owner cannot be removed (delete or archive team instead).
+   */
+  async removeTeamMember(
+    organizationId: string,
+    teamId: string,
+    userId: string,
+  ): Promise<Team & { membersCount: number; projectsCount: number }> {
+    await this.getTeamById(organizationId, teamId);
+
+    const membership = await this.teamMemberRepository.findOne({
+      where: { teamId, userId },
+    });
+    if (!membership) {
+      throw new NotFoundException('Member not found in team');
+    }
+    if (membership.role === TeamMemberRole.OWNER) {
+      throw new BadRequestException(
+        'Cannot remove the team owner. Archive the team or remove other members first.',
+      );
+    }
+
+    await this.teamMemberRepository.remove(membership);
 
     return this.getTeamById(organizationId, teamId);
   }

--- a/zephix-frontend/src/features/administration/api/administration.api.ts
+++ b/zephix-frontend/src/features/administration/api/administration.api.ts
@@ -121,6 +121,37 @@ export type UserWorkspaceAccess = {
   accessLevel: "workspace_owner" | "delivery_owner" | "contributor" | "viewer";
 };
 
+export type AdminTeamMember = {
+  id: string;
+  userId: string;
+  role: string;
+  user: {
+    id: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  } | null;
+};
+
+export type AdminTeamSummary = {
+  id: string;
+  name: string;
+  shortCode: string;
+  color?: string | null;
+  visibility?: string;
+  description?: string | null;
+  workspaceId?: string | null;
+  status: string;
+  memberCount: number;
+  projectCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminTeamDetail = AdminTeamSummary & {
+  members: AdminTeamMember[];
+};
+
 export type AdminDirectoryUser = {
   id: string;
   name: string;
@@ -446,6 +477,62 @@ export const administrationApi = {
     patch: { columnConfig?: Record<string, boolean> },
   ): Promise<Record<string, unknown>> {
     return request.patch(`/admin/templates/${templateId}`, patch);
+  },
+
+  async listAdminTeams(params?: {
+    search?: string;
+    page?: number;
+    limit?: number;
+    status?: string;
+    workspaceId?: string;
+  }): Promise<AdminTeamSummary[]> {
+    const rows = await request.get<AdminTeamSummary[]>(`/admin/teams${buildQuery(params || {})}`);
+    return asArray(rows);
+  },
+
+  async getAdminTeam(teamId: string): Promise<AdminTeamDetail> {
+    return request.get<AdminTeamDetail>(`/admin/teams/${teamId}`);
+  },
+
+  async createAdminTeam(body: {
+    name: string;
+    shortCode: string;
+    description?: string;
+    visibility?: string;
+    color?: string;
+    workspaceId?: string;
+  }): Promise<AdminTeamSummary> {
+    return request.post<AdminTeamSummary>(`/admin/teams`, {
+      ...body,
+      visibility: body.visibility ?? "public",
+    });
+  },
+
+  async updateAdminTeam(
+    teamId: string,
+    body: Partial<{
+      name: string;
+      shortCode: string;
+      description: string;
+      visibility: string;
+      color: string;
+      workspaceId: string;
+      status: string;
+    }>,
+  ): Promise<AdminTeamSummary> {
+    return request.patch<AdminTeamSummary>(`/admin/teams/${teamId}`, body);
+  },
+
+  async deleteAdminTeam(teamId: string): Promise<AdminTeamSummary> {
+    return request.delete<AdminTeamSummary>(`/admin/teams/${teamId}`);
+  },
+
+  async addTeamMember(teamId: string, userId: string): Promise<AdminTeamDetail> {
+    return request.post<AdminTeamDetail>(`/admin/teams/${teamId}/members`, { userId });
+  },
+
+  async removeTeamMember(teamId: string, userId: string): Promise<AdminTeamDetail> {
+    return request.delete<AdminTeamDetail>(`/admin/teams/${teamId}/members/${userId}`);
   },
 
   async changeUserRole(

--- a/zephix-frontend/src/features/administration/pages/AdministrationGovernancePage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationGovernancePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { ClipboardList, Info, ShieldCheck, X } from "lucide-react";
 import {
   administrationApi,
   type GovernanceApproval,
@@ -7,7 +8,10 @@ import {
   type GovernanceHealth,
   type GovernanceQueueItem,
 } from "@/features/administration/api/administration.api";
-import { POLICY_UI_META } from "@/features/administration/constants/governance-policies";
+import {
+  POLICY_UI_META,
+  type GovernancePolicyUiMeta,
+} from "@/features/administration/constants/governance-policies";
 import { ConfirmActionDialog } from "../components/ConfirmActionDialog";
 
 type GovernanceTab = "policies" | "exceptions" | "approvals";
@@ -34,10 +38,121 @@ function formatExceptionTypeLabel(exceptionType: string): string {
   return exceptionType.replace(/_/g, " ");
 }
 
+const GOVERNANCE_EXPLAINER_KEY = "zephix-admin-governance-explainer-dismissed";
+
+/** Engine evaluates these on task create / status / bulk today. */
+const ACTIVE_POLICY_CODES = new Set(["scope-change-control", "task-completion-signoff"]);
+
+/** Phase lifecycle checkpoints; WorkPhasesService hook still TODO. */
+const PHASE_GATE_POLICY_CODES = new Set(["phase-gate-approval", "deliverable-doc-required"]);
+
+type PolicyUiBucket = "active" | "phaseGate" | "planned";
+
+function categorizeCatalogPolicies(policies: GovernanceCatalogItem[]): Record<PolicyUiBucket, GovernanceCatalogItem[]> {
+  const active: GovernanceCatalogItem[] = [];
+  const phaseGate: GovernanceCatalogItem[] = [];
+  const planned: GovernanceCatalogItem[] = [];
+  for (const p of policies) {
+    if (ACTIVE_POLICY_CODES.has(p.code)) active.push(p);
+    else if (PHASE_GATE_POLICY_CODES.has(p.code)) phaseGate.push(p);
+    else planned.push(p);
+  }
+  return { active, phaseGate, planned };
+}
+
+function PolicyCard({
+  policy,
+  meta,
+  status,
+  onConfigure,
+}: {
+  policy: GovernanceCatalogItem;
+  meta: GovernancePolicyUiMeta | null;
+  status: "active" | "coming" | "planned";
+  onConfigure: () => void;
+}) {
+  const title = meta?.displayName ?? policy.name;
+  const description = meta?.description ?? policy.ruleDefinition?.message ?? "";
+  const methodologies = meta?.methodologies ?? [];
+
+  return (
+    <div
+      className={`mb-3 rounded-lg border p-4 ${
+        status === "active"
+          ? "border-gray-200 bg-white"
+          : status === "coming"
+            ? "border-amber-100 bg-amber-50/30"
+            : "border-gray-100 bg-gray-50/50"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="font-medium text-gray-900">{title}</h4>
+            {status === "active" ? (
+              <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">Enforceable</span>
+            ) : null}
+            {status === "coming" ? (
+              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700">Coming soon</span>
+            ) : null}
+            {status === "planned" ? (
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">Planned</span>
+            ) : null}
+          </div>
+          <p className="mt-1 text-sm text-gray-500">{description}</p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium uppercase tracking-wide text-gray-400">{policy.entityType}</span>
+            {methodologies.length > 0 ? (
+              <>
+                <span className="text-gray-300">·</span>
+                <div className="flex flex-wrap gap-1">
+                  {methodologies.map((m) => (
+                    <span key={m} className="rounded bg-gray-100 px-1.5 py-0.5 text-xs capitalize text-gray-600">
+                      {m}
+                    </span>
+                  ))}
+                </div>
+              </>
+            ) : null}
+          </div>
+        </div>
+        {status === "active" ? (
+          <div className="flex shrink-0 flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-3">
+            <span className="text-xs text-gray-400">
+              Active on {policy.activeOnTemplates} template{policy.activeOnTemplates !== 1 ? "s" : ""}
+            </span>
+            <button
+              type="button"
+              onClick={onConfigure}
+              className="text-sm font-medium text-blue-600 hover:text-blue-800"
+            >
+              Configure →
+            </button>
+          </div>
+        ) : null}
+      </div>
+      {status === "active" && policy.activeOnTemplates > 0 ? (
+        <p className="mt-3 border-t border-gray-100 pt-3 text-xs text-gray-400">
+          Toggle this policy on the Templates page for each methodology template. Project instances inherit enabled
+          policies automatically.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function PoliciesTab() {
+  const navigate = useNavigate();
   const [catalog, setCatalog] = useState<GovernanceCatalogItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showExplainer, setShowExplainer] = useState(() => {
+    try {
+      return typeof localStorage !== "undefined" && localStorage.getItem(GOVERNANCE_EXPLAINER_KEY) !== "1";
+    } catch {
+      return true;
+    }
+  });
 
   useEffect(() => {
     let active = true;
@@ -58,6 +173,19 @@ function PoliciesTab() {
     };
   }, []);
 
+  const dismissExplainer = () => {
+    try {
+      localStorage.setItem(GOVERNANCE_EXPLAINER_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setShowExplainer(false);
+  };
+
+  const goTemplates = () => {
+    navigate("/administration/templates");
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -71,87 +199,108 @@ function PoliciesTab() {
     return <div className="py-8 text-center text-sm text-red-600">{error}</div>;
   }
 
+  const { active, phaseGate, planned } = categorizeCatalogPolicies(catalog);
+
   return (
-    <section className="space-y-4">
-      <p className="text-sm text-gray-600">
-        Governance policies define rules that projects must follow. Policies are configured per
-        template and inherited by projects created from that template.
-      </p>
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Policies</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Governance policies define the rules and controls that projects follow. Policies are configured per template
+          and inherited by projects created from that template.
+        </p>
+      </div>
+
+      {showExplainer ? (
+        <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
+          <div className="flex items-start gap-3">
+            <Info className="mt-0.5 h-5 w-5 shrink-0 text-blue-500" aria-hidden />
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-medium text-blue-900">How governance works in Zephix</h3>
+              <p className="mt-1 text-sm text-blue-700">
+                Policies define guardrails for your projects. Enable policies on templates — every project created from
+                that template inherits them automatically. When a team member takes an action that violates a policy,
+                they are blocked and can request an exception. Admins review exceptions in the Exceptions tab.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 text-blue-400 hover:text-blue-600"
+              onClick={dismissExplainer}
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       {catalog.length === 0 ? (
         <div className="py-8 text-center text-sm text-gray-500">
-          No governance policies available. The system policy catalog will be populated when the
-          governance migration runs.
+          No governance policies available. The system policy catalog will be populated when the governance migration
+          runs.
         </div>
       ) : (
-        <div className="space-y-3">
-          {catalog.map((policy) => {
-            const meta = POLICY_UI_META[policy.code];
-            if (!meta) return null;
-
-            return (
-              <div
+        <>
+          <div className="mb-8">
+            <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-gray-900">
+              <span className="h-2 w-2 shrink-0 rounded-full bg-green-500" aria-hidden />
+              Active policies
+            </h3>
+            <p className="mb-4 text-xs text-gray-500">
+              These policies are enforceable now. Toggle them on per template to activate.
+            </p>
+            {active.map((policy) => (
+              <PolicyCard
                 key={policy.code}
-                className={`rounded-lg border p-4 ${
-                  meta.tier === 3
-                    ? "border-gray-100 bg-gray-50 opacity-60"
-                    : "border-gray-200 bg-white"
-                }`}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-medium text-gray-900">{meta.displayName}</span>
-                      {meta.tier === 2 ? (
-                        <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-600">
-                          Enforcement coming soon
-                        </span>
-                      ) : null}
-                      {meta.tier === 3 ? (
-                        <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">
-                          Coming soon
-                        </span>
-                      ) : null}
-                      {policy.activeOnTemplates > 0 && meta.tier <= 2 ? (
-                        <span className="rounded bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-600">
-                          Active on {policy.activeOnTemplates} template
-                          {policy.activeOnTemplates !== 1 ? "s" : ""}
-                        </span>
-                      ) : null}
-                      {policy.activeOnTemplates === 0 && meta.tier <= 2 ? (
-                        <span className="rounded bg-gray-50 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">
-                          Not configured
-                        </span>
-                      ) : null}
-                    </div>
-                    <p className="mt-1 text-xs text-gray-500">{meta.description}</p>
-                    <p className="mt-1 text-[10px] font-medium uppercase tracking-wide text-gray-500">
-                      {policy.entityType}
-                    </p>
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {meta.methodologies.map((m) => (
-                        <span
-                          key={m}
-                          className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] capitalize text-gray-500"
-                        >
-                          {m}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                  {meta.tier <= 2 ? (
-                    <Link
-                      to="/administration/templates"
-                      className="shrink-0 whitespace-nowrap text-xs text-blue-600 hover:text-blue-800"
-                    >
-                      Configure →
-                    </Link>
-                  ) : null}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+                policy={policy}
+                meta={POLICY_UI_META[policy.code] ?? null}
+                status="active"
+                onConfigure={goTemplates}
+              />
+            ))}
+          </div>
+
+          <div className="mb-8">
+            <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-gray-900">
+              <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" aria-hidden />
+              Phase gate controls
+            </h3>
+            <p className="mb-4 text-xs text-gray-500">
+              Phase gates are checkpoints where projects must meet specific criteria before advancing. Enforcement is
+              being wired — these policies will be active in the next release.
+            </p>
+            {phaseGate.map((policy) => (
+              <PolicyCard
+                key={policy.code}
+                policy={policy}
+                meta={POLICY_UI_META[policy.code] ?? null}
+                status="coming"
+                onConfigure={goTemplates}
+              />
+            ))}
+          </div>
+
+          <div className="mb-8">
+            <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-gray-900">
+              <span className="h-2 w-2 shrink-0 rounded-full bg-gray-300" aria-hidden />
+              Planned
+            </h3>
+            <p className="mb-4 text-xs text-gray-500">
+              Additional controls on the roadmap. Some definitions exist in the catalog; engine wiring will follow in
+              future releases.
+            </p>
+            {planned.map((policy) => (
+              <PolicyCard
+                key={policy.code}
+                policy={policy}
+                meta={POLICY_UI_META[policy.code] ?? null}
+                status="planned"
+                onConfigure={goTemplates}
+              />
+            ))}
+          </div>
+        </>
       )}
     </section>
   );
@@ -248,9 +397,9 @@ export default function AdministrationGovernancePage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold text-gray-900">Governance</h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Manage policy definitions, exception workflow, and approval readiness.
+        <h1 className="text-2xl font-bold text-gray-900">Governance</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Policy catalog, exception queue, and recorded decisions. Configure which policies apply on the Templates page.
         </p>
       </header>
 
@@ -297,7 +446,14 @@ export default function AdministrationGovernancePage() {
           {loading ? (
             <p className="mt-2 text-sm text-gray-500">Loading exceptions...</p>
           ) : queue.length === 0 ? (
-            <p className="mt-2 text-sm text-gray-500">No exceptions in queue.</p>
+            <div className="py-12 text-center">
+              <ShieldCheck className="mx-auto h-10 w-10 text-green-300" aria-hidden />
+              <h3 className="mt-3 text-sm font-medium text-gray-900">No pending exceptions</h3>
+              <p className="mx-auto mt-1 max-w-md text-sm text-gray-500">
+                When a team member is blocked by a governance policy, they can request an exception. Pending exceptions
+                will appear here for your review.
+              </p>
+            </div>
           ) : (
             <div className="mt-3 space-y-2">
               {queue.map((item) => {
@@ -402,7 +558,14 @@ export default function AdministrationGovernancePage() {
           {loading ? (
             <p className="mt-2 text-sm text-gray-500">Loading approvals...</p>
           ) : approvals.length === 0 ? (
-            <p className="mt-2 text-sm text-gray-500">No approvals found.</p>
+            <div className="py-12 text-center">
+              <ClipboardList className="mx-auto h-10 w-10 text-gray-300" aria-hidden />
+              <h3 className="mt-3 text-sm font-medium text-gray-900">No approvals yet</h3>
+              <p className="mx-auto mt-1 max-w-md text-sm text-gray-500">
+                Approved and rejected governance exceptions will be recorded here as an audit trail of governance
+                decisions.
+              </p>
+            </div>
           ) : (
             <div className="mt-3 space-y-2">
               {approvals.map((item) => (

--- a/zephix-frontend/src/features/administration/pages/AdministrationTeamsPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdministrationTeamsPage.tsx
@@ -1,26 +1,531 @@
-import { UsersRound } from "lucide-react";
+import { Fragment, useCallback, useEffect, useState } from "react";
+import { Loader2, MoreHorizontal, UsersRound, X } from "lucide-react";
+
+import {
+  administrationApi,
+  type AdminDirectoryUser,
+  type AdminTeamDetail,
+  type AdminTeamMember,
+  type AdminTeamSummary,
+} from "@/features/administration/api/administration.api";
+
+function displayNameFromUser(user: AdminTeamMember["user"]): string {
+  if (!user) return "Unknown";
+  const n = [user.firstName, user.lastName].filter(Boolean).join(" ").trim();
+  return n || user.email || "Unknown";
+}
+
+function initials(name: string): string {
+  const p = name.trim().split(/\s+/).filter(Boolean);
+  if (p.length >= 2) return (p[0][0] + p[1][0]).toUpperCase().slice(0, 2);
+  if (p.length === 1 && p[0].length >= 2) return p[0].slice(0, 2).toUpperCase();
+  return name.slice(0, 2).toUpperCase() || "?";
+}
+
+function roleLabel(role: string): string {
+  const r = role.toUpperCase();
+  if (r === "OWNER") return "Lead";
+  return "Member";
+}
+
+type TeamModalMode = "create" | "edit" | null;
 
 export default function AdministrationTeamsPage() {
+  const [teams, setTeams] = useState<AdminTeamSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
+  const [detailById, setDetailById] = useState<Record<string, AdminTeamDetail>>({});
+  const [detailLoadingId, setDetailLoadingId] = useState<string | null>(null);
+  const [menuTeamId, setMenuTeamId] = useState<string | null>(null);
+  const [modalMode, setModalMode] = useState<TeamModalMode>(null);
+  const [editingTeam, setEditingTeam] = useState<AdminTeamSummary | null>(null);
+  const [formName, setFormName] = useState("");
+  const [formShortCode, setFormShortCode] = useState("");
+  const [formDescription, setFormDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [addMemberTeamId, setAddMemberTeamId] = useState<string | null>(null);
+  const [userSearch, setUserSearch] = useState("");
+  const [userHits, setUserHits] = useState<AdminDirectoryUser[]>([]);
+  const [userSearchLoading, setUserSearchLoading] = useState(false);
+  const [busyMemberKey, setBusyMemberKey] = useState<string | null>(null);
+
+  const loadTeams = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await administrationApi.listAdminTeams({ limit: 100, page: 1 });
+      setTeams(rows);
+    } catch {
+      setError("Failed to load teams.");
+      setTeams([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTeams();
+  }, [loadTeams]);
+
+  const loadDetail = async (teamId: string) => {
+    setDetailLoadingId(teamId);
+    try {
+      const d = await administrationApi.getAdminTeam(teamId);
+      setDetailById((prev) => ({ ...prev, [teamId]: d }));
+    } catch {
+      setError("Failed to load team members.");
+    } finally {
+      setDetailLoadingId(null);
+    }
+  };
+
+  const toggleExpand = async (teamId: string) => {
+    if (expandedTeamId === teamId) {
+      setExpandedTeamId(null);
+      return;
+    }
+    setExpandedTeamId(teamId);
+    if (!detailById[teamId]) {
+      await loadDetail(teamId);
+    }
+  };
+
+  const openCreate = () => {
+    setEditingTeam(null);
+    setFormName("");
+    setFormShortCode("");
+    setFormDescription("");
+    setModalMode("create");
+  };
+
+  const openEdit = (t: AdminTeamSummary) => {
+    setEditingTeam(t);
+    setFormName(t.name);
+    setFormShortCode(t.shortCode || "");
+    setFormDescription(t.description || "");
+    setModalMode("edit");
+    setMenuTeamId(null);
+  };
+
+  const submitModal = async () => {
+    const name = formName.trim();
+    const raw = formShortCode.trim().replace(/^@+/, "").toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 10);
+    if (!name || name.length < 2) {
+      setError("Team name must be at least 2 characters.");
+      return;
+    }
+    if (!raw || raw.length < 2) {
+      setError("Alias (short code) must be at least 2 letters or numbers.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      if (modalMode === "create") {
+        await administrationApi.createAdminTeam({
+          name,
+          shortCode: raw,
+          description: formDescription.trim() || undefined,
+          visibility: "public",
+        });
+      } else if (modalMode === "edit" && editingTeam) {
+        await administrationApi.updateAdminTeam(editingTeam.id, {
+          name,
+          shortCode: raw,
+          description: formDescription.trim() || undefined,
+        });
+      }
+      setModalMode(null);
+      setEditingTeam(null);
+      setDetailById({});
+      setExpandedTeamId(null);
+      await loadTeams();
+    } catch {
+      setError("Could not save team. Check alias is unique.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onDeleteTeam = async (t: AdminTeamSummary) => {
+    if (!window.confirm(`Archive team "${t.name}"? Members stay in the org but lose this team label.`)) return;
+    setMenuTeamId(null);
+    try {
+      await administrationApi.deleteAdminTeam(t.id);
+      setDetailById({});
+      setExpandedTeamId(null);
+      await loadTeams();
+    } catch {
+      setError("Failed to archive team.");
+    }
+  };
+
+  useEffect(() => {
+    if (addMemberTeamId == null) {
+      setUserHits([]);
+      return;
+    }
+    const q = userSearch.trim();
+    if (q.length < 2) {
+      setUserHits([]);
+      return;
+    }
+    const id = window.setTimeout(() => {
+      void (async () => {
+        setUserSearchLoading(true);
+        try {
+          const res = await administrationApi.listUsers({
+            search: q,
+            limit: 20,
+            page: 1,
+            status: "all",
+          });
+          setUserHits(res.data);
+        } catch {
+          setUserHits([]);
+        } finally {
+          setUserSearchLoading(false);
+        }
+      })();
+    }, 300);
+    return () => window.clearTimeout(id);
+  }, [userSearch, addMemberTeamId]);
+
+  const onAddMember = async (teamId: string, userId: string) => {
+    setBusyMemberKey(`${teamId}:${userId}`);
+    setError(null);
+    try {
+      const updated = await administrationApi.addTeamMember(teamId, userId);
+      setDetailById((prev) => ({ ...prev, [teamId]: updated }));
+      setAddMemberTeamId(null);
+      setUserSearch("");
+      setUserHits([]);
+      await loadTeams();
+    } catch {
+      setError("Could not add member.");
+    } finally {
+      setBusyMemberKey(null);
+    }
+  };
+
+  const onRemoveMember = async (teamId: string, userId: string) => {
+    if (!window.confirm("Remove this person from the team?")) return;
+    setBusyMemberKey(`${teamId}:${userId}`);
+    setError(null);
+    try {
+      const updated = await administrationApi.removeTeamMember(teamId, userId);
+      setDetailById((prev) => ({ ...prev, [teamId]: updated }));
+      await loadTeams();
+    } catch {
+      setError("Could not remove member (team owner cannot be removed).");
+    } finally {
+      setBusyMemberKey(null);
+    }
+  };
+
   return (
-    <div>
-      <div className="mb-6">
-        <h1 className="text-xl font-bold text-gray-900">Teams</h1>
-        <p className="text-sm text-gray-500 mt-1">
-          Create and manage teams, departments, and cross-functional groups.
-        </p>
-      </div>
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <div className="w-16 h-16 rounded-2xl bg-gradient-to-r from-blue-500 to-cyan-500 flex items-center justify-center mb-4">
-          <UsersRound className="w-8 h-8 text-white" />
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Teams</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Organize people into teams and departments. Aliases appear as short codes (for example{" "}
+            <span className="font-mono text-xs">@ENG</span>).
+          </p>
         </div>
-        <h2 className="text-lg font-semibold text-gray-900 mb-2">Teams — Coming Soon</h2>
-        <p className="text-sm text-gray-500 max-w-md">
-          Organize your people into teams and departments. Assign teams to workspaces and projects for streamlined access management.
-        </p>
-        <span className="mt-4 inline-flex items-center rounded-full bg-gradient-to-r from-blue-50 to-cyan-50 px-3 py-1 text-xs font-medium text-blue-700">
-          On the roadmap
-        </span>
-      </div>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="inline-flex shrink-0 items-center justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          + Create team
+        </button>
+      </header>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      {menuTeamId ? (
+        <button
+          type="button"
+          className="fixed inset-0 z-40 cursor-default bg-transparent"
+          aria-label="Close menu"
+          onClick={() => setMenuTeamId(null)}
+        />
+      ) : null}
+
+      <section className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        {loading ? (
+          <div className="flex items-center justify-center gap-2 py-16 text-sm text-gray-500">
+            <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+            Loading teams…
+          </div>
+        ) : teams.length === 0 ? (
+          <div className="py-16 text-center">
+            <UsersRound className="mx-auto h-12 w-12 text-gray-300" aria-hidden />
+            <h3 className="mt-4 text-lg font-medium text-gray-900">No teams yet</h3>
+            <p className="mx-auto mt-2 max-w-md text-sm text-gray-500">
+              Create teams to organize people into departments and cross-functional groups.
+            </p>
+            <button
+              type="button"
+              onClick={openCreate}
+              className="mt-4 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            >
+              + Create team
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="border-b bg-gray-50 text-xs font-medium uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-4 py-3">Team name</th>
+                  <th className="px-4 py-3">Alias</th>
+                  <th className="px-4 py-3">Members</th>
+                  <th className="px-4 py-3 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {teams.map((team) => {
+                  const detail = detailById[team.id];
+                  return (
+                    <Fragment key={team.id}>
+                      <tr
+                        className="cursor-pointer border-b border-gray-100 hover:bg-gray-50"
+                        onClick={() => void toggleExpand(team.id)}
+                      >
+                        <td className="px-4 py-3 font-medium text-gray-900">{team.name}</td>
+                        <td className="px-4 py-3 font-mono text-xs text-gray-600">@{team.shortCode || "—"}</td>
+                        <td className="px-4 py-3 text-gray-600">{team.memberCount}</td>
+                        <td className="relative px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
+                          <button
+                            type="button"
+                            className="inline-flex rounded p-1 text-gray-500 hover:bg-gray-100"
+                            aria-label="Team actions"
+                            onClick={() => setMenuTeamId((id) => (id === team.id ? null : team.id))}
+                          >
+                            <MoreHorizontal className="h-5 w-5" />
+                          </button>
+                          {menuTeamId === team.id ? (
+                            <div className="absolute right-4 z-50 mt-1 w-44 rounded-md border border-gray-200 bg-white py-1 text-left shadow-lg">
+                              <button
+                                type="button"
+                                className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                                onClick={() => openEdit(team)}
+                              >
+                                Edit team
+                              </button>
+                              <button
+                                type="button"
+                                className="block w-full px-3 py-2 text-left text-sm text-red-700 hover:bg-red-50"
+                                onClick={() => void onDeleteTeam(team)}
+                              >
+                                Archive team
+                              </button>
+                            </div>
+                          ) : null}
+                        </td>
+                      </tr>
+                      {expandedTeamId === team.id ? (
+                        <tr className="border-b border-gray-100 bg-slate-50/80">
+                          <td colSpan={4} className="px-4 py-4">
+                            {detailLoadingId === team.id ? (
+                              <div className="flex items-center gap-2 text-sm text-gray-500">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Loading members…
+                              </div>
+                            ) : detail ? (
+                              <div className="space-y-3">
+                                <ul className="space-y-2">
+                                  {(detail.members || []).map((m) => {
+                                    const label = displayNameFromUser(m.user);
+                                    return (
+                                      <li
+                                        key={m.id}
+                                        className="flex items-center justify-between gap-3 rounded-md border border-gray-200 bg-white px-3 py-2"
+                                      >
+                                        <div className="flex min-w-0 items-center gap-3">
+                                          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-semibold text-white">
+                                            {initials(label)}
+                                          </div>
+                                          <div className="min-w-0">
+                                            <div className="truncate font-medium text-gray-900">{label}</div>
+                                            <div className="text-xs text-gray-500">{m.user?.email}</div>
+                                          </div>
+                                          <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700">
+                                            {roleLabel(m.role)}
+                                          </span>
+                                        </div>
+                                        {m.role.toUpperCase() !== "OWNER" ? (
+                                          <button
+                                            type="button"
+                                            disabled={busyMemberKey === `${team.id}:${m.userId}`}
+                                            className="text-xs text-red-600 hover:underline disabled:opacity-40"
+                                            onClick={() => void onRemoveMember(team.id, m.userId)}
+                                          >
+                                            Remove
+                                          </button>
+                                        ) : (
+                                          <span className="text-xs text-gray-400">Owner</span>
+                                        )}
+                                      </li>
+                                    );
+                                  })}
+                                </ul>
+                                {addMemberTeamId === team.id ? (
+                                  <div className="rounded-md border border-indigo-200 bg-white p-3">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <span className="text-xs font-medium text-gray-700">Search people</span>
+                                      <button
+                                        type="button"
+                                        className="text-gray-400 hover:text-gray-600"
+                                        onClick={() => {
+                                          setAddMemberTeamId(null);
+                                          setUserSearch("");
+                                          setUserHits([]);
+                                        }}
+                                        aria-label="Close add member"
+                                      >
+                                        <X className="h-4 w-4" />
+                                      </button>
+                                    </div>
+                                    <input
+                                      type="text"
+                                      value={userSearch}
+                                      onChange={(e) => setUserSearch(e.target.value)}
+                                      placeholder="Name or email (min 2 characters)…"
+                                      className="mt-2 w-full rounded border border-gray-300 px-2 py-1.5 text-sm"
+                                    />
+                                    {userSearchLoading ? (
+                                      <p className="mt-2 text-xs text-gray-500">Searching…</p>
+                                    ) : userHits.length > 0 ? (
+                                      <ul className="mt-2 max-h-40 overflow-y-auto rounded border border-gray-100 bg-gray-50">
+                                        {userHits.map((u) => (
+                                          <li key={u.id}>
+                                            <button
+                                              type="button"
+                                              className="flex w-full items-center justify-between px-2 py-2 text-left text-sm hover:bg-white"
+                                              disabled={busyMemberKey === `${team.id}:${u.id}`}
+                                              onClick={() => void onAddMember(team.id, u.id)}
+                                            >
+                                              <span>
+                                                {u.name}{" "}
+                                                <span className="text-xs text-gray-500">({u.email})</span>
+                                              </span>
+                                              <span className="text-xs text-indigo-600">Add</span>
+                                            </button>
+                                          </li>
+                                        ))}
+                                      </ul>
+                                    ) : userSearch.trim().length >= 2 ? (
+                                      <p className="mt-2 text-xs text-gray-500">No matches.</p>
+                                    ) : null}
+                                  </div>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setAddMemberTeamId(team.id);
+                                      setUserSearch("");
+                                      setUserHits([]);
+                                    }}
+                                  >
+                                    + Add member
+                                  </button>
+                                )}
+                              </div>
+                            ) : (
+                              <p className="text-sm text-gray-500">Could not load members.</p>
+                            )}
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {modalMode ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => {
+            setModalMode(null);
+            setEditingTeam(null);
+          }}
+          role="presentation"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="w-full max-w-md rounded-lg bg-white p-5 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold text-gray-900">
+              {modalMode === "create" ? "Create team" : "Edit team"}
+            </h2>
+            <div className="mt-4 space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Name</label>
+                <input
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="Engineering"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Alias (short code)</label>
+                <input
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2 font-mono text-sm uppercase"
+                  value={formShortCode}
+                  onChange={(e) =>
+                    setFormShortCode(
+                      e.target.value.replace(/[^a-zA-Z0-9]/g, "").toUpperCase().slice(0, 10),
+                    )
+                  }
+                  placeholder="ENG"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Description (optional)</label>
+                <textarea
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                  rows={3}
+                  value={formDescription}
+                  onChange={(e) => setFormDescription(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                onClick={() => {
+                  setModalMode(null);
+                  setEditingTeam(null);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                onClick={() => void submitModal()}
+              >
+                {saving ? "Saving…" : modalMode === "create" ? "Create" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/zephix-frontend/src/features/administration/pages/__tests__/AdministrationPages.test.tsx
+++ b/zephix-frontend/src/features/administration/pages/__tests__/AdministrationPages.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/features/administration/api/administration.api", () => ({
     listRecentActivity: vi.fn(),
     listGovernanceQueue: vi.fn(),
     listGovernanceApprovals: vi.fn(),
+    getGovernanceCatalog: vi.fn(),
     approveException: vi.fn(),
     rejectException: vi.fn(),
     requestMoreInfo: vi.fn(),
@@ -59,6 +60,7 @@ describe("Administration pages", () => {
       data: [],
       meta: { page: 1, limit: 20, total: 0 },
     });
+    vi.mocked(administrationApi.getGovernanceCatalog).mockResolvedValue([]);
     vi.mocked(administrationApi.listUsers).mockResolvedValue({
       data: [],
       meta: { page: 1, limit: 20, total: 0 },
@@ -90,7 +92,7 @@ describe("Administration pages", () => {
     const exceptionsTab = await screen.findByRole("button", { name: "Exceptions" });
     await user.click(exceptionsTab);
     await waitFor(() =>
-      expect(screen.getByText("No exceptions in queue.")).toBeInTheDocument(),
+      expect(screen.getByText("No pending exceptions")).toBeInTheDocument(),
     );
   });
 


### PR DESCRIPTION
## Summary
- **Teams:** Functional Administration Teams page (CRUD, expandable members, add/remove via admin APIs).
- **Governance:** Policies tab grouped as Active / Phase gate / Planned; explainer; Configure → Templates; richer empty states.
- **Backend:** POST/DELETE /admin/teams/:id/members for member management.

## Verification
- BE/FE tsc clean
- Vitest: administration + shell
- Jest: admin + teams paths

Targets **staging** per platform rules.

Made with [Cursor](https://cursor.com)