### PR TITLE
fix(provisioning): remove auto-created workspace — onboarding handles it

### DIFF
--- a/zephix-backend/src/modules/auth/services/org-provisioning.service.ts
+++ b/zephix-backend/src/modules/auth/services/org-provisioning.service.ts
@@ -1,21 +1,19 @@
 /**
  * OrgProvisioningService — post-signup per-organization setup.
  *
- * Called after AuthService.signup() or OrganizationSignupService creates the org.
- * Creates everything a new org needs to function:
- *   1. Default workspace (with founder as workspace_owner)
- *   2. User settings row (eager, not lazy)
- *   3. Onboarding state initialization
+ * Called after signup transaction completes. Creates:
+ *   1. User settings row (eager, not lazy)
+ *   2. Onboarding state initialization
+ *
+ * Workspace creation is handled by the onboarding flow — user chooses
+ * their own workspace name instead of getting a generic auto-created one.
  *
  * Idempotent: checks before creating. Calling twice does nothing harmful.
- * Non-blocking: signup succeeds even if provisioning fails. Lazy-create
- * patterns fill gaps on subsequent requests.
+ * Non-blocking: signup succeeds even if provisioning fails.
  */
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
-import { Workspace } from '../../workspaces/entities/workspace.entity';
-import { WorkspaceMember } from '../../workspaces/entities/workspace-member.entity';
+import { Repository } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { UserSettings } from '../../users/entities/user-settings.entity';
 import { AuditService } from '../../audit/services/audit.service';
@@ -23,8 +21,6 @@ import { AuditAction, AuditEntityType } from '../../audit/audit.constants';
 
 export interface ProvisioningResult {
   organizationId: string;
-  workspaceId: string | null;
-  workspaceCreated: boolean;
   userSettingsCreated: boolean;
   onboardingInitialized: boolean;
 }
