### PR TITLE
feat(projects): unhide Table and Documents tabs

### DIFF
--- a/zephix-frontend/src/App.tsx
+++ b/zephix-frontend/src/App.tsx
@@ -37,7 +37,7 @@ import DocsPage from "@/pages/docs/DocsPage";
 import FormsPage from "@/pages/forms/FormsPage";
 import { ProjectPlanView } from "@/views/work-management/ProjectPlanView";
 import { ProjectPageLayout } from "@/features/projects/layout";
-import { ProjectOverviewTab, ProjectTasksTab, ProjectBoardTab, ProjectGanttTab } from "@/features/projects/tabs";
+import { ProjectOverviewTab, ProjectTasksTab, ProjectBoardTab, ProjectTableTab, ProjectGanttTab, ProjectDocumentsTab } from "@/features/projects/tabs";
 import { NotEnabledInProject } from "@/features/projects/components/NotEnabledInProject";
 import ProjectsPage from "@/pages/projects/ProjectsPage";
 import SettingsPage from "@/pages/settings/SettingsPage";
@@ -285,11 +285,11 @@ export default function App() {
                   <Route path="gantt" element={<ProjectGanttTab />} />
                   {/* Hidden tabs — show controlled "not enabled" state */}
                   <Route path="plan" element={<NotEnabledInProject featureName="Plan" description="Phase planning view will return when work breakdown structure UX is finalized." />} />
-                  <Route path="table" element={<NotEnabledInProject featureName="Table view" description="Spreadsheet-style task editing is not part of the MVP project shell." />} />
+                  <Route path="table" element={<ProjectTableTab />} />
                   <Route path="risks" element={<NotEnabledInProject featureName="Risks" description="The Risk Management Engine is on the platform roadmap and is not active in the MVP shell." />} />
                   <Route path="resources" element={<NotEnabledInProject featureName="Resources" description="The Resource & Capacity Management Engine is on the platform roadmap and is not active in the MVP shell." />} />
                   <Route path="change-requests" element={<NotEnabledInProject featureName="Change Requests" description="Change request governance is on the platform roadmap." />} />
-                  <Route path="documents" element={<NotEnabledInProject featureName="Documents" description="Project document management is on the platform roadmap." />} />
+                  <Route path="documents" element={<ProjectDocumentsTab />} />
                   <Route path="budget" element={<NotEnabledInProject featureName="Budget" description="Budget tracking is part of the Governance Engine roadmap." />} />
                   <Route path="kpis" element={<NotEnabledInProject featureName="KPIs" description="Project-level KPI tracking is part of the Governance Engine roadmap." />} />
                 </Route>

--- a/zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx
+++ b/zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx
@@ -53,7 +53,7 @@ const PROJECT_TABS_ALL = [
 ] as const;
 
 /** MVP visible tabs (HR3) */
-const MVP_VISIBLE_TAB_IDS = new Set(['overview', 'tasks', 'board', 'gantt']);
+const MVP_VISIBLE_TAB_IDS = new Set(['overview', 'tasks', 'board', 'gantt', 'table', 'documents']);
 const PROJECT_TABS = PROJECT_TABS_ALL.filter((t) => MVP_VISIBLE_TAB_IDS.has(t.id));
 
 type TabId = typeof PROJECT_TABS[number]['id'];


### PR DESCRIPTION
## Summary
Unhides two project tabs whose components and backend endpoints already exist and function correctly. First step of tester-readiness work.

## Background
Audit of project tab implementations on `chore/promote-c1-gates-to-required` classified each hidden tab:

| Tab | Classification | Action |
|---|---|---|
| Table | READY TO UNHIDE | This PR |
| Documents | READY TO UNHIDE | This PR |
| Risks | NEEDS WIRING | Separate PR |
| Budget | NOT READY (contract mismatch) | Separate PR |

This PR addresses the two READY tabs only. Risks and Budget will get focused PRs each because they require non-trivial work (API wrapper fix + edit/delete UI for Risks; backend/frontend contract alignment for Budget).

## Changes
### `zephix-frontend/src/App.tsx`
Swapped two route elements from `NotEnabledInProject` to real components:
- `/projects/:projectId/table` → `ProjectTableTab`
- `/projects/:projectId/documents` → `ProjectDocumentsTab`

### `zephix-frontend/src/features/projects/layout/ProjectPageLayout.tsx`
Added `'table'` and `'documents'` to `MVP_VISIBLE_TAB_IDS`, making them appear in the project tab rail.

## Verification
- `npm run typecheck` passes
- No lint errors on edited files
- Risks and Budget routes still point to `NotEnabledInProject` (intentional)
- Imports resolved correctly from `@/features/projects/tabs`
- No backend changes
- No test changes

## Out of scope
- Risks tab (next PR — fix API wrapper unwrap bug, add edit/delete UI)
- Budget tab (PR after that — align frontend/backend contract)
- Risk register field expansion / Risk Matrix view (later work)
- Lessons Learned (later work)

## Manual QA after merge
1. Sign in to staging
2. Open or create a project
3. Verify tab rail shows: Overview, Tasks, Board, Gantt, **Table**, **Documents**
4. Click Table — should load task list (NOT NotEnabledInProject)
5. Click Documents — should load document list (NOT NotEnabledInProject)
6. Verify Risks and Budget tabs are NOT in the tab rail (confirming they remain hidden)
7. Browser console: no errors

Made with [Cursor](https://cursor.com)