### PR TITLE
fix(env): harden environment validation and feature flag guard

### DIFF
--- a/zephix-backend/src/bootstrap/env-validator.spec.ts
+++ b/zephix-backend/src/bootstrap/env-validator.spec.ts
@@ -1,0 +1,203 @@
+import { validateEnvironment } from './env-validator';
+
+describe('validateEnvironment', () => {
+  const validProductionEnv = {
+    NODE_ENV: 'production',
+    ZEPHIX_ENV: 'production',
+    DATABASE_URL: 'postgres://user:pass@host:5432/db',
+    REDIS_URL: 'redis://host:6379',
+    JWT_SECRET: 'a'.repeat(32),
+    JWT_REFRESH_SECRET: 'b'.repeat(32),
+    REFRESH_TOKEN_PEPPER: 'c'.repeat(32),
+    INTEGRATION_ENCRYPTION_KEY: 'd'.repeat(32),
+  };
+
+  describe('NODE_ENV validation', () => {
+    it('accepts development, test, production', () => {
+      for (const nodeEnv of ['development', 'test', 'production']) {
+        const env =
+          nodeEnv === 'production'
+            ? { ...validProductionEnv, NODE_ENV: nodeEnv }
+            : { NODE_ENV: nodeEnv, ZEPHIX_ENV: 'development' };
+        const result = validateEnvironment(env);
+        expect(result.errors).toEqual([]);
+      }
+    });
+
+    it('warns (does not error) on NODE_ENV="staging" during migration', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'staging',
+        ZEPHIX_ENV: 'staging',
+      });
+      expect(
+        result.errors.some((e) => e.includes('NODE_ENV="staging"')),
+      ).toBe(false);
+      expect(
+        result.warnings.some((w) =>
+          w.includes('TransitionalNodeEnvWarning'),
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects empty NODE_ENV', () => {
+      const result = validateEnvironment({ ZEPHIX_ENV: 'development' });
+      expect(
+        result.errors.some((e) => e.includes('NODE_ENV is not set')),
+      ).toBe(true);
+    });
+
+    it('rejects other invalid NODE_ENV values', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'banana',
+        ZEPHIX_ENV: 'staging',
+      });
+      expect(
+        result.errors.some((e) => e.includes('NODE_ENV="banana"')),
+      ).toBe(true);
+    });
+
+    it('still rejects capitalization typos', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'Production',
+        ZEPHIX_ENV: 'production',
+      });
+      expect(
+        result.errors.some((e) => e.includes('NODE_ENV="Production"')),
+      ).toBe(true);
+    });
+  });
+
+  describe('ZEPHIX_ENV validation', () => {
+    it('accepts development, staging, production', () => {
+      for (const zephixEnv of ['development', 'staging', 'production']) {
+        const env = { NODE_ENV: 'development', ZEPHIX_ENV: zephixEnv };
+        const result = validateEnvironment(env);
+        expect(
+          result.errors.some((e) =>
+            e.includes(`ZEPHIX_ENV="${zephixEnv}" is invalid`),
+          ),
+        ).toBe(false);
+      }
+    });
+
+    it('errors on unset ZEPHIX_ENV when NODE_ENV=production', () => {
+      const env = {
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgres://u:p@h:5432/d',
+        REDIS_URL: 'redis://h:6379',
+        JWT_SECRET: 'a'.repeat(32),
+        JWT_REFRESH_SECRET: 'b'.repeat(32),
+        REFRESH_TOKEN_PEPPER: 'c'.repeat(32),
+        INTEGRATION_ENCRYPTION_KEY: 'd'.repeat(32),
+      };
+      const result = validateEnvironment(env);
+      expect(
+        result.errors.some((e) => e.includes('ZEPHIX_ENV is required')),
+      ).toBe(true);
+    });
+
+    it('warns (does not error) on unset ZEPHIX_ENV when NODE_ENV=development', () => {
+      const result = validateEnvironment({ NODE_ENV: 'development' });
+      expect(result.errors.some((e) => e.includes('ZEPHIX_ENV'))).toBe(false);
+      expect(
+        result.warnings.some((w) => w.includes('ZEPHIX_ENV is not set')),
+      ).toBe(true);
+    });
+
+    it('treats empty string ZEPHIX_ENV as unset (warns in development)', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'development',
+        ZEPHIX_ENV: '',
+      });
+      expect(result.errors.some((e) => e.includes('ZEPHIX_ENV'))).toBe(false);
+      expect(
+        result.warnings.some((w) => w.includes('ZEPHIX_ENV is not set')),
+      ).toBe(true);
+    });
+
+    it('silent on unset ZEPHIX_ENV when NODE_ENV=test', () => {
+      const result = validateEnvironment({ NODE_ENV: 'test' });
+      expect(result.errors.some((e) => e.includes('ZEPHIX_ENV'))).toBe(false);
+      expect(result.warnings.some((w) => w.includes('ZEPHIX_ENV'))).toBe(false);
+    });
+
+    it('rejects invalid ZEPHIX_ENV value', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'development',
+        ZEPHIX_ENV: 'banana',
+      });
+      expect(
+        result.errors.some((e) => e.includes('ZEPHIX_ENV="banana" is invalid')),
+      ).toBe(true);
+    });
+  });
+
+  describe('cross-variable consistency', () => {
+    it('warns when NODE_ENV=development but ZEPHIX_ENV≠development', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'development',
+        ZEPHIX_ENV: 'staging',
+      });
+      expect(result.warnings.some((w) => w.includes('Inconsistent'))).toBe(
+        true,
+      );
+    });
+
+    it('errors on NODE_ENV=production + ZEPHIX_ENV=development', () => {
+      const result = validateEnvironment({
+        ...validProductionEnv,
+        ZEPHIX_ENV: 'development',
+      });
+      expect(
+        result.errors.some((e) => e.includes('Dangerous combination')),
+      ).toBe(true);
+    });
+  });
+
+  describe('production secrets', () => {
+    it('passes with all secrets present and ≥32 chars', () => {
+      const result = validateEnvironment(validProductionEnv);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('fails when JWT_SECRET is missing', () => {
+      const { JWT_SECRET: _j, ...rest } = validProductionEnv;
+      const result = validateEnvironment(rest);
+      expect(
+        result.errors.some((e) =>
+          e.includes('Missing required secret: JWT_SECRET'),
+        ),
+      ).toBe(true);
+    });
+
+    it('fails when JWT_SECRET is too short', () => {
+      const result = validateEnvironment({
+        ...validProductionEnv,
+        JWT_SECRET: 'short',
+      });
+      expect(
+        result.errors.some((e) => e.includes('JWT_SECRET is too short')),
+      ).toBe(true);
+    });
+
+    it('does not require secrets when NODE_ENV=development', () => {
+      const result = validateEnvironment({
+        NODE_ENV: 'development',
+        ZEPHIX_ENV: 'development',
+      });
+      expect(
+        result.errors.some((e) => e.includes('Missing required secret')),
+      ).toBe(false);
+    });
+
+    it('validates DATABASE_URL presence (not length — it is a URL)', () => {
+      const { DATABASE_URL: _d, ...rest } = validProductionEnv;
+      const result = validateEnvironment(rest);
+      expect(
+        result.errors.some((e) =>
+          e.includes('Missing required secret: DATABASE_URL'),
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/zephix-backend/src/bootstrap/env-validator.todo.md
+++ b/zephix-backend/src/bootstrap/env-validator.todo.md
@@ -1,0 +1,27 @@
+# env-validator - Transitional TODO
+
+## Transitional: NODE_ENV="staging" warning
+
+Currently `validateEnvironment()` accepts `NODE_ENV=staging` with a warning
+instead of an error. This is a migration window to allow Railway staging to
+boot while we switch `NODE_ENV` from `staging` to `production`.
+
+### Removal criteria
+
+Remove the transitional branch in `validateEnvironment()` when ALL of:
+
+- [ ] Railway staging backend shows `Environment validated: NODE_ENV=production, ZEPHIX_ENV=staging` in logs for at least 7 days
+- [ ] Railway staging logs no longer contain `TransitionalNodeEnvWarning`
+- [ ] Any other environments (demo, sandbox, CI) have been audited and set to valid NODE_ENV values
+- [ ] Team has been notified that `NODE_ENV=staging` will become fatal
+
+### Code location
+
+`zephix-backend/src/bootstrap/env-validator.ts` - search for `TransitionalNodeEnvWarning`
+
+### When removing
+
+1. Delete the `if (nodeEnv === 'staging')` branch
+2. Keep the `errors.push(...)` else branch as the sole path
+3. Update `env-validator.spec.ts`: change the warning test back to expecting an error
+4. Delete this file (`env-validator.todo.md`)

--- a/zephix-backend/src/bootstrap/env-validator.ts
+++ b/zephix-backend/src/bootstrap/env-validator.ts
@@ -1,0 +1,188 @@
+import { Logger } from '@nestjs/common';
+
+/**
+ * Environment validation for Zephix backend.
+ *
+ * Design principle:
+ * - NODE_ENV is the Node.js ecosystem convention (development | test | production).
+ *   It controls framework-level behavior: error verbosity, logging, optimizations.
+ * - ZEPHIX_ENV is the application-level environment distinction (development | staging | production).
+ *   It controls business logic: DB safety guard, email bypass, CORS, staging-only features.
+ *
+ * This validator runs at process startup (before DB wiring guard) so misconfiguration
+ * aborts before silent skips (e.g. empty ZEPHIX_ENV + DB guard).
+ *
+ * NOTE: `bootstrap()` in main.ts also validates JWT/pepper/integration keys — defense
+ * in depth. Do not remove one without consolidating. See main.ts comment near requiredEnvVars.
+ */
+
+const logger = new Logger('EnvValidator');
+
+export const VALID_NODE_ENVS = ['development', 'test', 'production'] as const;
+export const VALID_ZEPHIX_ENVS = ['development', 'staging', 'production'] as const;
+
+export type NodeEnv = (typeof VALID_NODE_ENVS)[number];
+export type ZephixEnv = (typeof VALID_ZEPHIX_ENVS)[number];
+
+/**
+ * Secrets required when NODE_ENV=production.
+ * Length validation (≥32 chars) is enforced for values containing SECRET/PEPPER/KEY.
+ */
+const REQUIRED_PRODUCTION_SECRETS = [
+  'DATABASE_URL',
+  'REDIS_URL',
+  'JWT_SECRET',
+  'JWT_REFRESH_SECRET',
+  'REFRESH_TOKEN_PEPPER',
+  'INTEGRATION_ENCRYPTION_KEY',
+] as const;
+
+const MIN_SECRET_LENGTH = 32;
+
+export interface EnvValidationResult {
+  errors: string[];
+  warnings: string[];
+  nodeEnv: string | undefined;
+  zephixEnv: string | undefined;
+}
+
+/**
+ * Pure function — validates environment variables and returns errors/warnings.
+ * Does not exit the process. Used by `assertValidEnvironment` and unit tests.
+ */
+export function validateEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): EnvValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const nodeEnv = env.NODE_ENV;
+  const zephixEnv = env.ZEPHIX_ENV;
+
+  // 1. NODE_ENV validation
+  if (!nodeEnv) {
+    errors.push(
+      'NODE_ENV is not set. Required values: ' + VALID_NODE_ENVS.join(' | '),
+    );
+  } else if (!VALID_NODE_ENVS.includes(nodeEnv as NodeEnv)) {
+    // TRANSITIONAL: Staging historically ran with NODE_ENV=staging (non-standard).
+    // Warn instead of failing so Railway staging can boot during the migration to
+    // NODE_ENV=production + ZEPHIX_ENV=staging. Remove after Session 7 migration.
+    if (nodeEnv === 'staging') {
+      warnings.push(
+        `TransitionalNodeEnvWarning: NODE_ENV="staging" is not a standard Node.js value. ` +
+          `The Node ecosystem recognizes only: ${VALID_NODE_ENVS.join(' | ')}. ` +
+          `ACTION REQUIRED: On Railway staging, set NODE_ENV=production and keep ` +
+          `ZEPHIX_ENV=staging. Staging should mirror production framework behavior. ` +
+          `This warning will become a fatal error in a future release.`,
+      );
+    } else {
+      errors.push(
+        `NODE_ENV="${nodeEnv}" is not a valid Node.js environment. ` +
+          `Valid values: ${VALID_NODE_ENVS.join(' | ')}. ` +
+          `Use ZEPHIX_ENV for staging/production distinction.`,
+      );
+    }
+  }
+
+  // 2. ZEPHIX_ENV validation (context-dependent)
+  if (!zephixEnv) {
+    if (nodeEnv === 'production') {
+      errors.push(
+        'ZEPHIX_ENV is required when NODE_ENV=production. ' +
+          'Valid values: ' +
+          VALID_ZEPHIX_ENVS.join(' | '),
+      );
+    } else if (nodeEnv === 'development') {
+      warnings.push(
+        'ZEPHIX_ENV is not set. Defaulting behavior to development. ' +
+          'For clarity, set ZEPHIX_ENV=development in your local .env file.',
+      );
+    }
+    // NODE_ENV=test: silent (test runners may not set ZEPHIX_ENV)
+  } else if (!VALID_ZEPHIX_ENVS.includes(zephixEnv as ZephixEnv)) {
+    errors.push(
+      `ZEPHIX_ENV="${zephixEnv}" is invalid. ` +
+        `Valid values: ${VALID_ZEPHIX_ENVS.join(' | ')}`,
+    );
+  }
+
+  // 3. Cross-variable consistency
+  if (nodeEnv === 'development' && zephixEnv && zephixEnv !== 'development') {
+    warnings.push(
+      `Inconsistent: NODE_ENV=development but ZEPHIX_ENV=${zephixEnv}. ` +
+        `Local development should use ZEPHIX_ENV=development.`,
+    );
+  }
+
+  if (nodeEnv === 'production' && zephixEnv === 'development') {
+    errors.push(
+      'Dangerous combination: NODE_ENV=production with ZEPHIX_ENV=development. ' +
+        'This is never a valid deployment configuration.',
+    );
+  }
+
+  // 4. Production secrets presence and length
+  if (nodeEnv === 'production') {
+    for (const key of REQUIRED_PRODUCTION_SECRETS) {
+      const val = env[key];
+      if (!val || val.trim().length === 0) {
+        errors.push(`Missing required secret: ${key}`);
+        continue;
+      }
+
+      const isSecretMaterial =
+        key.includes('SECRET') || key.includes('PEPPER') || key.includes('KEY');
+
+      if (isSecretMaterial && val.length < MIN_SECRET_LENGTH) {
+        errors.push(
+          `${key} is too short (${val.length} characters). ` +
+            `Minimum required: ${MIN_SECRET_LENGTH}.`,
+        );
+      }
+    }
+  }
+
+  return { errors, warnings, nodeEnv, zephixEnv };
+}
+
+/**
+ * Asserts the environment is valid. Logs warnings. On errors, logs and exits process.
+ * Call from main.ts at top-level, before DB safety guard.
+ *
+ * Skipped when Jest/Vitest loads this module so test runners are not forced to satisfy
+ * full production env (bootstrap() already returns early for the same signals).
+ */
+export function assertValidEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env.JEST_WORKER_ID || env.VITEST) {
+    return;
+  }
+
+  const result = validateEnvironment(env);
+
+  for (const warning of result.warnings) {
+    logger.warn(warning);
+  }
+
+  if (result.errors.length > 0) {
+    logger.error('═══════════════════════════════════════════════════════');
+    logger.error('ENVIRONMENT VALIDATION FAILED — aborting startup');
+    logger.error('═══════════════════════════════════════════════════════');
+    for (const error of result.errors) {
+      logger.error(`  • ${error}`);
+    }
+    logger.error('═══════════════════════════════════════════════════════');
+    logger.error(
+      'Fix the environment configuration and redeploy. ' +
+        'Starting the service with invalid config is disallowed.',
+    );
+    process.exit(78);
+  }
+
+  logger.log(
+    `Environment validated: NODE_ENV=${result.nodeEnv || '(unset)'}, ` +
+      `ZEPHIX_ENV=${result.zephixEnv || '(unset)'}`,
+  );
+}

--- a/zephix-backend/src/main.ts
+++ b/zephix-backend/src/main.ts
@@ -29,11 +29,18 @@ if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// TOP-LEVEL MODULE INITIALIZATION (runs on import, before bootstrap())
+// Order: env validation → DB hostname guard. DB guard reads ZEPHIX_ENV and skips
+// if empty; validate first so misconfig is not masked by that skip.
+// ═══════════════════════════════════════════════════════════════════════════
+import { assertValidEnvironment } from './bootstrap/env-validator';
 // ENVIRONMENT ↔ DATABASE SAFETY GUARD
 // Prevents staging from hitting production Postgres and vice versa.
 // Uses ZEPHIX_ENV (explicit) over NODE_ENV (overloaded by frameworks).
-// ═══════════════════════════════════════════════════════════════════════════
 import { validateDbWiring } from './common/utils/db-safety-guard';
+
+assertValidEnvironment();
+
 {
   const zephixEnv = process.env.ZEPHIX_ENV || '';
   const dbUrl = process.env.DATABASE_URL || '';
@@ -139,6 +146,10 @@ async function bootstrap() {
 
   assertStagingEmailVerificationBypassGuardrails();
 
+  // NOTE: Environment shape (NODE_ENV / ZEPHIX_ENV) and production secret presence are
+  // also validated at top-level by assertValidEnvironment() before this function runs.
+  // This block is defense-in-depth and richer in-context errors. Do not remove without
+  // consolidating with src/bootstrap/env-validator.ts.
   // Validate required environment variables at startup
   const requiredEnvVars: Record<
     string,

--- a/zephix-backend/src/modules/workspaces/guards/feature-flag.guard.spec.ts
+++ b/zephix-backend/src/modules/workspaces/guards/feature-flag.guard.spec.ts
@@ -1,0 +1,107 @@
+import {
+  ForbiddenException,
+  ExecutionContext,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { WorkspaceMembershipFeatureGuard } from './feature-flag.guard';
+
+describe('WorkspaceMembershipFeatureGuard', () => {
+  function makeGuard(env: Record<string, string | undefined>) {
+    const configService = {
+      get: (key: string, defaultValue?: string) => env[key] ?? defaultValue,
+    } as unknown as ConfigService;
+    return new WorkspaceMembershipFeatureGuard(configService);
+  }
+
+  const mockContext = {} as ExecutionContext;
+
+  describe('bypass conditions', () => {
+    it('bypasses when NODE_ENV=development', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'development',
+        ZEPHIX_WS_MEMBERSHIP_V1: '0',
+      });
+      expect(guard.canActivate(mockContext)).toBe(true);
+    });
+
+    it('bypasses when NODE_ENV=test', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'test',
+        ZEPHIX_WS_MEMBERSHIP_V1: '0',
+      });
+      expect(guard.canActivate(mockContext)).toBe(true);
+    });
+  });
+
+  describe('enforcement in production mode (staging or real prod)', () => {
+    it('allows when flag=1 and NODE_ENV=production + ZEPHIX_ENV=staging', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'production',
+        ZEPHIX_ENV: 'staging',
+        ZEPHIX_WS_MEMBERSHIP_V1: '1',
+      });
+      expect(guard.canActivate(mockContext)).toBe(true);
+    });
+
+    it('allows when flag=1 and NODE_ENV=production + ZEPHIX_ENV=production', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'production',
+        ZEPHIX_ENV: 'production',
+        ZEPHIX_WS_MEMBERSHIP_V1: '1',
+      });
+      expect(guard.canActivate(mockContext)).toBe(true);
+    });
+
+    it('blocks when flag=0 and NODE_ENV=production', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'production',
+        ZEPHIX_ENV: 'staging',
+        ZEPHIX_WS_MEMBERSHIP_V1: '0',
+      });
+      expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
+    });
+
+    it('blocks when flag is unset and NODE_ENV=production', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'production',
+        ZEPHIX_ENV: 'production',
+      });
+      expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
+    });
+
+    it('allows when NODE_ENV is unset and flag=1 (defaults NODE_ENV to production)', () => {
+      const guard = makeGuard({
+        ZEPHIX_WS_MEMBERSHIP_V1: '1',
+      });
+      expect(guard.canActivate(mockContext)).toBe(true);
+    });
+
+    it('blocks when NODE_ENV unset and flag unset (defaults to production, flag off)', () => {
+      const guard = makeGuard({});
+      expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('error payload shape', () => {
+    it('throws structured ForbiddenException', () => {
+      const guard = makeGuard({
+        NODE_ENV: 'production',
+        ZEPHIX_WS_MEMBERSHIP_V1: '0',
+      });
+      try {
+        guard.canActivate(mockContext);
+        fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenException);
+        const response = (err as ForbiddenException).getResponse() as {
+          code?: string;
+          feature?: string;
+          message?: string;
+        };
+        expect(response.code).toBe('FEATURE_DISABLED');
+        expect(response.feature).toBe('workspace_membership_v1');
+        expect(response.message).toBeDefined();
+      }
+    });
+  });
+});

