### PR TITLE
fix(frontend): text selection, copy/paste, and admin UI with DevTools open

### DIFF
--- a/zephix-frontend/src/App.tsx
+++ b/zephix-frontend/src/App.tsx
@@ -184,6 +184,7 @@ function DndUserSelectCleanup() {
 
     window.addEventListener("dragend", clear);
     window.addEventListener("mouseup", clear);
+    window.addEventListener("pointerup", clear);
     window.addEventListener("touchend", clear);
     window.addEventListener("visibilitychange", clear);
     window.addEventListener("blur", clear);
@@ -193,6 +194,7 @@ function DndUserSelectCleanup() {
     return () => {
       window.removeEventListener("dragend", clear);
       window.removeEventListener("mouseup", clear);
+      window.removeEventListener("pointerup", clear);
       window.removeEventListener("touchend", clear);
       window.removeEventListener("visibilitychange", clear);
       window.removeEventListener("blur", clear);

--- a/zephix-frontend/src/features/administration/layout/AdministrationLayout.tsx
+++ b/zephix-frontend/src/features/administration/layout/AdministrationLayout.tsx
@@ -30,13 +30,19 @@ export default function AdministrationLayout() {
        */}
       <Header />
 
-      <div className="lg:hidden flex-1 p-6">
+      {/*
+       * Viewport width drives Tailwind breakpoints. Docked DevTools shrinks the *page*
+       * width (often to ~500–900px), which is still “desktop” — `lg`/`md` falsely flipped
+       * many users to the mobile hint. Keep the hint for narrow *phones* only (≲ typical
+       * portrait width), not for “narrow because DevTools”.
+       */}
+      <div className="flex flex-1 p-6 min-[480px]:hidden">
         <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-700">
           Administration tools are best used on desktop.
         </div>
       </div>
 
-      <div className="hidden min-h-0 flex-1 lg:flex">
+      <div className="hidden min-h-0 flex-1 min-[480px]:flex">
         <aside className={`${navWidth} shrink-0 border-r border-gray-200 bg-white transition-all`}>
           {/*
            * Admin Console MVP-1 — "Back to Zephix" exit affordance.

--- a/zephix-frontend/src/index.css
+++ b/zephix-frontend/src/index.css
@@ -49,8 +49,20 @@
     scroll-behavior: smooth;
   }
 
+  /*
+   * Stale drag-and-drop styles can leave `user-select: none` on `body`, which inherits
+   * everywhere and breaks copy/paste (including login fields). `clearUserSelectLock` strips
+   * those injections; these rules keep form controls explicitly selectable if inheritance
+   * is still wrong in edge browsers.
+   */
+  input:not([disabled]):not([type="hidden"]),
+  textarea:not([disabled]) {
+    user-select: text !important;
+    -webkit-user-select: text !important;
+  }
+
   ::selection {
-    background: var(--selection);
+    background: var(--selection, rgba(59, 130, 246, 0.35));
   }
 
   a {

--- a/zephix-frontend/src/lib/dom/clearUserSelectLock.test.ts
+++ b/zephix-frontend/src/lib/dom/clearUserSelectLock.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { clearUserSelectLock } from "./clearUserSelectLock";
+
+describe("clearUserSelectLock", () => {
+  afterEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+    document.body.removeAttribute("style");
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("removes stale hello-pangea body user-select rule from data-rfd-dynamic styles", () => {
+    const style = document.createElement("style");
+    style.setAttribute("data-rfd-dynamic", "ctx-1");
+    style.textContent = `[data-rfd-drag-handle-context-id="ctx-1"] { cursor: grab; }
+body {
+        cursor: grabbing;
+        user-select: none;
+        -webkit-user-select: none;
+      }`;
+    document.head.appendChild(style);
+
+    clearUserSelectLock();
+
+    const next = style.textContent ?? "";
+    expect(next).not.toMatch(/user-select:\s*none/i);
+    expect(next).toContain("cursor: grab");
+  });
+});

--- a/zephix-frontend/src/lib/dom/clearUserSelectLock.ts
+++ b/zephix-frontend/src/lib/dom/clearUserSelectLock.ts
@@ -1,28 +1,59 @@
-function clearInlineUserSelect(body: HTMLBodyElement): void {
-  body.style.removeProperty("user-select");
-  body.style.removeProperty("-webkit-user-select");
-  body.style.removeProperty("-moz-user-select");
-  body.style.removeProperty("-ms-user-select");
+function clearInlineUserSelect(el: HTMLElement): void {
+  el.style.removeProperty("user-select");
+  el.style.removeProperty("-webkit-user-select");
+  el.style.removeProperty("-moz-user-select");
+  el.style.removeProperty("-ms-user-select");
+}
+
+/**
+ * hello-pangea / react-beautiful-dnd injects `<style data-rfd-dynamic>` whose
+ * "dragging" payload includes `body { user-select: none; ... }`. If a drag is
+ * interrupted, that rule can persist in the stylesheet (inline body cleanup is not enough).
+ */
+function stripStaleRfdBodyUserSelectRule(): void {
+  if (typeof document === "undefined") return;
+  document.querySelectorAll<HTMLStyleElement>("style[data-rfd-dynamic]").forEach((style) => {
+    const t = style.textContent ?? "";
+    if (!t.includes("body") || !/user-select:\s*none/i.test(t)) return;
+    const cleaned = t.replace(/body\s*\{[^}]*\}/g, "").trim();
+    if (cleaned !== t) {
+      style.textContent = cleaned;
+    }
+  });
+}
+
+function computedUserSelectNone(el: HTMLElement): boolean {
+  const computed = window.getComputedStyle(el);
+  const raw = (computed as CSSStyleDeclaration & { webkitUserSelect?: string }).webkitUserSelect;
+  return computed.userSelect === "none" || raw === "none";
+}
+
+function ensureTextSelectable(el: HTMLElement | null): void {
+  if (!el) return;
+  clearInlineUserSelect(el);
+  if (typeof window === "undefined") return;
+  if (computedUserSelectNone(el)) {
+    el.style.setProperty("user-select", "text", "important");
+    el.style.setProperty("-webkit-user-select", "text", "important");
+  }
 }
 
 /**
  * Defensive cleanup for stale global text-selection locks.
  *
- * Drag libraries can temporarily apply `user-select: none` to `<body>`.
- * If a drag is interrupted, that lock may persist and break copy/select
- * throughout the app.
+ * Drag libraries can temporarily apply `user-select: none` to `<body>` (via injected CSS).
+ * If a drag is interrupted, that lock may persist and break copy/select throughout the app.
  */
 export function clearUserSelectLock(): void {
   if (typeof document === "undefined") return;
+
+  stripStaleRfdBodyUserSelectRule();
+
+  const html = document.documentElement;
   const body = document.body;
-  if (!body) return;
+  const root = document.getElementById("root");
 
-  clearInlineUserSelect(body);
-
-  const computed = window.getComputedStyle(body);
-  if (computed.userSelect === "none") {
-    // Override stale computed lock (including stylesheet/!important paths).
-    body.style.setProperty("user-select", "text", "important");
-    body.style.setProperty("-webkit-user-select", "text", "important");
-  }
+  ensureTextSelectable(html);
+  ensureTextSelectable(body);
+  ensureTextSelectable(root);
 }

--- a/zephix-frontend/src/main.tsx
+++ b/zephix-frontend/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+
 import App from './App.tsx'
 import './index.css'
-import { initializeAnalytics } from './lib/analytics'
-import { QueryProvider } from './lib/providers/QueryProvider'
 import { cleanupLegacyAuthStorage } from './auth/cleanupAuthStorage'
+import { clearUserSelectLock } from './lib/dom/clearUserSelectLock'
+import { QueryProvider } from './lib/providers/QueryProvider'
 
 // ═══════════════════════════════════════════════════════════════════════════
 // ENVIRONMENT WIRING SAFETY GUARD
@@ -39,6 +40,11 @@ if (typeof window !== 'undefined' && VITE_API_URL && import.meta.env.MODE !== 'd
 
 // Cleanup legacy auth tokens on app startup
 cleanupLegacyAuthStorage();
+
+// Clear stale global `user-select` locks before first paint (DnD libs inject `<style>` on body).
+clearUserSelectLock();
+queueMicrotask(() => clearUserSelectLock());
+requestAnimationFrame(() => clearUserSelectLock());
 
 // Initialize analytics
 // initializeAnalytics(); // Temporarily disabled for debugging


### PR DESCRIPTION
## Summary
Fixes two related staging UX issues:

### Copy / paste / select text
- `@hello-pangea/dnd` can leave a stale `<style data-rfd-dynamic>` rule with `body { user-select: none }`, which inherits everywhere (including login email/password).
- **Strip** that injected `body` block, **clear** inline locks on `html`, `body`, and `#root`, and treat `-webkit-user-select` as well as `user-select`.
- **Bootstrap** `clearUserSelectLock()` from `main.tsx` (sync + microtask + rAF) before paint.
- **Base CSS:** `user-select: text !important` on visible `input`/`textarea`; **`::selection`** fallback when `--selection` is unset.
- **App:** listen for `pointerup` in addition to mouse/touch/drag end.
- **Test:** `clearUserSelectLock.test.ts` for RFD style stripping.

### Administration + Chrome DevTools
- Responsive split used `lg` (1024px); docked DevTools shrinks the page width and triggered the “best used on desktop” placeholder instead of the real admin shell.
- Switch to **`min-[480px]`** so typical docked-DevTools widths still show the full Administration layout; the hint remains for very narrow viewports (phones).

## Verification
- `cd zephix-frontend && npm run build`
- `npx vitest run src/lib/dom/clearUserSelectLock.test.ts`

## Target branch
**staging** (per repo policy).

Made with [Cursor](https://cursor.com)