@@ -34,11 +30,6 @@ export class OrgProvisioningService {
   private readonly logger = new Logger(OrgProvisioningService.name);
 
   constructor(
-    private readonly dataSource: DataSource,
-    @InjectRepository(Workspace)
-    private readonly workspaceRepo: Repository<Workspace>,
-    @InjectRepository(WorkspaceMember)
-    private readonly memberRepo: Repository<WorkspaceMember>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     @Optional()
@@ -58,45 +49,35 @@ export class OrgProvisioningService {
     userName: string;
     organizationName: string;
   }): Promise<ProvisioningResult> {
-    const { organizationId, userId, userName, organizationName } = params;
+    const { organizationId, userId } = params;
     const result: ProvisioningResult = {
       organizationId,
-      workspaceId: null,
-      workspaceCreated: false,
       userSettingsCreated: false,
       onboardingInitialized: false,
     };
 
     this.logger.log(
-      `Provisioning org ${organizationId} ("${organizationName}") for user ${userId}`,
+      `Provisioning org ${organizationId} ("${params.organizationName}") for user ${userId}`,
     );
 
-    // 1. Default workspace
-    try {
-      const ws = await this.ensureDefaultWorkspace(organizationId, userId, organizationName);
-      if (ws) {
-        result.workspaceId = ws.id;
-        result.workspaceCreated = true;
-      }
-    } catch (err) {
-      this.logger.warn(`Workspace provisioning failed: ${err.message}`);
-    }
+    // Workspace creation is handled by the onboarding flow — user chooses
+    // their own workspace name instead of getting a generic auto-created one.
 
-    // 2. User settings
+    // 1. User settings
     try {
       result.userSettingsCreated = await this.ensureUserSettings(userId, organizationId);
     } catch (err) {
-      this.logger.warn(`User settings provisioning failed: ${err.message}`);
+      this.logger.warn(`User settings provisioning failed: ${(err as Error).message}`);
     }
 
-    // 3. Onboarding state
+    // 2. Onboarding state
     try {
       result.onboardingInitialized = await this.initializeOnboarding(userId);
     } catch (err) {
-      this.logger.warn(`Onboarding init failed: ${err.message}`);
+      this.logger.warn(`Onboarding init failed: ${(err as Error).message}`);
     }
 
-    // 4. Audit event (best-effort)
+    // 3. Audit event (best-effort)
     try {
       await this.auditService?.record({
         action: AuditAction.GOVERNANCE_EVALUATE,
@@ -107,8 +88,6 @@ export class OrgProvisioningService {
         actorPlatformRole: 'ADMIN',
         after: {
           event: 'org.provisioned',
-          workspaceCreated: result.workspaceCreated,
-          workspaceId: result.workspaceId,
           userSettingsCreated: result.userSettingsCreated,
           onboardingInitialized: result.onboardingInitialized,
         },
@@ -118,65 +97,11 @@ export class OrgProvisioningService {
     }
 
     this.logger.log(
-      `Provisioning complete: workspace=${result.workspaceCreated}, ` +
-      `settings=${result.userSettingsCreated}, onboarding=${result.onboardingInitialized}`,
+      `Provisioning complete: settings=${result.userSettingsCreated}, ` +
+      `onboarding=${result.onboardingInitialized}`,
     );
 
     return result;
-  }
-
-  /**
-   * Create a default workspace if the org has none.
-   * Returns the workspace (existing or new) or null if failed.
-   */
-  private async ensureDefaultWorkspace(
-    organizationId: string,
-    userId: string,
-    organizationName: string,
-  ): Promise<Workspace | null> {
-    // Check if any workspace exists for this org
-    const existing = await this.workspaceRepo.findOne({
-      where: { organizationId },
-    });
-    if (existing) {
-      this.logger.debug(`Org ${organizationId} already has workspace ${existing.id}`);
-      return existing;
-    }
-
-    // Create workspace + workspace_member in a transaction
-    return this.dataSource.transaction(async (manager) => {
-      const wsRepo = manager.getRepository(Workspace);
-      const memRepo = manager.getRepository(WorkspaceMember);
-
-      const slug = organizationName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '')
-        .substring(0, 50) || 'workspace';
-
-      const workspace = wsRepo.create({
-        name: `${organizationName}`,
-        slug,
-        organizationId,
-        createdBy: userId,
-        isPrivate: false,
-      });
-      const saved = await wsRepo.save(workspace);
-
-      // Add founder as workspace_owner
-      const member = memRepo.create({
-        organizationId,
-        workspaceId: saved.id,
-        userId,
-        role: 'workspace_owner',
-        status: 'active',
-        createdBy: userId,
-      });
-      await memRepo.save(member);
-
-      this.logger.log(`Created default workspace "${saved.name}" (${saved.id})`);
-      return saved;
-    });
   }
 
   /**
@@ -191,7 +116,7 @@ export class OrgProvisioningService {
     const existing = await this.userSettingsRepo.findOne({
       where: { userId, organizationId },
     });
-    if (existing) return false; // Already exists
+    if (existing) return false;
 
     const row = this.userSettingsRepo.create({
       userId,
@@ -212,7 +137,6 @@ export class OrgProvisioningService {
     const user = await this.userRepo.findOne({ where: { id: userId } });
     if (!user) return false;
 
-    // Only set if not already initialized
     if (user.onboardingStatus && user.onboardingStatus !== 'not_started') {
       return false;
     }


### PR DESCRIPTION
## Summary
Remove workspace auto-creation from OrgProvisioningService. The onboarding flow on staging already handles workspace creation — user chooses their own name.

**Removed:** `ensureDefaultWorkspace()`, Workspace/WorkspaceMember/DataSource imports, `workspaceId`/`workspaceCreated` from result.

**Kept:** User settings eager creation, onboarding state init, audit logging.

## Test plan
- [ ] `tsc --noEmit -p tsconfig.build.json` exits 0
- [ ] New signup creates user_settings + sets onboardingStatus
- [ ] No auto-created workspace after signup
- [ ] Onboarding flow prompts user to create workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)