### PR TITLE
fix(routing): project navigation redirect to inbox

### DIFF
--- a/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
+++ b/zephix-frontend/src/features/workspaces/SidebarWorkspaces.tsx
@@ -223,10 +223,15 @@ export function SidebarWorkspaces() {
         if (next[wsId] && !wsProjects[wsId] && !wsProjectsLoading[wsId]) {
           void loadWorkspaceProjects(wsId);
         }
+        // Expanding a workspace also activates it — ensures RequireWorkspace
+        // passes when the user clicks a child project.
+        if (next[wsId]) {
+          setActiveWorkspace(wsId);
+        }
         return next;
       });
     },
-    [wsProjects, wsProjectsLoading, loadWorkspaceProjects],
+    [wsProjects, wsProjectsLoading, loadWorkspaceProjects, setActiveWorkspace],
   );
   const rootRef = useRef<HTMLDivElement>(null);
   const menuPanelRef = useRef<HTMLDivElement>(null);
@@ -921,7 +926,10 @@ export function SidebarWorkspaces() {
                           // the index route → ProjectOverviewTab, and
                           // ProjectPageLayout's Waterfall landing-tab redirect
                           // still kicks in for Waterfall projects → /tasks.
-                          onClick={() => navigate(`/projects/${p.id}`)}
+                          onClick={() => {
+                            setActiveWorkspace(ws.id);
+                            navigate(`/projects/${p.id}`);
+                          }}
                           className={`flex min-w-0 flex-1 items-center gap-2 truncate rounded-md px-2 py-1 text-left text-xs transition ${
                             isProjectActive ? 'font-medium text-blue-700' : 'text-slate-600'
                           }`}

--- a/zephix-frontend/src/routes/RequireWorkspace.tsx
+++ b/zephix-frontend/src/routes/RequireWorkspace.tsx
@@ -12,11 +12,21 @@ import { useWorkspaceStore } from "@/state/workspace.store";
  *     <Route path="/projects" ... />
  *   </Route>
  *
- * /home is org-level and never requires a workspace. /inbox is paid + workspace-scoped (Batch 2).
+ * Zustand persist hydration: the workspace store rehydrates from
+ * localStorage on mount. During the initial sync render the store
+ * may report activeWorkspaceId as null even though a value exists
+ * in storage. We check the `_hasHydrated` flag (Zustand persist
+ * middleware sets it after rehydration) to avoid false redirects.
+ * If not hydrated yet, we render nothing (brief flash) rather than
+ * redirecting to inbox.
  */
 export default function RequireWorkspace() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const hasHydrated = useWorkspaceStore.persist?.hasHydrated?.() ?? true;
   const location = useLocation();
+
+  // Wait for Zustand persist to rehydrate from localStorage before deciding.
+  if (!hasHydrated) return null;
 
   if (!activeWorkspaceId) {
     const intended = location.pathname + location.search;


### PR DESCRIPTION
## Summary
- **Sidebar project click** now calls `setActiveWorkspace(ws.id)` before navigating, so `RequireWorkspace` guard passes
- **Chevron expand** also activates the workspace, ensuring child project clicks have context
- **RequireWorkspace** now waits for Zustand persist hydration before redirecting, preventing false redirects on fresh page loads

## Root Cause
Expanding a workspace tree via chevron and clicking a project never set `activeWorkspaceId`. The `RequireWorkspace` guard saw `null` and redirected to `/inbox?next=...`, which is a dead end since `InboxPage` doesn't consume the `next` parameter.

## Test plan
- [ ] Click chevron to expand workspace → click project → should open project (not redirect to inbox)
- [ ] Hard refresh on a project URL → should load correctly after hydration
- [ ] Click workspace name → click project → still works as before
- [ ] Single-workspace auto-select still works on first login

🤖 Generated with [Claude Code](https://claude.com/claude-code)