### PR TITLE
fix(tasks): TaskListSection uses workspaceId prop — fixes blank Activities

### DIFF
--- a/zephix-frontend/src/features/projects/components/TaskListSection.tsx
+++ b/zephix-frontend/src/features/projects/components/TaskListSection.tsx
@@ -94,7 +94,7 @@ interface Props {
 export function TaskListSection({ projectId, workspaceId }: Props) {
   const { user } = useAuth();
   const { isReadOnly } = useWorkspaceRole(workspaceId);
-  const { getWorkspaceMembers, setWorkspaceMembers, activeWorkspaceId } = useWorkspaceStore();
+  const { getWorkspaceMembers, setWorkspaceMembers } = useWorkspaceStore();
   const [tasks, setTasks] = useState<WorkTask[]>([]);
   /** True when server reports more tasks than fit in one page at WORK_TASK_LIST_PAGE_SIZE. */
   const [taskListMayBeIncomplete, setTaskListMayBeIncomplete] = useState(false);
@@ -174,7 +174,9 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
   const isAdmin = isAdminUser(user);
   const isGuest = isGuestUser(user);
   const canEdit = !isReadOnly && !isGuest;
-  const hasWorkspaceMismatch = !activeWorkspaceId || activeWorkspaceId !== workspaceId;
+  // Use the workspaceId prop as source of truth — the parent (ProjectTasksTab)
+  // already knows the correct workspace from ProjectPageLayout.
+  const hasWorkspaceMismatch = !workspaceId;
 
   // Handle WORKSPACE_REQUIRED errors consistently
   const handleWorkspaceError = useCallback(() => {
@@ -188,7 +190,7 @@ export function TaskListSection({ projectId, workspaceId }: Props) {
       loadWorkspaceMembers();
       loadProjectTeam();
     }
-  }, [projectId, workspaceId, activeWorkspaceId]);
+  }, [projectId, workspaceId]);
 
   // Phase 3: load per-project team to filter Activities assignee pool
   async function loadProjectTeam() {


### PR DESCRIPTION
## Summary
Non-waterfall projects (Agile, Kanban, Hybrid, Scrum) showed a blank Activities tab because TaskListSection re-read activeWorkspaceId from the Zustand store and compared it with the workspaceId prop. When navigating directly to a project URL, the store hadn't synced yet — the mismatch guard blocked loadTasks().

## Fix
Use the workspaceId prop as source of truth. The parent already knows the correct workspace.

## Test plan
- [ ] Create project from Agile template → Activities tab shows tasks
- [ ] Navigate directly to project URL → Activities loads correctly
- [ ] Waterfall projects still work (uses WaterfallTable, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)