### PR TITLE
ci: add Railway install simulation to catch CI/deploy drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,6 +605,69 @@ jobs:
           echo "Frontend smoke tests skipped temporarily - require backend connection"
           echo "Run manually with: npm run preview && npm run test:smoke"
 
+  railway-install-backend:
+    name: Railway install simulation (backend)
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: zephix-backend/package-lock.json
+
+      - name: Install with --omit=dev (Railway production simulation)
+        working-directory: zephix-backend
+        run: npm ci --legacy-peer-deps --omit=dev
+
+      - name: Build with production-only deps
+        working-directory: zephix-backend
+        run: npm run build
+
+      - name: Verify dist exists
+        working-directory: zephix-backend
+        run: |
+          test -f dist/src/main.js || (echo "❌ dist/src/main.js missing after build" && exit 1)
+          test -f dist/src/config/data-source-migrate.js || (echo "❌ canonical migration script missing" && exit 1)
+          echo "✅ Backend production build artifacts present"
+
+  railway-install-frontend:
+    name: Railway install simulation (frontend)
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: zephix-frontend/package-lock.json
+
+      - name: Step 1 - Verify prepare hook handles missing husky gracefully
+        working-directory: zephix-frontend
+        run: |
+          # Simulate Railway-like environment where husky might not be available
+          # The prepare-husky.cjs script should no-op cleanly
+          npm ci --omit=dev
+          echo "✅ npm ci --omit=dev succeeded (prepare hook handled missing husky)"
+
+      - name: Step 2 - Full install for build (matches nixpacks --include=dev)
+        working-directory: zephix-frontend
+        run: |
+          rm -rf node_modules
+          npm ci --include=dev
+          echo "✅ npm ci --include=dev succeeded"
+
+      - name: Step 3 - Production build
+        working-directory: zephix-frontend
+        run: |
+          npm run build
+          test -d dist || (echo "❌ dist directory missing after build" && exit 1)
+          echo "✅ Frontend production build artifacts present"
+
   # Sprint 10+ merge gate — blocks merge on governance test failure,
   # migration idempotency failure, or health endpoint failure after deploy
   sprint-merge-gate:

--- a/docs/cicd/README.md
+++ b/docs/cicd/README.md
@@ -29,6 +29,35 @@ Manual release builds and GitHub release creation.
 ### architecture-inventory.yml
 Generates architecture inventory artifacts on main branch changes.
 
+## Railway Install Simulation
+
+Two CI jobs simulate Railway's actual install behavior to catch CI/deploy drift:
+
+### railway-install-backend
+Mirrors Railway backend deploy:
+- `npm ci --legacy-peer-deps --omit=dev`
+- `npm run build`
+- Verifies dist artifacts (main.js, canonical migration script)
+
+### railway-install-frontend
+Mirrors Railway frontend deploy:
+- Step 1: `npm ci --omit=dev` (verifies prepare hook handles missing husky)
+- Step 2: `npm ci --include=dev` (matches nixpacks build phase)
+- Step 3: `npm run build` (verifies dist exists)
+
+### Why These Exist
+
+Standard CI uses `npm ci` (with all dependencies). Railway omits dev dependencies in production install paths. Two issues hidden by this drift in PR #188:
+
+1. Backend: `tenant.guard.ts` typed `request.user` via dev-only Express type augmentation. Failed on Railway with TS2339.
+2. Frontend: `package.json` ran `husky` directly in prepare hook. Failed on Railway with sh exit 127.
+
+These jobs catch such drift at PR time instead of deploy time.
+
+### Future Maintenance
+
+When Railway changes its build behavior (e.g., Nixpacks to Railpack migration), update these jobs to match. The goal is exact parity between CI and Railway install/build commands.
+
 ## Branch protection setup (manual)
 
 After this PR merges, configure branch protection on staging:

--- a/docs/cicd/known-issues.md
+++ b/docs/cicd/known-issues.md
@@ -48,3 +48,28 @@ assumptions break at runtime, as with the LoginPage `request` reference.
 
 High for next session. These errors were silent because no CI was running on
 staging PRs.
+
+## Issue: CI/Railway install drift (RESOLVED 2026-04-26)
+
+### Status
+RESOLVED in PR #190 (this PR).
+
+### Was
+CI installed with dev dependencies (`npm ci`), Railway installed without (`npm ci --omit=dev`).
+Two pre-existing issues silently masked by CI's looser install:
+- Backend `tenant.guard.ts` typed via dev-only Express type augmentation
+- Frontend `prepare: husky` ran husky binary unavailable in production install
+
+Both fixes shipped in PR #189. This PR adds CI simulation to prevent recurrence.
+
+### Now
+Two new CI jobs added:
+- `ci / Railway install simulation (backend)`
+- `ci / Railway install simulation (frontend)`
+
+Mirror Railway's exact install commands. Catches future drift at PR time.
+
+### Action Required
+After this PR merges, add both new check names to staging ruleset required checks:
+- `ci / Railway install simulation (backend)`
+- `ci / Railway install simulation (frontend)`


### PR DESCRIPTION
## Summary
Adds two CI jobs that mirror Railway's actual install behavior. Catches CI/deploy drift at PR time instead of at deploy time.

## Background
PR #189 unblocked staging by fixing two pre-existing issues that CI's looser install behavior masked:
- Backend `tenant.guard.ts` typed `request.user` via dev-only Express type augmentation. Failed Railway deploy with TS2339 because Railway omits dev deps.
- Frontend `package.json` ran `husky` directly in prepare hook. Failed Railway deploy with sh exit 127 because husky is in devDependencies.

This PR adds CI simulation so the next instance of CI/Railway drift fails CI before it can fail deploy.

## New jobs

### railway-install-backend
- `npm ci --legacy-peer-deps --omit=dev`
- `npm run build`
- Verifies `dist/src/main.js` and `dist/src/config/data-source-migrate.js` exist

### railway-install-frontend
- Step 1: `npm ci --omit=dev` (verifies prepare-husky.cjs handles missing husky)
- Step 2: `npm ci --include=dev` (matches nixpacks build phase)
- Step 3: `npm run build` (verifies dist exists)

## Job count
12 total jobs (was 10, +2 new).

## Verification
Local simulation passed for both services before commit:
- Backend: `npm ci --legacy-peer-deps --omit=dev && npm run build` ✅
- Frontend: All 3 steps ✅

## What this PR does NOT do
- Does NOT add the new jobs to ruleset required checks (manual GitHub UI step after merge)

## Post-merge manual step
Add to staging ruleset required checks:
- `ci / Railway install simulation (backend)`
- `ci / Railway install simulation (frontend)`

After this, all 8 active CI jobs will be required for staging PR merges (was 6, +2 new).

## Documentation
- `docs/cicd/README.md`: section explaining Railway simulation jobs
- `docs/cicd/known-issues.md`: marked install drift as RESOLVED

## Future maintenance
When Railway changes build behavior (e.g., Nixpacks → Railpack migration), update these jobs to match. Goal is exact parity between CI and Railway commands.

Made with [Cursor](https://cursor.com)