### PR TITLE
fix(auth): correct email verification frontend call

### DIFF
--- a/zephix-frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/zephix-frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { Zap, CheckCircle, XCircle, Loader } from 'lucide-react';
-import { api } from '@/lib/api';
+
+import { request } from '@/lib/api';
 
 export const VerifyEmailPage: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -20,7 +21,7 @@ export const VerifyEmailPage: React.FC = () => {
 
     const verifyEmail = async () => {
       try {
-        const response = await api.post('/auth/verify-email', { token });
+        await request.get(`/auth/verify-email?token=${encodeURIComponent(token)}`);
         setStatus('success');
         setMessage('Email verified successfully! You can now log in.');
 


### PR DESCRIPTION
## Summary
Fixes the email verification flow that has been broken end-to-end. Single-file frontend change.

## Background
Audit identified contract mismatch: frontend was POSTing to `/auth/verify-email` with token in body, but backend exposes `GET /auth/verify-email?token=<token>`.

Investigation confirmed:
- ✅ **Email template** — already correct, links to `/verify-email?token=<token>`
- ✅ **Frontend route** — already correct, `/verify-email` mounted to `VerifyEmailPage`
- ✅ **Backend endpoint** — already correct, `GET /api/auth/verify-email?token=<token>`
- ❌ **Frontend API call** — incorrectly used `POST` with body

This PR fixes only the frontend API call. No backend changes. No email template changes.

## Impact
Before this fix: Every user who clicked the verification link in the welcome email got an error. Email verification flow was broken end-to-end.

After this fix: Standard signup flow works — user signs up → receives email → clicks link → verified → can log in.

This is a Day 1 blocker for testers. Must ship before tester launch.

## Changes
### `zephix-frontend/src/pages/auth/VerifyEmailPage.tsx`
- Changed `api.post('/auth/verify-email', { token })` to `request.get(\`/auth/verify-email?token=\${encodeURIComponent(token)}\`)`
- Updated import to use `request` helper consistent with LoginPage resend flow
- Token URL-encoded for safety

## Verification
- `npm run typecheck` passes
- `eslint` passes on changed file
- Backend untouched
- Email template untouched
- LoginPage resend flow untouched

## Out of scope (future cleanup)
Orphan auth pages with stale contracts exist but are not mounted in App.tsx:
- `src/pages/auth/EmailVerificationPage.tsx` — calls `/auth/verify-email/:token` (wrong contract)
- `src/pages/auth/PendingVerificationPage.tsx` — calls `/auth/resend-verification` with wrong method

These should be deleted or properly wired in separate cleanup work. Not in this PR because they're not mounted and fixing them adds risk without immediate value.

## Manual QA after merge
1. Sign up with a fresh test email on staging
2. Wait for verification email to arrive
3. Click verification link in email
4. Verify: redirected to login (or auto-logged in, depending on flow)
5. Verify: can now log in (email is marked verified)
6. Try clicking the verification link a second time — should show "already verified" or "expired" gracefully
7. Try clicking with a bad token (manually edit URL) — should show error gracefully

## Deployment risk
Low. Single-file frontend change. Backend unchanged. Existing pending verification links continue to work because the URL pattern hasn't changed.

Made with [Cursor](https://cursor.com)