### PR TITLE
fix(backend): admin trash 403 — drop legacy enforceDelete (main-aligned)

### DIFF
--- a/zephix-backend/src/modules/workspaces/admin-trash.controller.spec.ts
+++ b/zephix-backend/src/modules/workspaces/admin-trash.controller.spec.ts
@@ -1,0 +1,55 @@
+import { AdminTrashController } from './admin-trash.controller';
+
+describe('AdminTrashController', () => {
+  it('listTrash delegates without legacy enforceDelete (AdminOnlyGuard covers auth)', async () => {
+    const workspacesService = {
+      listTrash: jest.fn().mockResolvedValue([{ id: 'w1', name: 'W' }]),
+    };
+
+    const controller = new AdminTrashController(workspacesService as any);
+
+    const result = await controller.listTrash('workspace', {
+      id: 'admin-1',
+      organizationId: 'org-1',
+      role: 'user' as any,
+    } as any);
+
+    expect(workspacesService.listTrash).toHaveBeenCalledWith('org-1', 'workspace');
+    expect(result).toEqual([{ id: 'w1', name: 'W' }]);
+  });
+
+  it('purge with id delegates to workspacesService.purge', async () => {
+    const workspacesService = {
+      purge: jest.fn().mockResolvedValue({ id: 'ws-1' }),
+      purgeOldTrash: jest.fn(),
+    };
+
+    const controller = new AdminTrashController(workspacesService as any);
+
+    const result = await controller.purge(
+      { id: 'ws-1' },
+      { id: 'u1', organizationId: 'org-1', role: 'admin' } as any,
+    );
+
+    expect(workspacesService.purge).toHaveBeenCalledWith('ws-1');
+    expect(workspacesService.purgeOldTrash).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: 'ws-1' });
+  });
+
+  it('purge with days delegates to purgeOldTrash', async () => {
+    const workspacesService = {
+      purge: jest.fn(),
+      purgeOldTrash: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const controller = new AdminTrashController(workspacesService as any);
+
+    await controller.purge(
+      { days: 30 },
+      { id: 'u1', organizationId: 'org-1', role: 'admin' } as any,
+    );
+
+    expect(workspacesService.purgeOldTrash).toHaveBeenCalledWith(30);
+    expect(workspacesService.purge).not.toHaveBeenCalled();
+  });
+});

--- a/zephix-backend/src/modules/workspaces/admin-trash.controller.ts
+++ b/zephix-backend/src/modules/workspaces/admin-trash.controller.ts
@@ -3,7 +3,6 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AdminOnlyGuard } from '../../shared/guards/admin-only.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { WorkspacesService } from './workspaces.service';
-import { WorkspacePolicy } from './workspace.policy';
 
 type UserJwt = {
   id: string;
@@ -11,31 +10,26 @@ type UserJwt = {
   role: 'admin' | 'member' | 'guest';
 };
 
+/**
+ * Org-wide trash (admin plane). Authorization: JwtAuthGuard + AdminOnlyGuard only.
+ * Do not re-check with WorkspacePolicy.enforceDelete(u.role) — JWT `users.role` is often
+ * `user`, which incorrectly 403s platform ADMINs (AdminOnlyGuard already passed).
+ */
 @Controller('admin/trash')
 @UseGuards(JwtAuthGuard, AdminOnlyGuard)
 export class AdminTrashController {
-  constructor(
-    private readonly workspacesService: WorkspacesService,
-    private readonly policy: WorkspacePolicy,
-  ) {}
+  constructor(private readonly workspacesService: WorkspacesService) {}
 
   @Get()
   listTrash(@Query('type') type: string, @CurrentUser() u: UserJwt) {
-    console.log('AdminTrashController.listTrash called with:', {
-      type,
-      organizationId: u.organizationId,
-      role: u.role,
-    });
-    this.policy.enforceDelete(u.role);
     return this.workspacesService.listTrash(u.organizationId, type);
   }
 
   @Post('purge')
   purge(
     @Body() body: { id?: string; days?: number },
-    @CurrentUser() u: UserJwt,
+    @CurrentUser() _u: UserJwt,
   ) {
-    this.policy.enforceDelete(u.role);
     if (body.id) {
       return this.workspacesService.purge(body.id);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
PR #156 targeted an older branch shape and hit merge conflicts with `main`. This PR applies the same **authorization fix** against **current `main`**.

## Problem
`AdminTrashController` called `WorkspacePolicy.enforceDelete(u.role)` after `AdminOnlyGuard` had already verified platform **ADMIN**. JWT `users.role` is often `user`, not `admin` → **403** on `GET /api/admin/trash`.

## Change (main codebase)
- Remove `WorkspacePolicy` from `admin-trash.controller.ts` and all `enforceDelete(u.role)` calls.
- Remove debug `console.log` from list handler.
- Add `admin-trash.controller.spec.ts` (list + purge paths).

**Note:** On current `main`, this controller only wires **workspace** trash via `WorkspacesService` (no `PlatformTrashAdminService` in tree). A separate effort can extend trash to projects if the unified service lands on `main`.

## Verify
`npx jest src/modules/workspaces/admin-trash.controller.spec.ts`

Closes the intent of #156 once merged; **#156 can be closed** in favor of this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2becee78-954f-48cb-bc2e-dd5c236fe9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2becee78-954f-48cb-bc2e-dd5c236fe9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

