### PR TITLE
chore(rules): add builder UX standards and product principles

### DIFF
--- a/.cursor/rules/40-zephix-builder-ux.mdc
+++ b/.cursor/rules/40-zephix-builder-ux.mdc
@@ -1,0 +1,72 @@
+---
+description: Zephix builder UX standards. Applies to any user-facing configurator, form, wizard, or editor that lets a user create or modify something.
+globs:
+  - zephix-frontend/**/*Builder*
+  - zephix-frontend/**/*Editor*
+  - zephix-frontend/**/*Configurator*
+  - zephix-frontend/**/*Wizard*
+  - zephix-frontend/**/*Form*
+---
+
+# Builder UX Non-Negotiables
+
+Any UI component that lets a user create or configure something
+(template, view, column, workflow, automation, dashboard, report,
+field, role, policy) MUST follow these 8 rules.
+
+## Rule 1: Fork-first, not blank-first
+- Every builder opens with a list of "start from" options.
+- "Blank" is allowed only when no fork option exists. It is never the default.
+- For templates: show System templates → Org templates → "Start blank" (last).
+
+## Rule 2: Constrained choices
+- No builder screen shows more than 7 visible options at one decision point.
+- Additional options live behind "More" with search.
+- Default selections are ALWAYS pre-selected. Blank radio groups are forbidden.
+
+## Rule 3: Live preview
+- The result of any configuration is visible to the user as they configure.
+- "Save and see what happens" workflows are forbidden.
+- For columns: show sample row with the column rendered.
+- For views: show the view as it will appear.
+- For workflows: show the status flow diagram updating in real time.
+
+## Rule 4: AI as primary action
+- Every builder has an "Ask AI to help" button at the top.
+- AI produces a working configuration, not a question.
+- AI's first response is a draft the user can accept, modify, or reject.
+- AI never asks "what would you like?" without offering a starting answer.
+
+## Rule 5: Recipe library
+- Every builder ships with at least 3 pre-built recipes.
+- Recipes are accessible from the empty state and from "Ask AI."
+- Recipes are maintained in `zephix-frontend/src/features/builders/recipes/<builder-name>.ts`
+
+## Rule 6: Inline editing
+- Where possible, the user edits in place (rename inline, drag to reorder).
+- Modals are reserved for multi-step flows that genuinely need them.
+- Justification required in PR description if a builder uses a modal for a single-field edit.
+
+## Rule 7: Implicit save
+- Drafts auto-save. No "Save Draft" button required.
+- "Discard changes" prompts are forbidden unless data loss is real.
+- The user can leave a half-built configuration and return to it.
+
+## Rule 8: AI explains its work
+- When AI configures something, it shows what it did and why in plain language.
+- Format: "I set [field] to [value] because [reason]. Want to change?"
+- AI explanations are inline, not in a separate help panel.
+
+## Builder Acceptance Test (PR gate)
+
+A builder cannot be merged unless it passes:
+
+- [ ] 30-second test: non-technical user produces working result in <30s with AI, <2min without
+- [ ] No fully-empty default state
+- [ ] ≤7 visible options per decision point
+- [ ] Live preview present
+- [ ] "Ask AI" is a primary action
+- [ ] At least 3 recipes shipped
+- [ ] Undo works for any action
+
+If any item fails, the builder is not ready for review. Fix before requesting review.

--- a/.cursor/rules/42-zephix-product-principles.mdc
+++ b/.cursor/rules/42-zephix-product-principles.mdc
@@ -1,0 +1,27 @@
+---
+description: Zephix product principles. Applies to all UI/UX and feature decisions.
+alwaysApply: true
+---
+
+# Product Principles
+
+## Principle 1: Pre-configured first, configurable second
+- Every feature ships with sensible defaults that work without configuration.
+- Configuration UI is added only when defaults cannot serve the majority case.
+- "Blank canvas" defaults require a written justification in the PR description.
+- The test: a new user opens the feature and gets a working result without making decisions. If they must configure before they can use it, the default is wrong.
+
+## Principle 2: Capabilities are quiet
+- Features enforce silently. They do not announce themselves with badges, banners, or pills.
+- Forbidden patterns: status badges that describe internal feature state ("Governed", "Policies active", "Premium", "Beta"), shield icons in headers, "powered by" labels.
+- Governance, security, compliance, AI, automation — these are infrastructure. They surface ONLY when:
+  1. The user is configuring them in the admin console
+  2. The user is blocked by them (then explain why in plain language)
+  3. The user is reviewing audit logs
+- Mature platforms enforce silently. Startup-stage platforms advertise their features. Zephix is the former.
+
+## Principle 3: PMBOK 8 alignment is internal, not marketing
+- Build to PMBOK 8 structure: Governance, Scope, Schedule, Finance, Stakeholders, Resources, Risk as performance domains. 5 Focus Areas (Initiating, Planning, Executing, Monitoring & Controlling, Closing) as project lifecycle.
+- Do NOT surface "PMBOK 8" or any framework name in the product UI.
+- The product works for orgs that have never heard of PMBOK and for orgs that live by it.
+- Framework alignment is a proof point for buyers who care, not a feature for users.

