### PR TITLE
fix(frontend): Admin Trash shows deleted workspaces

### DIFF
--- a/zephix-frontend/src/pages/admin/AdminTrashPage.tsx
+++ b/zephix-frontend/src/pages/admin/AdminTrashPage.tsx
@@ -25,9 +25,11 @@ export default function AdminTrashPage() {
       setLoading(true);
       setError(null);
 
-      // Fetch trash items from backend
-      const response = await apiClient.get('/admin/trash', { params: { type: 'workspace' } });
-      const trashData = Array.isArray(response.data) ? response.data : [];
+      // apiClient.get unwraps { data: T } — use the return value directly (not .data)
+      const trashPayload = await apiClient.get<unknown>('/admin/trash', {
+        params: { type: 'workspace' },
+      });
+      const trashData = Array.isArray(trashPayload) ? trashPayload : [];
 
       // Transform backend data to TrashItem format
       const transformedItems: TrashItem[] = trashData.map((item: any) => ({

--- a/zephix-frontend/src/pages/admin/__tests__/AdminTrashPage.test.tsx
+++ b/zephix-frontend/src/pages/admin/__tests__/AdminTrashPage.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * AdminTrashPage — trash list uses apiClient return value (already unwrapped).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import AdminTrashPage from '../AdminTrashPage';
+import { apiClient } from '@/lib/api/client';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn(),
+}));
+
+describe('AdminTrashPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists workspaces returned from GET /admin/trash (unwrapped array)', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue([
+      {
+        id: 'ws-1',
+        name: 'Deleted Workspace',
+        deletedAt: '2026-04-01T12:00:00.000Z',
+      },
+    ]);
+
+    render(<AdminTrashPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Deleted Workspace')).toBeInTheDocument();
+    });
+    expect(apiClient.get).toHaveBeenCalledWith('/admin/trash', {
+      params: { type: 'workspace' },
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The Admin Trash page (`/admin/trash`) always showed "No deleted items" even when workspaces were soft-deleted because it read `response.data` after `apiClient.get()`, which already unwraps `{ data: T }` to `T`.

## Changes
- Use the return value of `apiClient.get()` as the trash list array.
- Add a unit test that mocks the unwrapped array shape.

## Verification
- `npx vitest run src/pages/admin/__tests__/AdminTrashPage.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2becee78-954f-48cb-bc2e-dd5c236fe9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2becee78-954f-48cb-bc2e-dd5c236fe9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

