### PR TITLE
fix(projects): restore project team assignee actions

### DIFF
--- a/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
+++ b/zephix-frontend/src/features/projects/components/ProjectOverviewCards.tsx
@@ -22,9 +22,8 @@ import {
   UserPlus,
   Users,
 } from 'lucide-react';
-import { api } from '@/lib/api';
-import { useAuth } from '@/state/AuthContext';
-import { listWorkspaceMembers, type WorkspaceMember } from '@/features/workspaces/workspace.api';
+import { toast } from 'sonner';
+
 import { projectsApi, projectShowsGovernanceIndicator, type ProjectDetail } from '../projects.api';
 // listTasks/updateTask will be used when To Do gets backend persistence
 import {
@@ -32,6 +31,10 @@ import {
   type NeedsAttentionItem,
   type ProjectOverview,
 } from '../model/projectOverview';
+
+import { api } from '@/lib/api';
+import { useAuth } from '@/state/AuthContext';
+import { listWorkspaceMembers, type WorkspaceMember } from '@/features/workspaces/workspace.api';
 import { GradientAvatar } from '@/components/ui/GradientAvatar';
 
 /* ── Types ──────────────────────────────────────────────────── */
@@ -58,6 +61,10 @@ function memberName(m: WorkspaceMember): string {
   return m.user?.email || m.email || 'Unknown';
 }
 
+function memberUserId(m: WorkspaceMember): string {
+  return m.userId || m.user?.id || '';
+}
+
 const DOC_ICON_GRADIENTS: [string, string][] = [
   ['#FAC775', '#EF9F27'],
   ['#85B7EB', '#378ADD'],
@@ -78,18 +85,6 @@ function DocRow({ hoverTint, children }: { hoverTint: string; children: ReactNod
       {children}
     </div>
   );
-}
-
-function isThisWeek(dateStr: string | null | undefined): boolean {
-  if (!dateStr) return false;
-  const d = new Date(dateStr);
-  const now = new Date();
-  const startOfWeek = new Date(now);
-  startOfWeek.setDate(now.getDate() - now.getDay());
-  startOfWeek.setHours(0, 0, 0, 0);
-  const endOfWeek = new Date(startOfWeek);
-  endOfWeek.setDate(startOfWeek.getDate() + 7);
-  return d >= startOfWeek && d < endOfWeek;
 }
 
 function formatShortDate(dateStr: string | null | undefined): string {
@@ -281,9 +276,13 @@ export function ProjectOverviewCards({
   const { user } = useAuth();
 
   // Team state
+  const [workspaceMembers, setWorkspaceMembers] = useState<WorkspaceMember[]>([]);
+  const [teamMemberIds, setTeamMemberIds] = useState<string[]>([]);
   const [teamMembers, setTeamMembers] = useState<WorkspaceMember[]>([]);
   const [pmMember, setPmMember] = useState<WorkspaceMember | null>(null);
   const [teamLoading, setTeamLoading] = useState(true);
+  const [teamMutating, setTeamMutating] = useState(false);
+  const [teamManageOpen, setTeamManageOpen] = useState(false);
 
   // Docs state
   const [docs, setDocs] = useState<ProjectDoc[]>([]);
@@ -305,8 +304,15 @@ export function ProjectOverviewCards({
         const teamIds = new Set(teamResult.value.teamMemberIds || []);
         const pmId = overview?.deliveryOwnerUserId ?? teamResult.value.projectManagerId ?? null;
         const allMembers = membersResult.value || [];
+        setWorkspaceMembers(allMembers);
+        setTeamMemberIds(teamResult.value.teamMemberIds || []);
         setPmMember(pmId ? allMembers.find((m) => m.userId === pmId || m.user?.id === pmId) ?? null : null);
         setTeamMembers(allMembers.filter((m) => teamIds.has(m.userId || '') || teamIds.has(m.user?.id || '')));
+      } else {
+        setWorkspaceMembers([]);
+        setTeamMemberIds([]);
+        setPmMember(null);
+        setTeamMembers([]);
       }
       setTeamLoading(false);
     });
@@ -318,6 +324,64 @@ export function ProjectOverviewCards({
     if (!pmId) return teamMembers;
     return teamMembers.filter((m) => (m.userId || m.user?.id) !== pmId);
   }, [teamMembers, pmMember]);
+
+  const availableTeamMembers = useMemo(() => {
+    const assigned = new Set(teamMemberIds);
+    return workspaceMembers.filter((m) => {
+      const id = memberUserId(m);
+      return id && !assigned.has(id);
+    });
+  }, [workspaceMembers, teamMemberIds]);
+
+  const syncTeamMembers = useCallback(
+    (nextIds: string[]) => {
+      const nextIdSet = new Set(nextIds);
+      setTeamMemberIds(nextIds);
+      setTeamMembers(workspaceMembers.filter((m) => nextIdSet.has(memberUserId(m))));
+    },
+    [workspaceMembers],
+  );
+
+  const handleAddTeamMember = useCallback(
+    async (userId: string) => {
+      if (!userId || teamMemberIds.includes(userId)) return;
+      setTeamMutating(true);
+      try {
+        const result = await projectsApi.updateProjectTeam(project.id, [...teamMemberIds, userId]);
+        syncTeamMembers(result.teamMemberIds || []);
+        toast.success('Team member added');
+      } catch (error: any) {
+        toast.error(error?.response?.data?.message || 'Failed to add team member');
+      } finally {
+        setTeamMutating(false);
+      }
+    },
+    [project.id, syncTeamMembers, teamMemberIds],
+  );
+
+  const handleRemoveTeamMember = useCallback(
+    async (userId: string) => {
+      const pmId = pmMember ? memberUserId(pmMember) : null;
+      if (!userId || userId === pmId) {
+        toast.error('Project Lead cannot be removed from the team');
+        return;
+      }
+      setTeamMutating(true);
+      try {
+        const result = await projectsApi.updateProjectTeam(
+          project.id,
+          teamMemberIds.filter((id) => id !== userId),
+        );
+        syncTeamMembers(result.teamMemberIds || []);
+        toast.success('Team member removed');
+      } catch (error: any) {
+        toast.error(error?.response?.data?.message || 'Failed to remove team member');
+      } finally {
+        setTeamMutating(false);
+      }
+    },
+    [pmMember, project.id, syncTeamMembers, teamMemberIds],
+  );
 
   // Fetch documents
   useEffect(() => {
@@ -381,11 +445,13 @@ export function ProjectOverviewCards({
           {canEdit && (
             <button
               type="button"
+              onClick={() => setTeamManageOpen((open) => !open)}
               className="flex items-center gap-1 rounded-lg px-2.5 py-1"
               style={{ fontSize: 12, color: '#0F6E56', background: '#E1F5EE' }}
+              aria-expanded={teamManageOpen}
             >
               <Settings style={{ width: 12, height: 12 }} />
-              Manage
+              {teamManageOpen ? 'Done' : 'Manage'}
             </button>
           )}
         </div>
@@ -413,7 +479,13 @@ export function ProjectOverviewCards({
                 {pmMember ? (
                   <GradientAvatar name={memberName(pmMember)} size={20} />
                 ) : canEdit ? (
-                  <button type="button" className="flex items-center gap-1 rounded-lg px-2 py-1" style={{ fontSize: 11, color: '#0F6E56', background: '#E1F5EE' }}>+ Assign</button>
+                  <span
+                    className="rounded-lg px-2 py-1"
+                    style={{ fontSize: 11, color: '#64748b', background: '#f1f5f9' }}
+                    title="Project Lead assignment is not editable from this card yet."
+                  >
+                    Not editable
+                  </span>
                 ) : null}
               </div>
 
@@ -426,9 +498,13 @@ export function ProjectOverviewCards({
                   <p style={{ fontSize: 13, fontWeight: 500, color: '#1e293b' }}>Business Lead</p>
                   <p style={{ fontSize: 11, color: '#94a3b8' }}>Not assigned</p>
                 </div>
-                {canEdit && (
-                  <button type="button" className="flex items-center gap-1 rounded-lg px-2 py-1" style={{ fontSize: 11, color: '#0F6E56', background: '#E1F5EE' }}>+ Assign</button>
-                )}
+                <span
+                  className="rounded-lg px-2 py-1"
+                  style={{ fontSize: 11, color: '#64748b', background: '#f1f5f9' }}
+                  title="Business Lead is display-only until the backend role field is added."
+                >
+                  Coming soon
+                </span>
               </div>
 
               {/* Team members */}
@@ -463,9 +539,85 @@ export function ProjectOverviewCards({
                   )}
                 </div>
                 {canEdit && (
-                  <button type="button" className="flex items-center gap-1 rounded-lg px-2 py-1" style={{ fontSize: 11, color: '#854F0B', background: '#FAEEDA' }}>+ Add</button>
+                  <button
+                    type="button"
+                    onClick={() => setTeamManageOpen(true)}
+                    className="flex items-center gap-1 rounded-lg px-2 py-1"
+                    style={{ fontSize: 11, color: '#854F0B', background: '#FAEEDA' }}
+                  >
+                    + Add
+                  </button>
                 )}
               </div>
+
+              {teamManageOpen && canEdit && (
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-medium text-slate-700">Manage project team</p>
+                      <p className="mt-0.5 text-[11px] text-slate-500">
+                        Add or remove workspace members for this project. Activities assignees are filtered to this team.
+                      </p>
+                    </div>
+                    {teamMutating && <Loader2 className="h-4 w-4 animate-spin text-slate-400" />}
+                  </div>
+
+                  {teamMembers.length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {teamMembers.map((m) => {
+                        const id = memberUserId(m);
+                        const isPm = pmMember ? id === memberUserId(pmMember) : false;
+                        return (
+                          <span
+                            key={m.id || id}
+                            className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700"
+                          >
+                            {memberName(m)}
+                            {isPm && <span className="text-[10px] uppercase tracking-wide text-blue-600">Lead</span>}
+                            {!isPm && (
+                              <button
+                                type="button"
+                                onClick={() => void handleRemoveTeamMember(id)}
+                                disabled={teamMutating}
+                                className="ml-0.5 text-slate-400 hover:text-red-600 disabled:opacity-50"
+                                aria-label={`Remove ${memberName(m)} from project team`}
+                              >
+                                x
+                              </button>
+                            )}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  <div className="mt-3">
+                    <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+                      Add workspace member
+                    </p>
+                    {availableTeamMembers.length === 0 ? (
+                      <p className="text-xs text-slate-400">All workspace members are already on this project team.</p>
+                    ) : (
+                      <div className="flex flex-wrap gap-1.5">
+                        {availableTeamMembers.map((m) => {
+                          const id = memberUserId(m);
+                          return (
+                            <button
+                              key={m.id || id}
+                              type="button"
+                              onClick={() => void handleAddTeamMember(id)}
+                              disabled={teamMutating || !id}
+                              className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition hover:border-emerald-300 hover:bg-emerald-50 disabled:opacity-50"
+                            >
+                              + {memberName(m)}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/zephix-frontend/src/features/projects/tabs/ProjectTasksTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectTasksTab.tsx
@@ -76,6 +76,8 @@ export const ProjectTasksTab: React.FC = () => {
         <WaterfallTable
           projectId={projectId}
           workspaceId={workspaceId}
+          projectName={ctx.project?.name}
+          workspaceName={ctx.workspaceDisplayName}
           customizeViewOpen={customizeViewOpen}
           onCustomizeViewClose={handleClose}
           gearAnchorRef={gearRef}

--- a/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
+++ b/zephix-frontend/src/features/projects/waterfall/WaterfallTable.tsx
@@ -111,6 +111,7 @@ import { type Sprint } from '@/features/sprints/sprints.api';
 import { useSprintTaskAssignmentMutations } from '@/features/projects/hooks/useSprintTaskAssignmentMutations';
 import { workTasksByProjectQueryKey } from '@/features/projects/workTasksQueryKey';
 import { AssigneePicker } from '../components/AssigneePicker';
+import { projectsApi } from '../projects.api';
 import { getPhaseColor } from './phaseColors';
 import { computePhaseRollup } from './phaseRollups';
 import { CustomizeViewPanel, StandaloneFieldsPanel } from './CustomizeViewPanel';
@@ -120,6 +121,7 @@ import {
   listWorkspaceMembers,
   type WorkspaceMember,
 } from '@/features/workspaces/workspace.api';
+import { InviteProjectMemberDialog } from '@/features/workspaces/components/InviteProjectMemberDialog';
 import {
   getTaskRowMenuGroups,
   isTaskRowMenuActionVisible,
@@ -359,6 +361,8 @@ const WORK_TASK_LIST_PAGE_SIZE = 200;
 interface WaterfallTableProps {
   projectId: string;
   workspaceId: string;
+  projectName?: string;
+  workspaceName?: string | null;
   /** When true, opens the CustomizeViewPanel. Controlled by ProjectTasksTab. */
   customizeViewOpen?: boolean;
   /** Called when the panel requests close. */
@@ -374,6 +378,8 @@ interface WaterfallTableProps {
 export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   projectId,
   workspaceId,
+  projectName,
+  workspaceName,
   customizeViewOpen: externalOpen,
   onCustomizeViewClose: externalClose,
   gearAnchorRef,
@@ -421,6 +427,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
   const [tasks, setTasks] = useState<WorkTask[]>([]);
   const [taskListMayBeIncomplete, setTaskListMayBeIncomplete] = useState(false);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
+  const [assigneeInviteOpen, setAssigneeInviteOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -573,7 +580,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const [planPayload, taskRes, memberRes] = await Promise.all([
+      const [planPayload, taskRes, memberRes, projectTeamRes] = await Promise.all([
         request.get<{
           phases?: Array<{
             id: string;
@@ -592,6 +599,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
         // console error and the resulting empty / "/404" landing.
         listTasks({ projectId, limit: WORK_TASK_LIST_PAGE_SIZE }),
         listWorkspaceMembers(workspaceId).catch(() => [] as WorkspaceMember[]),
+        projectsApi.getProjectTeam(projectId).catch(() => null),
       ]);
 
       const rawPhases = planPayload?.phases ?? [];
@@ -610,7 +618,16 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
         items: Array.isArray(taskRes.items) ? taskRes.items : [],
         total: taskRes.total,
       });
-      setMembers(memberRes ?? []);
+      const allMembers = memberRes ?? [];
+      const projectTeamIds = new Set(projectTeamRes?.teamMemberIds ?? []);
+      setMembers(
+        projectTeamRes
+          ? allMembers.filter((m) => {
+              const id = m.userId || m.user?.id || m.id;
+              return projectTeamIds.has(id);
+            })
+          : allMembers,
+      );
 
       // Phase 3 (2026-04-08) — dependency fan-out removed alongside the
       // Dependency column. See `tasksWithPredecessors` comment above.
@@ -1767,6 +1784,7 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
                     onSprintReassign={handleSprintReassign}
                     canEditSprint={canEditSprint}
                     currentUserId={currentUserId}
+                    onInviteAssignee={() => setAssigneeInviteOpen(true)}
                   />
                   {/*
                    * Phase 12 — Inline subtask input row.
@@ -1893,6 +1911,19 @@ export const WaterfallTable: React.FC<WaterfallTableProps> = ({
         >
           Showing first {WORK_TASK_LIST_PAGE_SIZE} tasks. Some tasks may not be visible.
         </div>
+      )}
+
+      {assigneeInviteOpen && (
+        <InviteProjectMemberDialog
+          isOpen={assigneeInviteOpen}
+          onClose={() => setAssigneeInviteOpen(false)}
+          workspaceId={workspaceId}
+          workspaceName={workspaceName || 'this workspace'}
+          projectId={projectId}
+          projectName={projectName || 'this project'}
+          allowNewEmail={false}
+          onSuccess={() => void loadAll()}
+        />
       )}
 
       {/*
@@ -2200,6 +2231,7 @@ interface RowProps {
   canEditSprint: boolean;
   /** Current user ID — for AssigneePicker "Me" badge */
   currentUserId: string | null;
+  onInviteAssignee: () => void;
 }
 
 const ROW_MENU_ICONS: Record<
@@ -2266,6 +2298,8 @@ const WaterfallRow: React.FC<RowProps> = ({
   planningSprints,
   onSprintReassign,
   canEditSprint,
+  currentUserId,
+  onInviteAssignee,
 }) => {
   const rowMenuVisibilityCtx: TaskRowMenuVisibilityContext = {
     level,
@@ -2417,6 +2451,7 @@ const WaterfallRow: React.FC<RowProps> = ({
                 };
               })}
               currentUserId={currentUserId}
+              onInvite={onInviteAssignee}
               onSelect={(userId) => void onCommit('assignee', userId ?? '')}
               onClose={onCancelEdit}
               className="top-full left-0 mt-1"

--- a/zephix-frontend/src/features/workspaces/components/InviteProjectMemberDialog.tsx
+++ b/zephix-frontend/src/features/workspaces/components/InviteProjectMemberDialog.tsx
@@ -38,6 +38,8 @@ interface InviteProjectMemberDialogProps {
   workspaceName: string;
   projectId: string;
   projectName: string;
+  /** When false, only existing organization users can be added. */
+  allowNewEmail?: boolean;
   onSuccess?: () => void;
 }
 
@@ -94,6 +96,7 @@ export function InviteProjectMemberDialog({
   workspaceName,
   projectId,
   projectName,
+  allowNewEmail = true,
   onSuccess,
 }: InviteProjectMemberDialogProps) {
   const [query, setQuery] = useState("");
@@ -171,7 +174,8 @@ export function InviteProjectMemberDialog({
   }, [query, orgMembers]);
 
   // Check if query looks like a valid email.
-  const isEmailQuery = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(query.trim());
+  const isEmailQuery =
+    allowNewEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(query.trim());
   // Check if email already exists in org.
   const emailExistsInOrg = orgMembers.some(
     (m) => m.email.toLowerCase() === query.trim().toLowerCase(),
@@ -208,6 +212,10 @@ export function InviteProjectMemberDialog({
 
         toast.success(`${name} added to ${projectName}`);
       } else {
+        if (!allowNewEmail) {
+          setError("Only existing organization members can be added from this flow.");
+          return;
+        }
         // New email: invite to org + workspace.
         const wsAccessLevel = selectedRole === "viewer" ? "Viewer" : "Member";
         const res = await administrationApi.inviteUsers({
@@ -375,7 +383,7 @@ export function InviteProjectMemberDialog({
                     })}
 
                     {/* Invite by email option */}
-                    {isEmailQuery && !emailExistsInOrg && (
+                    {allowNewEmail && isEmailQuery && !emailExistsInOrg && (
                       <button
                         type="button"
                         onClick={handleSelectEmail}
@@ -400,7 +408,9 @@ export function InviteProjectMemberDialog({
                       <div className="px-3 py-3 text-sm text-gray-500">
                         No matching members.{" "}
                         <span className="text-gray-400">
-                          Type a full email to invite someone new.
+                          {allowNewEmail
+                            ? "Type a full email to invite someone new."
+                            : "Search for someone who already belongs to this organization."}
                         </span>
                       </div>
                     )}


### PR DESCRIPTION
## Summary
- Restore the Overview Project Team controls so `Manage` / `+ Add` open real add-remove project team controls instead of inert buttons.
- Fix the Activities assignee picker crash caused by `currentUserId` not being passed into row rendering.
- Source Activities assignee options from the project team and wire `Invite member` to add existing organization/platform users only.

## Test plan
- `npm run build` in `zephix-frontend` — passed
- `npm run lint:new` — currently blocked by existing `src/lib/api/client.ts` import-order error, unrelated to this change

## Operator notes
`Manage` means edit project-team membership. Project Lead and Business Lead are not fully backed by editable role-specific fields yet, so they no longer pretend to be assignable from this card.

Made with [Cursor](https://cursor.com)