### PR TITLE
fix: workspace creation stability — guard removal + onboarding contract

### DIFF
--- a/zephix-backend/src/modules/workspaces/workspaces.controller.ts
+++ b/zephix-backend/src/modules/workspaces/workspaces.controller.ts
@@ -266,8 +266,11 @@ export class WorkspacesController {
    * - Creator is always included as workspace_owner when deriving ownerUserIds
    */
   @Post()
-  @UseGuards(WorkspaceMembershipFeatureGuard, RequireOrgRoleGuard)
+  @UseGuards(RequireOrgRoleGuard)
   @RequireOrgRole(PlatformRole.ADMIN)
+  // WorkspaceMembershipFeatureGuard removed — it controls listing visibility,
+  // not creation rights. When the flag is off, users must still be able to
+  // create workspaces (especially during onboarding).
   async create(
     @Body() dto: CreateWorkspaceDto,
     @CurrentUser() u: UserJwt,

--- a/zephix-frontend/src/features/organizations/onboarding.api.ts
+++ b/zephix-frontend/src/features/organizations/onboarding.api.ts
@@ -9,6 +9,8 @@ export type OnboardingStatus = {
   completedSteps: string[];
   completedAt: string | null;
   skippedAt: string | null;
+  /** Legacy field — may be absent on newer backends. */
+  onboardingStatus?: string;
 };
 
 /**
@@ -23,7 +25,9 @@ export async function getOnboardingStatus(): Promise<OnboardingStatus> {
   // apiClient.get already unwraps one `{ data: T }` layer — do not destructure `.data` again.
   const payload = await apiClient.get<unknown>("/organizations/onboarding/status");
   const status = unwrap<OnboardingStatus>(payload);
-  if (!status || typeof status !== "object" || !("onboardingStatus" in status)) {
+  // Backend returns { completed, mustOnboard, skipped, workspaceCount, ... }
+  // Validate against the actual contract — must have `mustOnboard` boolean.
+  if (!status || typeof status !== "object" || typeof (status as any).mustOnboard !== "boolean") {
     throw new Error("Invalid onboarding status response");
   }
   return status;


### PR DESCRIPTION
## Summary
Fixes two root causes that break workspace creation on every deployment.

### Fix 1: Remove misplaced guard from workspace creation
`WorkspaceMembershipFeatureGuard` was on `POST /workspaces` — it controls **listing visibility**, not **creation rights**. When `ZEPHIX_WS_MEMBERSHIP_V1` wasn't set to `'1'`, all workspace creation was blocked with 403. Removed from create endpoint. Users must always be able to create workspaces, especially during onboarding.

### Fix 2: Align onboarding status contract
Frontend `onboarding.api.ts` checked for `'onboardingStatus' in status` but the backend returns `{ completed, mustOnboard, skipped, workspaceCount, ... }` — no `onboardingStatus` field. This caused `"Invalid onboarding status response"` error on every page load. Updated validation to check `mustOnboard` boolean — the actual field the backend sends.

### Why this keeps breaking
1. Feature flag guard on the wrong endpoint — any env var change breaks creation
2. Frontend/backend contract mismatch — response shape changed but validation wasn't updated
3. No integration test for signup → workspace → project flow

## Test plan
- [ ] Create workspace on staging → succeeds (no 400/403)
- [ ] Console shows no "Invalid onboarding status response" error
- [ ] Onboarding redirect works for new admin users (mustOnboard=true)
- [ ] Existing workspaces unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)