### PR TITLE
fix(deploy): delegate root Railway scripts to backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Zephix Platform - Monorepo",
   "scripts": {
+    "build": "npm --prefix zephix-backend run build",
+    "db:migrate": "npm --prefix zephix-backend run db:migrate",
+    "start:railway": "npm --prefix zephix-backend run start:railway",
     "verify": "npm run verify:backend && npm run verify:frontend",
     "verify:backend": "cd zephix-backend && npm run test:contracts && npm run lint",
     "verify:frontend": "cd zephix-frontend && npm run test:e2e:admin && npm run lint",


### PR DESCRIPTION
## Summary
- Add root-level `build`, `db:migrate`, and `start:railway` scripts that delegate to `zephix-backend`.
- Fix Railway deploys that execute the checked-in root `railway.toml` from the monorepo root and fail with `Missing script: db:migrate`.
- Keep backend package scripts unchanged; this is release wiring only.

## Test plan
- `npm run build` from repo root
- `npm run db:migrate -- --help` from repo root confirms the script resolves and delegates to `zephix-backend`

## Deploy note
This is a follow-up to PR #178. PR #178 already merged, so this must merge separately before the failing Railway deploy can be retried.

Made with [Cursor](https://cursor.com)