### PR TITLE
fix(backend): admin trash 403 — remove legacy WorkspacePolicy check

### DIFF
--- a/zephix-backend/src/modules/workspaces/admin-trash.controller.spec.ts
+++ b/zephix-backend/src/modules/workspaces/admin-trash.controller.spec.ts
@@ -1,6 +1,48 @@
 import { AdminTrashController } from './admin-trash.controller';
 
 describe('AdminTrashController', () => {
+  it('listTrash (paged) does not use legacy WorkspacePolicy — AdminOnlyGuard covers auth', async () => {
+    const workspacesService = {};
+    const projectsService = {};
+    const platformTrashAdmin = {
+      listTrashItemsPaged: jest.fn().mockResolvedValue({
+        items: [{ id: 'p1', name: 'P', type: 'project' }],
+        meta: { page: 1, limit: 25, total: 1, totalPages: 1 },
+      }),
+    };
+
+    const controller = new AdminTrashController(
+      workspacesService as any,
+      projectsService as any,
+      platformTrashAdmin as any,
+    );
+
+    const result = await controller.listTrash(
+      'all',
+      '1',
+      '25',
+      undefined,
+      {
+        id: 'admin-1',
+        organizationId: 'org-1',
+        role: 'user' as any,
+        platformRole: 'ADMIN',
+      } as any,
+    );
+
+    expect(platformTrashAdmin.listTrashItemsPaged).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      type: 'all',
+      search: undefined,
+      page: 1,
+      limit: 25,
+    });
+    expect(result).toEqual({
+      data: [{ id: 'p1', name: 'P', type: 'project' }],
+      meta: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    });
+  });
+
   it('purge with days returns symmetric purge payload', async () => {
     const workspacesService = { purge: jest.fn() };
     const projectsService = {};
@@ -13,13 +55,11 @@ describe('AdminTrashController', () => {
         cutoffTimestamp: '2026-01-01T00:00:00.000Z',
       }),
     };
-    const policy = { enforceDelete: jest.fn() };
 
     const controller = new AdminTrashController(
       workspacesService as any,
       projectsService as any,
       platformTrashAdmin as any,
-      policy as any,
     );
 
     const result = await controller.purge(
@@ -31,7 +71,6 @@ describe('AdminTrashController', () => {
       } as any,
     );
 
-    expect(policy.enforceDelete).toHaveBeenCalledWith('admin');
     expect(platformTrashAdmin.purgeStaleTrash).toHaveBeenCalledWith(
       'org-1',
       'admin-1',
@@ -57,13 +96,11 @@ describe('AdminTrashController', () => {
         .mockResolvedValue({ id: 'proj-1' }),
     };
     const platformTrashAdmin = { purgeStaleTrash: jest.fn() };
-    const policy = { enforceDelete: jest.fn() };
 
     const controller = new AdminTrashController(
       workspacesService as any,
       projectsService as any,
       platformTrashAdmin as any,
-      policy as any,
     );
 
     const result = await controller.purge(

--- a/zephix-backend/src/modules/workspaces/admin-trash.controller.ts
+++ b/zephix-backend/src/modules/workspaces/admin-trash.controller.ts
@@ -19,7 +19,6 @@ import {
 } from '../../shared/helpers/response.helper';
 import { ProjectsService } from '../projects/services/projects.service';
 import { WorkspacesService } from './workspaces.service';
-import { WorkspacePolicy } from './workspace.policy';
 import { PlatformTrashAdminService } from './platform-trash-admin.service';
 
 type UserJwt = {
@@ -36,7 +35,6 @@ export class AdminTrashController {
     private readonly workspacesService: WorkspacesService,
     private readonly projectsService: ProjectsService,
     private readonly platformTrashAdmin: PlatformTrashAdminService,
-    private readonly policy: WorkspacePolicy,
   ) {}
 
   @Get('retention-policy')
@@ -54,7 +52,6 @@ export class AdminTrashController {
     @Query('search') search: string | undefined,
     @CurrentUser() u: UserJwt,
   ) {
-    this.policy.enforceDelete(u.role);
     const hasPage = pageStr !== undefined && pageStr !== '';
     if (hasPage) {
       const page = Math.max(1, parseInt(pageStr, 10) || 1);
@@ -94,7 +91,6 @@ export class AdminTrashController {
     },
     @CurrentUser() u: UserJwt,
   ) {
-    this.policy.enforceDelete(u.role);
     if (body.id) {
       if (body.entityType === 'project') {
         const result = await this.projectsService.purgeTrashedProjectById(
@@ -123,7 +119,6 @@ export class AdminTrashController {
     @Param('id') id: string,
     @CurrentUser() u: UserJwt,
   ) {
-    this.policy.enforceDelete(u.role);
     const result = await this.platformTrashAdmin.restoreTrashItem(
       entityType,
       id,
@@ -138,7 +133,6 @@ export class AdminTrashController {
 
   @Delete()
   async clearAllTrash(@CurrentUser() u: UserJwt) {
-    this.policy.enforceDelete(u.role);
     const result = await this.platformTrashAdmin.clearAllTrash(
       u.organizationId,
       u.id,
@@ -152,7 +146,6 @@ export class AdminTrashController {
     @Param('id') id: string,
     @CurrentUser() u: UserJwt,
   ) {
-    this.policy.enforceDelete(u.role);
     const result = await this.platformTrashAdmin.permanentlyDeleteTrashItem(
       entityType,
       id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
`GET /api/admin/trash` returned **403** for org admins: `WorkspacePolicy.enforceDelete(u.role)` compared JWT `users.role` (`user`) to `'admin'` after `AdminOnlyGuard` had already verified **platform ADMIN**.

## Change
- Remove all `this.policy.enforceDelete(u.role)` calls from `AdminTrashController`.
- Drop unused `WorkspacePolicy` injection from that controller.
- Extend unit tests: paged `listTrash` succeeds with `role: 'user'` + `platformRole: 'ADMIN'` (controller-only; guards are not executed in unit test).

## Verification
- `npx jest src/modules/workspaces/admin-trash.controller.spec.ts`

## Post-deploy (staging)
1. `GET /api/admin/trash?page=1&limit=25&type=all` → **200**
2. Deleted projects visible in Trash UI
3. Restore / permanent delete as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2becee78-954f-48cb-bc2e-dd5c236fe9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2becee78-954f-48cb-bc2e-dd5c236fe9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

