### PR TITLE
feat(table): date picker, column icons, + button always visible

### DIFF
--- a/zephix-frontend/src/features/projects/columns/ColumnHeaderMenu.tsx
+++ b/zephix-frontend/src/features/projects/columns/ColumnHeaderMenu.tsx
@@ -1,8 +1,33 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown } from 'lucide-react';
+import {
+  Calendar,
+  CheckCircle,
+  ChevronDown,
+  Clock,
+  FileText,
+  Hash,
+  MessageSquare,
+  Tag,
+  Type,
+  User,
+  Users,
+} from 'lucide-react';
 import { COLUMN_REGISTRY } from './column-registry';
 import type { ProjectColumnKey } from './column-types';
+
+/** Icon per column dataType — displayed before the label in headers. */
+const COLUMN_ICONS: Record<string, React.FC<{ className?: string }>> = {
+  text: Type,
+  person: User,
+  status: CheckCircle,
+  date: Calendar,
+  number: Hash,
+  priority: Tag,
+  tags: Tag,
+  boolean: CheckCircle,
+  relation: Users,
+};
 
 /** Scroll containers between trigger and document root (for reposition + clipping avoidance). */
 function collectScrollParents(el: HTMLElement | null): HTMLElement[] {
@@ -240,7 +265,14 @@ export const TableColumnHeader: React.FC<TableColumnHeaderProps> = ({
           onMenuButtonClick();
         }}
       >
-        <span className="truncate">{label}</span>
+        <span className="flex items-center gap-1.5 truncate">
+          {(() => {
+            const col = COLUMN_REGISTRY[columnKey];
+            const Icon = col ? COLUMN_ICONS[col.dataType] : undefined;
+            return Icon ? <Icon className="h-3.5 w-3.5 shrink-0 text-slate-400" /> : null;
+          })()}
+          {label}
+        </span>
         <ChevronDown
           className={`h-3.5 w-3.5 shrink-0 text-slate-400 transition-transform dark:text-slate-500 ${
             menuOpen ? 'rotate-180' : ''

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -1588,10 +1588,10 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                   if (externalOpen) externalClose?.();
                   setStandaloneFieldsOpen(true);
                 }}
-                title="Show or hide columns"
-                aria-label="Show or hide columns"
+                title="Add a Column"
+                aria-label="Add a Column"
                 data-testid="waterfall-add-column-header"
-                className="flex h-full w-full items-center justify-center rounded px-1 py-2 opacity-0 transition-opacity group-hover/header:opacity-100 focus:opacity-100 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:hover:bg-slate-800"
+                className="flex h-full w-full items-center justify-center rounded px-1 py-2 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:hover:bg-slate-800"
               >
                 <Plus className="h-4 w-4 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300" />
               </button>
@@ -2777,15 +2777,27 @@ const InlineDate: React.FC<{
   onTab?: (direction: 1 | -1) => void;
 }> = ({ value, onCancel, onCommit, onTab }) => {
   const ref = useRef<HTMLInputElement | null>(null);
+  const committed = useRef(false);
   useEffect(() => {
-    ref.current?.focus();
+    const el = ref.current;
+    if (!el) return;
+    el.focus();
+    // Open the native date picker directly — no intermediate mm/dd/yyyy state
+    try { el.showPicker(); } catch { /* showPicker not supported in all browsers */ }
   }, []);
   return (
     <input
       ref={ref}
       type="date"
       defaultValue={value ? value.slice(0, 10) : ''}
-      onChange={(e) => onCommit(e.target.value)}
+      onChange={(e) => {
+        committed.current = true;
+        onCommit(e.target.value);
+      }}
+      onBlur={() => {
+        // Click outside dismisses back to —  (or the selected date)
+        if (!committed.current) onCancel();
+      }}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.preventDefault();


### PR DESCRIPTION
## Summary
Three table UX improvements from ClickUp walkthrough.

### 1. Date picker opens calendar directly
- Click date cell (`—`) → native calendar picker opens immediately via `showPicker()`
- No more intermediate `mm/dd/yyyy` text input state
- Click outside → dismisses back to `—` (blur-to-cancel)

### 2. Column header icons
- Each column header shows a type-appropriate icon before the label
- User for Assignee, Calendar for dates, CheckCircle for Status, Hash for numbers, Tag for priority/tags
- Icons match ClickUp's pattern of visual column type indicators

### 3. + Add Column button always visible
- Was `opacity-0` with hover-only reveal — now always visible at end of headers
- Tooltip: "Add a Column"
- Opens the Fields panel to toggle columns on/off

## Test plan
- [ ] Click date cell → calendar opens directly (no intermediate input)
- [ ] Click outside date picker → dismisses to blank
- [ ] Column headers show icons (Assignee = user, Status = check, dates = calendar)
- [ ] + button visible at end of column headers without hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)