--- a/zephix-backend/src/modules/workspaces/guards/feature-flag.guard.ts
+++ b/zephix-backend/src/modules/workspaces/guards/feature-flag.guard.ts
@@ -3,26 +3,59 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+/**
+ * WorkspaceMembershipFeatureGuard
+ *
+ * Enforces the ZEPHIX_WS_MEMBERSHIP_V1 feature flag.
+ *
+ * Bypass policy:
+ * - NODE_ENV=development → bypass (local dev loops)
+ * - NODE_ENV=test → bypass (test suites set their own flag state)
+ * - Anything else (including production and staging) → evaluate the flag
+ *
+ * This is intentionally NOT `NODE_ENV !== 'production'` because staging runs with
+ * NODE_ENV=production and must exercise the same guard behavior as production.
+ */
 @Injectable()
 export class WorkspaceMembershipFeatureGuard implements CanActivate {
-  constructor(private configService: ConfigService) {}
+  private readonly logger = new Logger(WorkspaceMembershipFeatureGuard.name);
 
-  canActivate(context: ExecutionContext): boolean {
-    // Bypass in development mode for local testing
-    if (process.env.NODE_ENV !== 'production') {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(_context: ExecutionContext): boolean {
+    const nodeEnv = this.configService.get<string>('NODE_ENV', 'production');
+    const zephixEnv = this.configService.get<string>('ZEPHIX_ENV', 'production');
+    const flagValue = this.configService.get<string>(
+      'ZEPHIX_WS_MEMBERSHIP_V1',
+    );
+
+    const isLocalOrTest = nodeEnv === 'development' || nodeEnv === 'test';
+
+    if (isLocalOrTest) {
+      this.logger.debug(
+        `[feature-flag-guard] Bypassed (nodeEnv=${nodeEnv || '(unset)'}, ` +
+          `zephixEnv=${zephixEnv || '(unset)'})`,
+      );
       return true;
     }
 
-    const isEnabled =
-      this.configService.get<string>('ZEPHIX_WS_MEMBERSHIP_V1') === '1';
+    const isEnabled = flagValue === '1';
 
     if (!isEnabled) {
-      throw new ForbiddenException(
-        'Workspace membership feature is not enabled',
+      this.logger.warn(
+        `[feature-flag-guard] BLOCKED: ZEPHIX_WS_MEMBERSHIP_V1="${flagValue ?? '<unset>'}" ` +
+          `in nodeEnv=${nodeEnv || '(unset)'}, zephixEnv=${zephixEnv || '(unset)'}`,
       );
+      throw new ForbiddenException({
+        code: 'FEATURE_DISABLED',
+        feature: 'workspace_membership_v1',
+        message:
+          'Workspace membership feature is not enabled for this environment',
+      });
     }
 
     return true;


### PR DESCRIPTION
## Summary
- Add startup environment validation that separates Node framework mode (`NODE_ENV`) from Zephix app environment (`ZEPHIX_ENV`).
- Preserve the staging migration path by warning on transitional `NODE_ENV=staging` instead of exit 78, with a tracked removal TODO.
- Harden the workspace membership feature flag guard so production-mode runtimes enforce `ZEPHIX_WS_MEMBERSHIP_V1=1`.

## Test plan
- `npx tsc --noEmit`
- `npm run build`
- `npx jest src/bootstrap/env-validator.spec.ts src/modules/workspaces/guards/feature-flag.guard.spec.ts --verbose --runInBand` — 2 suites, 27 tests passing
- `NODE_ENV=staging ZEPHIX_ENV=staging node -e "require('./dist/src/bootstrap/env-validator').assertValidEnvironment()"` — logs `TransitionalNodeEnvWarning`, then validates and exits 0

## Deployment notes
- Phase 1 staging smoke should expect `TransitionalNodeEnvWarning` while Railway still has `NODE_ENV=staging`.
- Phase 2 should flip Railway staging to `NODE_ENV=production` while keeping `ZEPHIX_ENV=staging`; the transitional warning should disappear.

Made with [Cursor](https://cursor.com)