### PR TITLE
feat(admin): Notion-style preferences + API (timezone auto, number format)

### DIFF
--- a/zephix-backend/src/modules/users/dto/update-preferences.dto.ts
+++ b/zephix-backend/src/modules/users/dto/update-preferences.dto.ts
@@ -10,28 +10,26 @@ export class UpdatePreferencesDto {
   @IsString()
   timezone?: string;
 
+  /** When true, client may derive timezone from the browser; stored value still updated on save. */
+  @IsOptional()
+  @IsBoolean()
+  timezoneAuto?: boolean;
+
   @IsOptional()
   @IsString()
   @IsIn(['MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY-MM-DD'])
   dateFormat?: string;
 
+  /** Number grouping: default (locale), US (1,000.00), EU (1.000,00). */
   @IsOptional()
   @IsString()
-  @IsIn(['waterfall', 'board', 'table', 'activities'])
-  defaultView?: string;
+  @IsIn(['default', 'en_US', 'eu'])
+  numberFormat?: string;
 
   @IsOptional()
   @IsString()
   @IsIn(['en'])
   language?: string;
-
-  @IsOptional()
-  @IsBoolean()
-  highContrast?: boolean;
-
-  @IsOptional()
-  @IsBoolean()
-  notifyTimezoneChange?: boolean;
 
   @IsOptional()
   @IsString()
@@ -42,9 +40,4 @@ export class UpdatePreferencesDto {
   @IsString()
   @IsIn(['12h', '24h'])
   timeFormat?: string;
-
-  @IsOptional()
-  @IsString()
-  @IsIn(['none', 'status', 'assignee', 'priority', 'dueDate'])
-  defaultTaskGrouping?: string;
 }

--- a/zephix-backend/src/modules/users/users.service.ts
+++ b/zephix-backend/src/modules/users/users.service.ts
@@ -8,14 +8,12 @@ import { UpdatePreferencesDto } from './dto/update-preferences.dto';
 export type UserAppPreferences = {
   theme: string;
   timezone?: string;
+  timezoneAuto?: boolean;
   dateFormat?: string;
-  defaultView?: string;
+  numberFormat?: string;
   language?: string;
-  highContrast?: boolean;
-  notifyTimezoneChange?: boolean;
   weekStartsOn?: string;
   timeFormat?: string;
-  defaultTaskGrouping?: string;
 };
 
 @Injectable()
@@ -111,33 +109,30 @@ export class UsersService {
     const prefs = (row.preferences || {}) as Record<string, unknown>;
     const out: UserAppPreferences = {
       theme: row.theme || 'light',
+      language: 'en',
     };
     if (typeof prefs.timezone === 'string') {
       out.timezone = prefs.timezone;
     }
+    if (typeof prefs.timezoneAuto === 'boolean') {
+      out.timezoneAuto = prefs.timezoneAuto;
+    } else {
+      out.timezoneAuto = true;
+    }
     if (typeof prefs.dateFormat === 'string') {
       out.dateFormat = prefs.dateFormat;
     }
-    if (typeof prefs.defaultView === 'string') {
-      out.defaultView = prefs.defaultView;
+    if (typeof prefs.numberFormat === 'string') {
+      out.numberFormat = prefs.numberFormat;
     }
     if (typeof prefs.language === 'string') {
       out.language = prefs.language;
-    }
-    if (typeof prefs.highContrast === 'boolean') {
-      out.highContrast = prefs.highContrast;
-    }
-    if (typeof prefs.notifyTimezoneChange === 'boolean') {
-      out.notifyTimezoneChange = prefs.notifyTimezoneChange;
     }
     if (typeof prefs.weekStartsOn === 'string') {
       out.weekStartsOn = prefs.weekStartsOn;
     }
     if (typeof prefs.timeFormat === 'string') {
       out.timeFormat = prefs.timeFormat;
-    }
-    if (typeof prefs.defaultTaskGrouping === 'string') {
-      out.defaultTaskGrouping = prefs.defaultTaskGrouping;
     }
     return out;
   }
@@ -171,32 +166,34 @@ export class UsersService {
     }
 
     const prefs = { ...((row.preferences as Record<string, unknown>) || {}) };
+    for (const legacy of [
+      'defaultView',
+      'defaultTaskGrouping',
+      'highContrast',
+      'notifyTimezoneChange',
+    ] as const) {
+      delete prefs[legacy];
+    }
     if (dto.timezone !== undefined) {
       prefs.timezone = dto.timezone;
+    }
+    if (dto.timezoneAuto !== undefined) {
+      prefs.timezoneAuto = dto.timezoneAuto;
     }
     if (dto.dateFormat !== undefined) {
       prefs.dateFormat = dto.dateFormat;
     }
-    if (dto.defaultView !== undefined) {
-      prefs.defaultView = dto.defaultView;
+    if (dto.numberFormat !== undefined) {
+      prefs.numberFormat = dto.numberFormat;
     }
     if (dto.language !== undefined) {
       prefs.language = dto.language;
-    }
-    if (dto.highContrast !== undefined) {
-      prefs.highContrast = dto.highContrast;
-    }
-    if (dto.notifyTimezoneChange !== undefined) {
-      prefs.notifyTimezoneChange = dto.notifyTimezoneChange;
     }
     if (dto.weekStartsOn !== undefined) {
       prefs.weekStartsOn = dto.weekStartsOn;
     }
     if (dto.timeFormat !== undefined) {
       prefs.timeFormat = dto.timeFormat;
-    }
-    if (dto.defaultTaskGrouping !== undefined) {
-      prefs.defaultTaskGrouping = dto.defaultTaskGrouping;
     }
     row.preferences = prefs;
 

--- a/zephix-frontend/src/features/administration/pages/AdminPreferencesPage.tsx
+++ b/zephix-frontend/src/features/administration/pages/AdminPreferencesPage.tsx
@@ -1,22 +1,23 @@
-import { useEffect, useMemo } from "react";
-import { useForm } from "react-hook-form";
+import { useEffect, useMemo, type ReactElement, type ReactNode } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 import { toast } from "sonner";
+
 import { request } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 const prefsSchema = z.object({
   theme: z.enum(["light", "dark", "system"]),
   timezone: z.string().min(1),
+  timezoneAuto: z.boolean(),
   dateFormat: z.enum(["MM/DD/YYYY", "DD/MM/YYYY", "YYYY-MM-DD"]),
-  defaultView: z.enum(["waterfall", "board", "table", "activities"]),
-  language: z.enum(["en"]),
-  highContrast: z.boolean(),
-  notifyTimezoneChange: z.boolean(),
+  numberFormat: z.enum(["default", "en_US", "eu"]),
+  language: z.literal("en"),
   weekStartsOn: z.enum(["sunday", "monday"]),
   timeFormat: z.enum(["12h", "24h"]),
-  defaultTaskGrouping: z.enum(["none", "status", "assignee", "priority", "dueDate"]),
 });
 
 type PrefsForm = z.infer<typeof prefsSchema>;
@@ -24,15 +25,21 @@ type PrefsForm = z.infer<typeof prefsSchema>;
 type PrefsApi = {
   theme: string;
   timezone?: string;
+  timezoneAuto?: boolean;
   dateFormat?: string;
-  defaultView?: string;
+  numberFormat?: string;
   language?: string;
-  highContrast?: boolean;
-  notifyTimezoneChange?: boolean;
   weekStartsOn?: string;
   timeFormat?: string;
-  defaultTaskGrouping?: string;
 };
+
+function browserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
 
 function supportedTimeZones(): string[] {
   try {
@@ -46,7 +53,74 @@ function supportedTimeZones(): string[] {
   return ["UTC", "America/New_York", "America/Los_Angeles", "Europe/London", "Asia/Singapore"];
 }
 
-export default function AdminPreferencesPage() {
+function PrefRow({
+  title,
+  description,
+  children,
+  className,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}): ReactElement {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 border-b border-gray-100 py-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between sm:gap-8",
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-semibold text-gray-900">{title}</div>
+        {description ? <p className="mt-1 text-sm text-gray-500">{description}</p> : null}
+      </div>
+      <div className="shrink-0 sm:w-56 sm:max-w-[14rem] sm:text-right">{children}</div>
+    </div>
+  );
+}
+
+function Toggle({
+  checked,
+  onCheckedChange,
+  id,
+  disabled,
+}: {
+  checked: boolean;
+  onCheckedChange: (v: boolean) => void;
+  id: string;
+  disabled?: boolean;
+}): ReactElement {
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "relative inline-flex cursor-pointer items-center",
+        disabled && "cursor-not-allowed opacity-60",
+      )}
+    >
+      <input
+        id={id}
+        type="checkbox"
+        className="peer sr-only"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onCheckedChange(e.target.checked)}
+      />
+      <span
+        className={cn(
+          "flex h-7 w-12 items-center justify-start rounded-full bg-gray-200 p-0.5 transition-colors",
+          "peer-checked:justify-end peer-checked:bg-indigo-600",
+          "peer-focus-visible:ring-2 peer-focus-visible:ring-indigo-500 peer-focus-visible:ring-offset-2",
+        )}
+      >
+        <span className="pointer-events-none h-5 w-5 shrink-0 rounded-full bg-white shadow" />
+      </span>
+    </label>
+  );
+}
+
+export default function AdminPreferencesPage(): ReactElement {
   const queryClient = useQueryClient();
   const timezones = useMemo(() => supportedTimeZones().slice().sort(), []);
 
@@ -60,36 +134,56 @@ export default function AdminPreferencesPage() {
     defaultValues: {
       theme: "light",
       timezone: "UTC",
+      timezoneAuto: true,
       dateFormat: "YYYY-MM-DD",
-      defaultView: "waterfall",
+      numberFormat: "default",
       language: "en",
-      highContrast: false,
-      notifyTimezoneChange: false,
       weekStartsOn: "monday",
       timeFormat: "24h",
-      defaultTaskGrouping: "status",
     },
   });
+
+  const timezoneAuto = useWatch({ control: form.control, name: "timezoneAuto" });
 
   useEffect(() => {
     if (!prefsQuery.data) return;
     const d = prefsQuery.data;
+    const tzAuto = d.timezoneAuto !== false;
     form.reset({
       theme: (d.theme as PrefsForm["theme"]) || "light",
-      timezone: d.timezone || "UTC",
+      timezone: d.timezone || browserTimeZone(),
+      timezoneAuto: tzAuto,
       dateFormat: (d.dateFormat as PrefsForm["dateFormat"]) || "YYYY-MM-DD",
-      defaultView: (d.defaultView as PrefsForm["defaultView"]) || "waterfall",
-      language: (d.language as PrefsForm["language"]) || "en",
-      highContrast: !!d.highContrast,
-      notifyTimezoneChange: !!d.notifyTimezoneChange,
+      numberFormat: (d.numberFormat as PrefsForm["numberFormat"]) || "default",
+      language: "en",
       weekStartsOn: (d.weekStartsOn as PrefsForm["weekStartsOn"]) || "monday",
       timeFormat: (d.timeFormat as PrefsForm["timeFormat"]) || "24h",
-      defaultTaskGrouping: (d.defaultTaskGrouping as PrefsForm["defaultTaskGrouping"]) || "status",
     });
   }, [prefsQuery.data, form]);
 
+  useEffect(() => {
+    if (!timezoneAuto) return;
+    const z = browserTimeZone();
+    const current = form.getValues("timezone");
+    if (current !== z) {
+      form.setValue("timezone", z, { shouldDirty: false });
+    }
+  }, [timezoneAuto, form]);
+
   const save = useMutation({
-    mutationFn: (body: Partial<PrefsForm>) => request.patch<PrefsApi>("/users/me/preferences", body),
+    mutationFn: (body: PrefsForm) => {
+      const payload = {
+        theme: body.theme,
+        timezone: body.timezone,
+        timezoneAuto: body.timezoneAuto,
+        dateFormat: body.dateFormat,
+        numberFormat: body.numberFormat,
+        language: body.language,
+        weekStartsOn: body.weekStartsOn,
+        timeFormat: body.timeFormat,
+      };
+      return request.patch<PrefsApi>("/users/me/preferences", payload);
+    },
     onSuccess: () => {
       toast.success("Preferences saved");
       void queryClient.invalidateQueries({ queryKey: ["users", "me-preferences"] });
@@ -97,11 +191,14 @@ export default function AdminPreferencesPage() {
     onError: () => toast.error("Could not save preferences"),
   });
 
+  const selectClass =
+    "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:ml-auto sm:max-w-[14rem]";
+
   return (
     <div className="relative space-y-8 pb-28">
       <header>
         <h1 className="text-2xl font-semibold text-gray-900">Preferences</h1>
-        <p className="mt-1 text-sm text-gray-600">Appearance, locale, time formats, and default views.</p>
+        <p className="mt-1 text-sm text-gray-600">Choose how you want Zephix to look and behave.</p>
       </header>
 
       {prefsQuery.isLoading && (
@@ -115,178 +212,159 @@ export default function AdminPreferencesPage() {
 
       {prefsQuery.data && (
         <form
-          className="space-y-10"
+          className="space-y-8"
           onSubmit={form.handleSubmit((values) => save.mutate(values))}
         >
-          <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">Appearance</h2>
-            <p className="mt-1 text-sm text-gray-500">How Zephix looks on this device.</p>
-            <div className="mt-4 grid gap-3 sm:grid-cols-3">
-              {(
-                [
-                  { id: "light", label: "Light" },
-                  { id: "dark", label: "Dark" },
-                  { id: "system", label: "Auto" },
-                ] as const
-              ).map((opt) => (
-                <label
-                  key={opt.id}
-                  className={`cursor-pointer rounded-lg border px-4 py-3 text-sm font-medium shadow-sm ${
-                    form.watch("theme") === opt.id
-                      ? "border-indigo-600 bg-indigo-50 text-indigo-900"
-                      : "border-gray-200 bg-white text-gray-800 hover:border-gray-300"
-                  }`}
-                >
-                  <input type="radio" className="sr-only" value={opt.id} {...form.register("theme")} />
-                  {opt.label}
-                </label>
-              ))}
-            </div>
-            <label className="mt-6 flex items-center justify-between gap-4 rounded-md border border-gray-100 bg-gray-50 px-4 py-3">
-              <div>
-                <span className="text-sm font-medium text-gray-900">High contrast</span>
-                <p className="text-xs text-gray-500">Increases contrast for readability.</p>
-              </div>
-              <input
-                type="checkbox"
-                className="h-4 w-4"
-                checked={form.watch("highContrast")}
-                onChange={(e) =>
-                  form.setValue("highContrast", e.target.checked, { shouldDirty: true, shouldTouch: true })
-                }
-              />
-            </label>
+          <section className="rounded-xl border border-gray-200 bg-white px-4 py-2 shadow-sm sm:px-6">
+            <h2 className="border-b border-gray-100 px-0 py-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+              Appearance
+            </h2>
+            <PrefRow
+              title="Theme"
+              description="Choose a theme for Zephix on this device."
+            >
+              <select className={selectClass} {...form.register("theme")}>
+                <option value="system">Use system setting</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </PrefRow>
           </section>
 
-          <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">Language &amp; region</h2>
-            <div className="mt-4 grid gap-4 md:grid-cols-2">
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="language">
-                  Language
-                </label>
-                <select
-                  id="language"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("language")}
-                >
-                  <option value="en">English</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="timezone">
-                  Timezone
-                </label>
-                <select
-                  id="timezone"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("timezone")}
-                >
-                  {timezones.map((tz) => (
-                    <option key={tz} value={tz}>
-                      {tz}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-            <label className="mt-4 flex items-center justify-between gap-4 rounded-md border border-gray-100 bg-gray-50 px-4 py-3">
-              <span className="text-sm font-medium text-gray-900">Notify me of timezone changes</span>
-              <input
-                type="checkbox"
-                className="h-4 w-4"
-                checked={form.watch("notifyTimezoneChange")}
-                onChange={(e) =>
-                  form.setValue("notifyTimezoneChange", e.target.checked, {
-                    shouldDirty: true,
-                    shouldTouch: true,
-                  })
-                }
-              />
-            </label>
+          <section className="rounded-xl border border-gray-200 bg-white px-4 py-2 shadow-sm sm:px-6">
+            <h2 className="border-b border-gray-100 px-0 py-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+              Language &amp; region
+            </h2>
+            <PrefRow
+              title="Language"
+              description="Choose the language you want to use Zephix in."
+            >
+              <select className={cn(selectClass, "text-gray-500")} disabled {...form.register("language")}>
+                <option value="en">English</option>
+              </select>
+            </PrefRow>
+            <PrefRow
+              title="Number format"
+              description="Choose how numbers and currencies are formatted. Default follows your locale when we apply it across the app."
+            >
+              <select className={selectClass} {...form.register("numberFormat")}>
+                <option value="default">Default</option>
+                <option value="en_US">1,000,000.00</option>
+                <option value="eu">1.000.000,00</option>
+              </select>
+            </PrefRow>
           </section>
 
-          <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">Time &amp; date format</h2>
-            <div className="mt-4 grid gap-4 md:grid-cols-3">
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="weekStartsOn">
-                  Start of week
-                </label>
-                <select
-                  id="weekStartsOn"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("weekStartsOn")}
-                >
-                  <option value="sunday">Sunday</option>
-                  <option value="monday">Monday</option>
-                </select>
+          <section className="rounded-xl border border-gray-200 bg-white px-4 py-2 shadow-sm sm:px-6">
+            <h2 className="border-b border-gray-100 px-0 py-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+              Time &amp; date
+            </h2>
+            <PrefRow
+              title="Start week on Monday"
+              description="When enabled, calendars and week-based views treat Monday as the first day of the week."
+            >
+              <div className="flex justify-end">
+                <Toggle
+                  id="week-mon"
+                  checked={form.watch("weekStartsOn") === "monday"}
+                  onCheckedChange={(on) =>
+                    form.setValue("weekStartsOn", on ? "monday" : "sunday", {
+                      shouldDirty: true,
+                      shouldTouch: true,
+                    })
+                  }
+                />
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="timeFormat">
-                  Time format
-                </label>
-                <select
-                  id="timeFormat"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("timeFormat")}
-                >
-                  <option value="24h">24-hour</option>
-                  <option value="12h">12-hour</option>
-                </select>
+            </PrefRow>
+            <PrefRow
+              title="Date format"
+              description="Default format for dates in lists and forms (full rollout will use this everywhere)."
+            >
+              <select className={selectClass} {...form.register("dateFormat")}>
+                <option value="MM/DD/YYYY">MM/DD/YYYY</option>
+                <option value="DD/MM/YYYY">DD/MM/YYYY</option>
+                <option value="YYYY-MM-DD">YYYY-MM-DD</option>
+              </select>
+            </PrefRow>
+            <PrefRow
+              title="Time format"
+              description="12-hour or 24-hour clock."
+            >
+              <select className={selectClass} {...form.register("timeFormat")}>
+                <option value="24h">24-hour</option>
+                <option value="12h">12-hour</option>
+              </select>
+            </PrefRow>
+            <PrefRow
+              title="Set time zone automatically using your location"
+              description="Uses your browser’s reported time zone. Reminders and emails will align to this when those features use it."
+            >
+              <div className="flex justify-end">
+                <Toggle
+                  id="tz-auto"
+                  checked={!!form.watch("timezoneAuto")}
+                  onCheckedChange={(on) => {
+                    form.setValue("timezoneAuto", on, { shouldDirty: true, shouldTouch: true });
+                    if (on) {
+                      form.setValue("timezone", browserTimeZone(), { shouldDirty: true });
+                    }
+                  }}
+                />
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="dateFormat">
-                  Date format
-                </label>
-                <select
-                  id="dateFormat"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("dateFormat")}
-                >
-                  <option value="MM/DD/YYYY">MM/DD/YYYY</option>
-                  <option value="DD/MM/YYYY">DD/MM/YYYY</option>
-                  <option value="YYYY-MM-DD">YYYY-MM-DD</option>
-                </select>
-              </div>
-            </div>
+            </PrefRow>
+            <PrefRow
+              title="Time zone"
+              description={
+                timezoneAuto
+                  ? "Managed automatically. Turn off the option above to choose manually."
+                  : "Choose your time zone."
+              }
+            >
+              <select
+                className={cn(selectClass, timezoneAuto && "cursor-not-allowed bg-gray-50 text-gray-500")}
+                disabled={timezoneAuto}
+                {...form.register("timezone")}
+              >
+                {timezones.map((tz) => (
+                  <option key={tz} value={tz}>
+                    {tz.replace(/_/g, " ")}
+                  </option>
+                ))}
+              </select>
+            </PrefRow>
           </section>
 
-          <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">Default views</h2>
-            <div className="mt-4 grid gap-4 md:grid-cols-2">
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="defaultView">
-                  Default project view
-                </label>
-                <select
-                  id="defaultView"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("defaultView")}
-                >
-                  <option value="waterfall">Waterfall</option>
-                  <option value="board">Board</option>
-                  <option value="table">Table</option>
-                  <option value="activities">Activities</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700" htmlFor="defaultTaskGrouping">
-                  Default task grouping
-                </label>
-                <select
-                  id="defaultTaskGrouping"
-                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  {...form.register("defaultTaskGrouping")}
-                >
-                  <option value="none">None</option>
-                  <option value="status">Status</option>
-                  <option value="assignee">Assignee</option>
-                  <option value="priority">Priority</option>
-                  <option value="dueDate">Due date</option>
-                </select>
-              </div>
-            </div>
+          <section className="rounded-xl border border-gray-200 bg-white px-4 py-4 shadow-sm sm:px-6">
+            <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">Navigation</h2>
+            <p className="text-sm text-gray-600">
+              Zephix remembers where you left off: your <strong>last visited page</strong> in each area is restored when
+              you return—no extra setting required.
+            </p>
+          </section>
+
+          <section className="rounded-xl border border-gray-200 bg-white px-4 py-4 shadow-sm sm:px-6">
+            <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">Privacy &amp; data</h2>
+            <p className="text-sm text-gray-600">
+              For most teams the highest-priority controls are:{" "}
+              <strong>cookie / tracking consent</strong> (legal requirement in many regions),{" "}
+              <strong>marketing and email opt-outs</strong> (CAN-SPAM, GDPR), and{" "}
+              <strong>who can discover or invite you</strong> (workspace safety). Fine-grained toggles will appear here as
+              the product matures; for now use your organization’s policies and{" "}
+              <Link className="font-medium text-indigo-600 hover:text-indigo-500" to="/administration/notifications">
+                notification settings
+              </Link>{" "}
+              for email categories.
+            </p>
+            <p className="mt-3 text-sm">
+              <a
+                className="font-medium text-indigo-600 hover:text-indigo-500"
+                href="https://getzephix.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Privacy policy (site)
+              </a>
+            </p>
           </section>
 
           <div className="pointer-events-none fixed bottom-6 right-6 z-20 flex justify-end sm:right-10">


### PR DESCRIPTION
## Summary
- Redesign `/administration/preferences` (Notion-like rows: label+description left, controls right).
- Backend: `timezoneAuto`, `numberFormat`; remove deprecated preference fields; strip legacy keys on save.

## Deploy note
Requires `user_settings` table (migration `18000000000072` if not already merged).

Merge to **staging** for Railway staging frontend/backend.

Made with [Cursor](https://cursor.com)