--- a/docs/ai/CURSOR_RUNBOOK_TEMPLATE.md
+++ b/docs/ai/CURSOR_RUNBOOK_TEMPLATE.md
@@ -67,6 +67,23 @@ git status --short
 
 short summary of what changed and why
 
+## Builder UX Acceptance (required for any builder/configurator/editor PR)
+
+If this change touches any user-facing builder, configurator, editor, wizard, 
+or form, the developer must self-check the following BEFORE requesting review.
+If the change does not involve a builder, write "N/A — not a builder change."
+
+- [ ] 30-second test passes (non-technical user produces working result in <30s with AI, <2min without)
+- [ ] No fully-empty default state shown to user
+- [ ] No more than 7 visible options at any decision point
+- [ ] Live preview is present and updates as user configures
+- [ ] "Ask AI to help" is a visible primary action on the builder
+- [ ] At least 3 pre-built recipes shipped with the builder
+- [ ] Undo works for any user action in the builder
+- [ ] Reference: .cursor/rules/40-zephix-builder-ux.mdc
+
+PRs that fail any of the above must NOT request review until fixed.
+
 Step 7. Commit
 Commit message format
 type(scope): summary


### PR DESCRIPTION
## Summary

Adds two new Cursor rule files and updates the runbook template to enforce 
enterprise-grade builder UX standards and product principles.

## What Changed

### New: `.cursor/rules/40-zephix-builder-ux.mdc`
8 non-negotiable rules for any user-facing builder, configurator, editor, 
wizard, or form:
1. Fork-first, not blank-first
2. Constrained choices (≤7 visible options per decision)
3. Live preview required
4. AI as primary action
5. Recipe library (≥3 recipes per builder)
6. Inline editing over modal builders
7. Implicit save (auto-save drafts)
8. AI explains its work

Includes a 7-item Builder Acceptance Test as a PR gate.

### New: `.cursor/rules/42-zephix-product-principles.mdc`
3 product principles applied to all UI/UX and feature decisions:
1. Pre-configured first, configurable second
2. Capabilities are quiet (no tacky badges, silent enforcement)
3. PMBOK 8 alignment is internal, not surfaced in UI

### Modified: `docs/ai/CURSOR_RUNBOOK_TEMPLATE.md`
Added Builder UX Acceptance section so builder PRs are double-gated:
- Cursor enforces during code generation (rule file)
- Human reviewer enforces during runbook execution (runbook checklist)

## Why

Existing rules cover engineering correctness (tenancy, security, scoping, 
contracts). They do not cover product/UX standards. Without these rules:
- Cursor defaults to blank-form configurators (matches majority of training data)
- Builders ship without acceptance tests, creating UX debt
- Product principles like "capabilities are quiet" depend on memory of past 
  corrections rather than enforced rules

These rules attack the verified market gap that defines Zephix's 
differentiator: enterprise capability without configuration tax.

## What's Out of Scope

- No application code changes
- No CI workflow changes  
- No changes to existing rule files (00, 10, 20, 30, root .cursorrules)
- File 41 (AI Scoping) explicitly deferred until existing AI implementation 
  is audited

## Risks / Follow-Ups

1. Existing builders in zephix-frontend may not pass the new acceptance test. 
   Audit list of existing builders and triage in a follow-up issue.
2. Glob patterns in File 40 may need refinement once builder file naming 
   conventions are confirmed (currently matches *Builder*, *Editor*, 
   *Configurator*, *Wizard*, *Form*).
3. File 41 (AI Scoping) deferred — schedule AI module audit before writing.

## Verification

- [x] Both rule files created with correct frontmatter
- [x] Runbook template updated with Builder UX Acceptance section
- [x] No application code touched
- [x] No new dependencies
- [x] Working tree was clean before changes
- [x] Branch is dedicated chore/ branch (not mixed with feature work)

Made with [Cursor](https://cursor.com)