### PR TITLE
fix(frontend): resolve 11 typecheck errors

### DIFF
--- a/zephix-frontend/src/features/administration/components/OrganizationProfileForm.tsx
+++ b/zephix-frontend/src/features/administration/components/OrganizationProfileForm.tsx
@@ -11,6 +11,13 @@ export type OrgProfile = {
   description: string;
 };
 
+type OrgProfileResponse = Partial<OrgProfile> & { domain?: string | null };
+
+type OrgProfileOverviewResponse = {
+  profile?: OrgProfileResponse;
+  data?: { profile?: OrgProfileResponse };
+};
+
 const INDUSTRY_OPTIONS = [
   "Technology",
   "Finance",
@@ -38,11 +45,11 @@ export function OrganizationProfileForm() {
     let active = true;
     (async () => {
       try {
-        const overview = await request.get<{ profile?: OrgProfile; data?: { profile?: OrgProfile } }>(
+        const overview = await request.get<OrgProfileOverviewResponse>(
           "/admin/organization/overview",
         );
         if (!active) return;
-        const p = overview?.profile || overview?.data?.profile || {};
+        const p: OrgProfileResponse = overview?.profile || overview?.data?.profile || {};
         const next: OrgProfile = {
           name: p.name || "",
           industry: p.industry || "Technology",

--- a/zephix-frontend/src/features/organizations/onboarding.api.ts
+++ b/zephix-frontend/src/features/organizations/onboarding.api.ts
@@ -14,6 +14,33 @@ export type OnboardingStatus = {
 };
 
 /**
+ * Derived onboarding status as a single string union for route policies.
+ *
+ * The backend intentionally returns composable flags; route policies need a
+ * stable single value that preserves the older policy semantics.
+ */
+export type OnboardingStatusValue =
+  | "not_started"
+  | "in_progress"
+  | "completed"
+  | "dismissed";
+
+/**
+ * Derive a single OnboardingStatusValue from the raw OnboardingStatus.
+ *
+ * Precedence: completed > dismissed > not_started > in_progress.
+ */
+export function deriveOnboardingStatusValue(
+  status: OnboardingStatus | undefined | null,
+): OnboardingStatusValue {
+  if (!status) return "not_started";
+  if (status.completed) return "completed";
+  if (status.skipped) return "dismissed";
+  if (status.mustOnboard) return "not_started";
+  return "in_progress";
+}
+
+/**
  * Unwrap the backend envelope: { data: {...}, meta: {...} }
  * Falls back to raw response if no envelope.
  */

--- a/zephix-frontend/src/features/organizations/useOrgHomeState.ts
+++ b/zephix-frontend/src/features/organizations/useOrgHomeState.ts
@@ -1,11 +1,17 @@
-import { type OnboardingStatus } from "./onboarding.api";
+import {
+  deriveOnboardingStatusValue,
+  type OnboardingStatus,
+  type OnboardingStatusValue,
+} from "./onboarding.api";
+import { useOrgOnboardingStatusQuery } from "./useOrgOnboardingStatusQuery";
+
 import { useAuth } from "@/state/AuthContext";
 import { platformRoleFromUser } from "@/utils/roles";
-import { useOrgOnboardingStatusQuery } from "./useOrgOnboardingStatusQuery";
 
 export type OrgHomeState = {
   isLoading: boolean;
   status: OnboardingStatus | undefined;
+  onboardingStatus: OnboardingStatusValue;
   workspaceCount: number;
   mustOnboard: boolean;
   skipped: boolean;
@@ -23,6 +29,7 @@ export function useOrgHomeState(): OrgHomeState {
   const workspaceCount = Number(status?.workspaceCount ?? 0);
   const mustOnboard = Boolean(status?.mustOnboard ?? false);
   const skipped = Boolean(status?.skipped ?? false);
+  const onboardingStatus = deriveOnboardingStatusValue(status);
 
   const platformRole = platformRoleFromUser(user);
   const isAdmin = platformRole === "ADMIN";
@@ -33,6 +40,7 @@ export function useOrgHomeState(): OrgHomeState {
     /** True until first fetch settles (success or error). Legacy pages may show a skeleton. */
     isLoading: q.isPending && !q.isError,
     status,
+    onboardingStatus,
     workspaceCount,
     mustOnboard,
     skipped,

--- a/zephix-frontend/src/features/projects/columns/ColumnHeaderMenu.tsx
+++ b/zephix-frontend/src/features/projects/columns/ColumnHeaderMenu.tsx
@@ -4,15 +4,13 @@ import {
   ArrowUpDown,
   Calendar,
   CheckCircle,
-  Clock,
-  FileText,
   Hash,
-  MessageSquare,
   Tag,
   Type,
   User,
   Users,
 } from 'lucide-react';
+
 import { COLUMN_REGISTRY } from './column-registry';
 import type { ProjectColumnKey } from './column-types';
 
@@ -273,10 +271,9 @@ export const TableColumnHeader: React.FC<TableColumnHeaderProps> = ({
         <span className="truncate">{label}</span>
         {/* Sort icon — visible on hover only, shows "Sort" tooltip */}
         {COLUMN_REGISTRY[columnKey]?.sortable && (
-          <ArrowUpDown
-            className="h-3.5 w-3.5 shrink-0 text-slate-400 opacity-0 transition-opacity group-hover/colhdr:opacity-60 dark:text-slate-500"
-            title="Sort"
-          />
+          <span title="Sort">
+            <ArrowUpDown className="h-3.5 w-3.5 shrink-0 text-slate-400 opacity-0 transition-opacity group-hover/colhdr:opacity-60 dark:text-slate-500" />
+          </span>
         )}
       </button>
       {menuOpen && (

--- a/zephix-frontend/src/features/projects/components/__tests__/DuplicateProjectModal.test.tsx
+++ b/zephix-frontend/src/features/projects/components/__tests__/DuplicateProjectModal.test.tsx
@@ -4,7 +4,10 @@ import { DuplicateProjectModal } from '../DuplicateProjectModal';
 
 // Mock dependencies
 const mockNavigate = vi.fn();
-const mockMutateAsync = vi.fn();
+const mockDuplicateProject = vi.fn();
+const mockWorkspaceState = {
+  activeWorkspaceId: 'test-workspace',
+};
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
@@ -18,16 +21,24 @@ vi.mock('sonner', () => ({
 }));
 
 vi.mock('@/state/workspace.store', () => ({
-  useWorkspaceStore: () => ({
-    activeWorkspaceId: 'test-workspace',
-  }),
+  useWorkspaceStore: Object.assign(
+    vi.fn(() => mockWorkspaceState),
+    {
+      getState: () => mockWorkspaceState,
+    },
+  ),
 }));
 
-vi.mock('../../api/useCloneProject', () => ({
-  useCloneProject: () => ({
-    mutateAsync: mockMutateAsync,
-    isPending: false,
-  }),
+vi.mock('../../projects.api', () => ({
+  projectsApi: {
+    duplicateProject: (...args: unknown[]) => mockDuplicateProject(...args),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    post: vi.fn(),
+  },
 }));
 
 const defaultProps = {
@@ -41,39 +52,28 @@ const defaultProps = {
 describe('DuplicateProjectModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockMutateAsync.mockResolvedValue({
+    mockDuplicateProject.mockResolvedValue({
       newProjectId: 'new-proj-1',
+      newProjectName: 'Test Project (Copy)',
       sourceProjectId: 'proj-1',
-      mode: 'structure_only',
-      cloneRequestId: 'req-1',
-      name: 'Test Project (Copy)',
-      workspaceId: 'ws-1',
+      phaseCount: 3,
+      taskCount: 12,
     });
   });
 
-  it('renders two options with Structure only selected by default', () => {
+  it('renders the structure-only duplicate form', () => {
     render(<DuplicateProjectModal {...defaultProps} />);
 
-    const structureOnly = screen.getByTestId('mode-structure-only');
-    const fullClone = screen.getByTestId('mode-full-clone');
-
-    expect(structureOnly).toBeDefined();
-    expect(fullClone).toBeDefined();
-
-    // Structure only should have the checked radio
-    const checkedRadio = structureOnly.querySelector('input[type="radio"]') as HTMLInputElement;
-    expect(checkedRadio?.checked).toBe(true);
+    expect(screen.getByText('Duplicate project')).toBeDefined();
+    expect(screen.getByText(/Copies phases, tasks, methodology, and description/)).toBeDefined();
+    expect(screen.getByTestId('clone-submit')).toBeDefined();
   });
 
-  it('Clone with work option is disabled', () => {
+  it('does not render deprecated clone mode options', () => {
     render(<DuplicateProjectModal {...defaultProps} />);
 
-    const fullClone = screen.getByTestId('mode-full-clone');
-    const radio = fullClone.querySelector('input[type="radio"]') as HTMLInputElement;
-    expect(radio?.disabled).toBe(true);
-
-    // Should show "Coming next" text
-    expect(fullClone.textContent).toContain('Coming next');
+    expect(screen.queryByTestId('mode-structure-only')).toBeNull();
+    expect(screen.queryByTestId('mode-full-clone')).toBeNull();
   });
 
   it('prefills name with (Copy) suffix', () => {
@@ -90,10 +90,7 @@ describe('DuplicateProjectModal', () => {
     fireEvent.click(submitBtn);
 
     await waitFor(() => {
-      expect(mockMutateAsync).toHaveBeenCalledWith({
-        workspaceId: 'ws-1',
-        projectId: 'proj-1',
-        mode: 'structure_only',
+      expect(mockDuplicateProject).toHaveBeenCalledWith('proj-1', {
         newName: 'Test Project (Copy)',
       });
     });
@@ -119,7 +116,7 @@ describe('DuplicateProjectModal', () => {
   });
 
   it('handles 409 conflict error', async () => {
-    mockMutateAsync.mockRejectedValue({
+    mockDuplicateProject.mockRejectedValue({
       response: { data: { code: 'CLONE_IN_PROGRESS', message: 'Already in progress' } },
     });
 
@@ -131,7 +128,7 @@ describe('DuplicateProjectModal', () => {
     fireEvent.click(submitBtn);
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('A duplication is already in progress');
+      expect(toast.error).toHaveBeenCalledWith('Already in progress');
     });
   });
 });

--- a/zephix-frontend/src/features/projects/layout/WorkSurfaceUiContext.tsx
+++ b/zephix-frontend/src/features/projects/layout/WorkSurfaceUiContext.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 type WorkSurfaceUiContextValue = {
   customizeViewOpen: boolean;
   setCustomizeViewOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  gearRef: React.RefObject<HTMLButtonElement | null>;
+  gearRef: React.RefObject<HTMLButtonElement>;
 };
 
 const WorkSurfaceUiContext = createContext<WorkSurfaceUiContextValue | null>(null);

--- a/zephix-frontend/src/features/projects/tabs/__tests__/board-view.test.tsx
+++ b/zephix-frontend/src/features/projects/tabs/__tests__/board-view.test.tsx
@@ -19,6 +19,9 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const mockNavigate = vi.fn();
+const mockSetSearchParams = vi.fn();
+
 // ── Mock auth context ────────────────────────────────────────────────
 
 const mockUser = { platformRole: 'MEMBER', role: 'MEMBER' };
@@ -28,9 +31,15 @@ vi.mock('@/state/AuthContext', () => ({
 
 // ── Mock react-router-dom ────────────────────────────────────────────
 
-vi.mock('react-router-dom', () => ({
-  useParams: () => ({ projectId: 'p1' }),
-}));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ projectId: 'p1' }),
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [new URLSearchParams(), mockSetSearchParams],
+  };
+});
 
 // ── Mock workspace store ─────────────────────────────────────────────
 
@@ -42,11 +51,13 @@ vi.mock('@/state/workspace.store', () => ({
 
 const mockListTasks = vi.fn();
 const mockUpdateTask = vi.fn();
+const mockCreateTask = vi.fn();
 const mockGetWorkflowConfig = vi.fn();
 
 vi.mock('@/features/work-management/workTasks.api', () => ({
   listTasks: (...args: any[]) => mockListTasks(...args),
   updateTask: (...args: any[]) => mockUpdateTask(...args),
+  createTask: (...args: any[]) => mockCreateTask(...args),
   getWorkflowConfig: (...args: any[]) => mockGetWorkflowConfig(...args),
 }));
 
@@ -134,6 +145,7 @@ describe('ProjectBoardTab', () => {
     mockListTasks.mockResolvedValue({ items: makeTasks(), total: 3 });
     mockGetWorkflowConfig.mockResolvedValue(defaultWipConfig);
     mockUpdateTask.mockResolvedValue(makeTasks()[0]);
+    mockCreateTask.mockResolvedValue(makeTasks()[0]);
     setRole('MEMBER');
   });
 

--- a/zephix-frontend/src/features/workspaces/dashboard/normalize.ts
+++ b/zephix-frontend/src/features/workspaces/dashboard/normalize.ts
@@ -40,24 +40,22 @@ function safeObject<T extends Record<string, unknown>>(val: unknown): T {
   return (val && typeof val === 'object' && !Array.isArray(val) ? val : {}) as T;
 }
 
-function safeString(val: unknown, fallback = ''): string {
-  return typeof val === 'string' ? val : fallback;
-}
-
 /* ── Normalizers ─────────────────────────────────────────────── */
 
 export function normalizeDashboardSummary(
   raw: DashboardSummary | null | undefined,
 ): DashboardSummary {
   const d = safeObject<any>(raw);
+  const documentsSummary = safeObject<{ total?: unknown }>(d.documentsSummary);
   return {
     projectCount: safeNumber(d.projectCount),
     projectStatusSummary: safeObject(d.projectStatusSummary),
-    taskCount: safeNumber(d.taskCount),
-    completedTaskCount: safeNumber(d.completedTaskCount),
-    overdueTaskCount: safeNumber(d.overdueTaskCount),
-    memberCount: safeNumber(d.memberCount),
-  } as DashboardSummary;
+    openRiskCount: safeNumber(d.openRiskCount),
+    documentsSummary: {
+      total: safeNumber(documentsSummary.total),
+    },
+    upcomingMilestonesCount: safeNumber(d.upcomingMilestonesCount),
+  };
 }
 
 export function normalizeMilestones(

--- a/zephix-frontend/src/lib/api/client.ts
+++ b/zephix-frontend/src/lib/api/client.ts
@@ -1,11 +1,10 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 // InternalAxiosRequestConfig is extended below via module augmentation (no import needed)
 
-import { normalizeDuplicateApiPath } from '@/lib/api/normalizeDuplicateApiPath';
-import { resolveApiBaseUrl } from '@/lib/api/resolveApiBaseUrl';
-
 import { StandardError, ApiClientConfig } from './types';
 
+import { normalizeDuplicateApiPath } from '@/lib/api/normalizeDuplicateApiPath';
+import { resolveApiBaseUrl } from '@/lib/api/resolveApiBaseUrl';
 import { useWorkspaceStore } from '@/state/workspace.store';
 
 function unwrapOneDataLayer(body: unknown): unknown {


### PR DESCRIPTION
## Summary
Resolves 11 frontend TypeScript errors documented in `docs/cicd/known-issues.md` after PR #186.

## Changes by group

**Onboarding (Groups 1+2):** Added `OnboardingStatusValue` type and derivation. Fixes broken DashboardLayout policy gate that was reading `undefined` for `onboardingStatus`.

**Dashboard normalizer (Group 4):** Updated `normalizeDashboardSummary` to return current `DashboardSummary` shape. Removes silent data drop where backend fields (open risks, documents, milestones) weren't reaching UI.

**OrganizationProfileForm (Group 3):** Added local response type to handle legacy `domain` fallback without polluting canonical `OrgProfile`.

**Component drift (Group 5):** Lucide icon `title` prop moved to wrapper. `gearRef` type narrowed.

## Verification
- npm run typecheck: 0 errors (was 11)
- npm run build: success
- npm run lint on touched files: clean
- onboarding tests pass (5 files, 16 tests)

## Runtime impact

Two fixes have runtime impact (not just type cleanup):
1. **DashboardLayout onboarding redirect** was reading `undefined` for `onboardingStatus` — now reads correctly derived value
2. **Dashboard summary cards** were potentially missing data from backend — now receives full payload

## What this PR does NOT do
- Does not remove `continue-on-error: true` from c1-gates job
- Does not add c1-gates to required checks
- Both deferred to separate small PR after this merges

Made with [Cursor](https://cursor.com)