### PR TITLE
fix(risks): add canonicalization metadata migration

### DIFF
--- a/zephix-backend/src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts
+++ b/zephix-backend/src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts
@@ -12,7 +12,6 @@ export class AddRiskCanonicalizationMetadata18000000000074
   implements MigrationInterface
 {
   name = 'AddRiskCanonicalizationMetadata18000000000074';
-  transaction = true;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/zephix-backend/src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts
+++ b/zephix-backend/src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts
@@ -96,11 +96,11 @@ export class AddRiskCanonicalizationMetadata18000000000074
             END AS "severity",
             CASE UPPER(COALESCE(r."status", 'OPEN'))
               WHEN 'OPEN' THEN 'OPEN'::"work_risks_status_enum"
-              WHEN 'CLOSED' THEN 'CLOSED'::"work_risks_status_enum"
               WHEN 'MITIGATED' THEN 'MITIGATED'::"work_risks_status_enum"
               WHEN 'ACCEPTED' THEN 'ACCEPTED'::"work_risks_status_enum"
               WHEN 'ACTIVE' THEN 'OPEN'::"work_risks_status_enum"
-              WHEN 'RESOLVED' THEN 'CLOSED'::"work_risks_status_enum"
+              WHEN 'CLOSED' THEN 'ACCEPTED'::"work_risks_status_enum"
+              WHEN 'RESOLVED' THEN 'ACCEPTED'::"work_risks_status_enum"
               ELSE 'OPEN'::"work_risks_status_enum"
             END AS "status",
             3 AS "probability",

--- a/zephix-backend/src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts
+++ b/zephix-backend/src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts
@@ -1,0 +1,180 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * PR 2A: Risk model canonicalization foundation.
+ *
+ * Adds traceability metadata to the workspace-aware work_risks table and
+ * backfills rows from the legacy risks table when a safe project->workspace
+ * mapping exists. This migration is intentionally additive and non-destructive:
+ * legacy risks rows are never modified or deleted.
+ */
+export class AddRiskCanonicalizationMetadata18000000000074
+  implements MigrationInterface
+{
+  name = 'AddRiskCanonicalizationMetadata18000000000074';
+  transaction = true;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "work_risks"
+        ADD COLUMN IF NOT EXISTS "source" VARCHAR(50),
+        ADD COLUMN IF NOT EXISTS "risk_type" VARCHAR(50),
+        ADD COLUMN IF NOT EXISTS "evidence" JSONB,
+        ADD COLUMN IF NOT EXISTS "detected_at" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN IF NOT EXISTS "legacy_risk_id" UUID;
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_work_risks_legacy_risk_id"
+        ON "work_risks" ("legacy_risk_id")
+        WHERE "legacy_risk_id" IS NOT NULL;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_work_risks_source"
+        ON "work_risks" ("source")
+        WHERE "source" IS NOT NULL;
+    `);
+
+    await queryRunner.query(`
+      DO $$
+      DECLARE
+        pre_risks_count INTEGER;
+        pre_work_risks_count INTEGER;
+        post_risks_count INTEGER;
+        post_work_risks_count INTEGER;
+        inserted_count INTEGER;
+        migrated_count INTEGER;
+        unmigratable_count INTEGER;
+        migrated_without_workspace_count INTEGER;
+      BEGIN
+        SELECT COUNT(*) INTO pre_risks_count FROM "risks";
+        SELECT COUNT(*) INTO pre_work_risks_count FROM "work_risks";
+
+        SELECT COUNT(*) INTO unmigratable_count
+        FROM "risks" r
+        LEFT JOIN "projects" p ON p."id"::text = r."project_id"::text
+        WHERE p."id" IS NULL OR p."workspace_id" IS NULL;
+
+        RAISE NOTICE 'Risk canonicalization pre-check: risks=%, work_risks=%, unmigratable=%',
+          pre_risks_count, pre_work_risks_count, unmigratable_count;
+
+        WITH inserted AS (
+          INSERT INTO "work_risks" (
+            "id",
+            "organization_id",
+            "workspace_id",
+            "project_id",
+            "title",
+            "description",
+            "severity",
+            "status",
+            "probability",
+            "impact",
+            "mitigation_plan",
+            "source",
+            "risk_type",
+            "evidence",
+            "detected_at",
+            "legacy_risk_id",
+            "created_at",
+            "updated_at",
+            "created_by"
+          )
+          SELECT
+            uuid_generate_v4() AS "id",
+            p."organization_id" AS "organization_id",
+            p."workspace_id" AS "workspace_id",
+            p."id" AS "project_id",
+            LEFT(COALESCE(NULLIF(r."title", ''), 'Untitled Risk'), 300) AS "title",
+            COALESCE(r."description", '') AS "description",
+            CASE UPPER(COALESCE(r."severity", 'MEDIUM'))
+              WHEN 'LOW' THEN 'LOW'::"work_risks_severity_enum"
+              WHEN 'MEDIUM' THEN 'MEDIUM'::"work_risks_severity_enum"
+              WHEN 'HIGH' THEN 'HIGH'::"work_risks_severity_enum"
+              WHEN 'CRITICAL' THEN 'CRITICAL'::"work_risks_severity_enum"
+              ELSE 'MEDIUM'::"work_risks_severity_enum"
+            END AS "severity",
+            CASE UPPER(COALESCE(r."status", 'OPEN'))
+              WHEN 'OPEN' THEN 'OPEN'::"work_risks_status_enum"
+              WHEN 'CLOSED' THEN 'CLOSED'::"work_risks_status_enum"
+              WHEN 'MITIGATED' THEN 'MITIGATED'::"work_risks_status_enum"
+              WHEN 'ACCEPTED' THEN 'ACCEPTED'::"work_risks_status_enum"
+              WHEN 'ACTIVE' THEN 'OPEN'::"work_risks_status_enum"
+              WHEN 'RESOLVED' THEN 'CLOSED'::"work_risks_status_enum"
+              ELSE 'OPEN'::"work_risks_status_enum"
+            END AS "status",
+            3 AS "probability",
+            3 AS "impact",
+            CASE
+              WHEN r."mitigation" IS NOT NULL THEN r."mitigation"::text
+              ELSE NULL
+            END AS "mitigation_plan",
+            LEFT(COALESCE(NULLIF(r."source", ''), 'legacy_migration'), 50) AS "source",
+            LEFT(r."type", 50) AS "risk_type",
+            r."evidence" AS "evidence",
+            COALESCE(r."detected_at", r."created_at")::timestamptz AS "detected_at",
+            r."id" AS "legacy_risk_id",
+            r."created_at" AS "created_at",
+            r."updated_at" AS "updated_at",
+            NULL::uuid AS "created_by"
+          FROM "risks" r
+          JOIN "projects" p ON p."id"::text = r."project_id"::text
+          WHERE p."workspace_id" IS NOT NULL
+            AND p."organization_id"::text = r."organization_id"::text
+            AND NOT EXISTS (
+              SELECT 1
+              FROM "work_risks" wr
+              WHERE wr."legacy_risk_id" = r."id"
+            )
+          RETURNING 1
+        )
+        SELECT COUNT(*) INTO inserted_count FROM inserted;
+
+        SELECT COUNT(*) INTO post_risks_count FROM "risks";
+        SELECT COUNT(*) INTO post_work_risks_count FROM "work_risks";
+        SELECT COUNT(*) INTO migrated_count
+        FROM "work_risks"
+        WHERE "legacy_risk_id" IS NOT NULL;
+
+        SELECT COUNT(*) INTO migrated_without_workspace_count
+        FROM "work_risks"
+        WHERE "legacy_risk_id" IS NOT NULL
+          AND "workspace_id" IS NULL;
+
+        RAISE NOTICE 'Risk canonicalization post-check: risks=%, work_risks=%, inserted=%, migrated_with_legacy_id=%',
+          post_risks_count, post_work_risks_count, inserted_count, migrated_count;
+
+        IF post_risks_count != pre_risks_count THEN
+          RAISE EXCEPTION 'Risk canonicalization failed: legacy risks count changed from % to %',
+            pre_risks_count, post_risks_count;
+        END IF;
+
+        IF migrated_without_workspace_count != 0 THEN
+          RAISE EXCEPTION 'Risk canonicalization failed: % migrated rows have no workspace_id',
+            migrated_without_workspace_count;
+        END IF;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "work_risks"
+      WHERE "legacy_risk_id" IS NOT NULL;
+    `);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_work_risks_source";`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_work_risks_legacy_risk_id";`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "work_risks"
+        DROP COLUMN IF EXISTS "legacy_risk_id",
+        DROP COLUMN IF EXISTS "detected_at",
+        DROP COLUMN IF EXISTS "evidence",
+        DROP COLUMN IF EXISTS "risk_type",
+        DROP COLUMN IF EXISTS "source";
+    `);
+  }
+}

--- a/zephix-backend/src/migrations/__tests__/18000000000074-AddRiskCanonicalizationMetadata.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000074-AddRiskCanonicalizationMetadata.spec.ts
@@ -71,7 +71,9 @@ describe('Migration 18000000000074 — risk canonicalization metadata', () => {
     expect(backfill).toContain("WHEN 'CRITICAL' THEN 'CRITICAL'");
     expect(backfill).toContain("ELSE 'MEDIUM'");
     expect(backfill).toContain("WHEN 'ACTIVE' THEN 'OPEN'");
-    expect(backfill).toContain("WHEN 'RESOLVED' THEN 'CLOSED'");
+    expect(backfill).toContain("WHEN 'CLOSED' THEN 'ACCEPTED'");
+    expect(backfill).toContain("WHEN 'RESOLVED' THEN 'ACCEPTED'");
+    expect(backfill).not.toContain("THEN 'CLOSED'");
     expect(backfill).toContain("ELSE 'OPEN'");
   });
 

--- a/zephix-backend/src/migrations/__tests__/18000000000074-AddRiskCanonicalizationMetadata.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000074-AddRiskCanonicalizationMetadata.spec.ts
@@ -86,6 +86,11 @@ describe('Migration 18000000000074 — risk canonicalization metadata', () => {
     expect(backfill).toContain('RAISE EXCEPTION');
   });
 
+  it('uses the TypeORM global migration transaction mode', () => {
+    const migration = new AddRiskCanonicalizationMetadata18000000000074();
+    expect('transaction' in migration).toBe(false);
+  });
+
   it('down removes only migrated copies and metadata added by this migration', async () => {
     const queries: string[] = [];
     const mockQueryRunner = {

--- a/zephix-backend/src/migrations/__tests__/18000000000074-AddRiskCanonicalizationMetadata.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000074-AddRiskCanonicalizationMetadata.spec.ts
@@ -1,0 +1,128 @@
+import { AddRiskCanonicalizationMetadata18000000000074 } from '../18000000000074-AddRiskCanonicalizationMetadata';
+
+describe('Migration 18000000000074 — risk canonicalization metadata', () => {
+  async function runUp() {
+    const queries: string[] = [];
+    const mockQueryRunner = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+      }),
+    };
+
+    const migration = new AddRiskCanonicalizationMetadata18000000000074();
+    await migration.up(mockQueryRunner as any);
+
+    return { queries, mockQueryRunner };
+  }
+
+  it('adds additive metadata columns to work_risks', async () => {
+    const { queries } = await runUp();
+    const alter = queries.find((sql) =>
+      sql.includes('ALTER TABLE "work_risks"'),
+    );
+
+    expect(alter).toContain('ADD COLUMN IF NOT EXISTS "source"');
+    expect(alter).toContain('ADD COLUMN IF NOT EXISTS "risk_type"');
+    expect(alter).toContain('ADD COLUMN IF NOT EXISTS "evidence" JSONB');
+    expect(alter).toContain('ADD COLUMN IF NOT EXISTS "detected_at"');
+    expect(alter).toContain('ADD COLUMN IF NOT EXISTS "legacy_risk_id" UUID');
+  });
+
+  it('creates partial indexes for traceability metadata', async () => {
+    const { queries } = await runUp();
+
+    expect(
+      queries.some((sql) =>
+        sql.includes(
+          'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_work_risks_legacy_risk_id"',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((sql) => sql.includes('WHERE "legacy_risk_id" IS NOT NULL')),
+    ).toBe(true);
+    expect(
+      queries.some((sql) =>
+        sql.includes('CREATE INDEX IF NOT EXISTS "IDX_work_risks_source"'),
+      ),
+    ).toBe(true);
+  });
+
+  it('backfills only safely mappable legacy risks and preserves legacy rows', async () => {
+    const { queries } = await runUp();
+    const backfill = queries.find((sql) => sql.includes('WITH inserted AS'));
+
+    expect(backfill).toContain('INSERT INTO "work_risks"');
+    expect(backfill).toContain('FROM "risks" r');
+    expect(backfill).toContain('JOIN "projects" p');
+    expect(backfill).toContain('p."workspace_id" IS NOT NULL');
+    expect(backfill).toContain(
+      'p."organization_id"::text = r."organization_id"::text',
+    );
+    expect(backfill).toContain('WHERE wr."legacy_risk_id" = r."id"');
+    expect(backfill).not.toMatch(/DELETE\s+FROM\s+"risks"/i);
+    expect(backfill).not.toMatch(/DROP\s+TABLE\s+"risks"/i);
+  });
+
+  it('normalizes legacy severity and status values into WorkRisk enums', async () => {
+    const { queries } = await runUp();
+    const backfill = queries.find((sql) => sql.includes('WITH inserted AS'));
+
+    expect(backfill).toContain("WHEN 'CRITICAL' THEN 'CRITICAL'");
+    expect(backfill).toContain("ELSE 'MEDIUM'");
+    expect(backfill).toContain("WHEN 'ACTIVE' THEN 'OPEN'");
+    expect(backfill).toContain("WHEN 'RESOLVED' THEN 'CLOSED'");
+    expect(backfill).toContain("ELSE 'OPEN'");
+  });
+
+  it('contains automated verification gates for non-destructive migration safety', async () => {
+    const { queries } = await runUp();
+    const backfill = queries.find((sql) => sql.includes('WITH inserted AS'));
+
+    expect(backfill).toContain('Risk canonicalization pre-check');
+    expect(backfill).toContain('Risk canonicalization post-check');
+    expect(backfill).toContain('post_risks_count != pre_risks_count');
+    expect(backfill).toContain('migrated_without_workspace_count != 0');
+    expect(backfill).toContain('RAISE EXCEPTION');
+  });
+
+  it('down removes only migrated copies and metadata added by this migration', async () => {
+    const queries: string[] = [];
+    const mockQueryRunner = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+      }),
+    };
+
+    const migration = new AddRiskCanonicalizationMetadata18000000000074();
+    await migration.down(mockQueryRunner as any);
+
+    expect(
+      queries.some(
+        (sql) =>
+          sql.includes('DELETE FROM "work_risks"') &&
+          sql.includes('"legacy_risk_id" IS NOT NULL'),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX IF EXISTS "IDX_work_risks_source"'),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP INDEX IF EXISTS "IDX_work_risks_legacy_risk_id"'),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((sql) =>
+        sql.includes('DROP COLUMN IF EXISTS "legacy_risk_id"'),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((sql) => sql.includes('DROP COLUMN IF EXISTS "source"')),
+    ).toBe(true);
+    expect(queries.join('\n')).not.toMatch(/DROP\s+TABLE\s+"risks"/i);
+    expect(queries.join('\n')).not.toMatch(/DELETE\s+FROM\s+"risks"/i);
+  });
+});

--- a/zephix-backend/src/modules/work-management/entities/work-risk.entity.spec.ts
+++ b/zephix-backend/src/modules/work-management/entities/work-risk.entity.spec.ts
@@ -1,0 +1,55 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { WorkRisk } from './work-risk.entity';
+
+describe('WorkRisk canonicalization metadata', () => {
+  const columns = getMetadataArgsStorage().columns.filter(
+    (column) => column.target === WorkRisk,
+  );
+
+  function findColumn(propertyName: keyof WorkRisk & string) {
+    return columns.find((column) => column.propertyName === propertyName);
+  }
+
+  it('maps legacy traceability metadata to snake_case database columns', () => {
+    expect(findColumn('source')?.options).toMatchObject({
+      type: 'varchar',
+      length: 50,
+      nullable: true,
+    });
+    expect(findColumn('riskType')?.options).toMatchObject({
+      name: 'risk_type',
+      type: 'varchar',
+      length: 50,
+      nullable: true,
+    });
+    expect(findColumn('evidence')?.options).toMatchObject({
+      type: 'jsonb',
+      nullable: true,
+    });
+    expect(findColumn('detectedAt')?.options).toMatchObject({
+      name: 'detected_at',
+      type: 'timestamp with time zone',
+      nullable: true,
+    });
+    expect(findColumn('legacyRiskId')?.options).toMatchObject({
+      name: 'legacy_risk_id',
+      type: 'uuid',
+      nullable: true,
+    });
+  });
+
+  it('preserves existing workspace and organization scoping columns', () => {
+    expect(findColumn('organizationId')?.options).toMatchObject({
+      name: 'organization_id',
+      type: 'uuid',
+    });
+    expect(findColumn('workspaceId')?.options).toMatchObject({
+      name: 'workspace_id',
+      type: 'uuid',
+    });
+    expect(findColumn('projectId')?.options).toMatchObject({
+      name: 'project_id',
+      type: 'uuid',
+    });
+  });
+});

--- a/zephix-backend/src/modules/work-management/entities/work-risk.entity.ts
+++ b/zephix-backend/src/modules/work-management/entities/work-risk.entity.ts
@@ -91,6 +91,25 @@ export class WorkRisk {
   @Column({ type: 'uuid', name: 'created_by', nullable: true })
   createdBy: string | null;
 
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  source: string | null;
+
+  @Column({ type: 'varchar', length: 50, name: 'risk_type', nullable: true })
+  riskType: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  evidence: Record<string, unknown> | null;
+
+  @Column({
+    type: 'timestamp with time zone',
+    name: 'detected_at',
+    nullable: true,
+  })
+  detectedAt: Date | null;
+
+  @Column({ type: 'uuid', name: 'legacy_risk_id', nullable: true })
+  legacyRiskId: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add additive migration to prepare `work_risks` as the canonical risk table.
- Add traceability metadata columns: `source`, `risk_type`, `evidence`, `detected_at`, `legacy_risk_id`.
- Backfill legacy `risks` rows only when project and workspace mappings are safe, while preserving the legacy `risks` table untouched.
- Extend `WorkRisk` entity metadata and add focused migration/entity tests.
- Use the repository's global TypeORM migration transaction mode (`all`); the migration does not override transaction mode.
- Avoid referencing the newly-added `CLOSED` enum value during fresh-database all-migrations runs; closed/resolved legacy rows map to `ACCEPTED` for this foundation backfill.

## Pre-Migration Data Assessment
User-provided staging counts before implementation:
- `risks`: 0 rows
- `work_risks`: 24 rows
- orphan `risks` rows: 0
- `risks` rows on projects with no workspace: 0
- severity/status/type/source distributions: empty because `risks` has 0 rows

## Verification
- `npm test -- 18000000000074-AddRiskCanonicalizationMetadata.spec.ts work-risk.entity.spec.ts --runInBand` — passed, 2 suites / 9 tests
- `npm run build:migrations` — passed
- `npm run build` — passed
- `npx eslint src/migrations/18000000000074-AddRiskCanonicalizationMetadata.ts --no-warn-ignored` — passed before follow-up SQL adjustments; final source compiles via build/build:migrations

## CI Follow-Up
- Initial PR CI exposed that per-migration `transaction = true` is forbidden when global TypeORM transaction mode is `all`.
- Follow-up CI exposed PostgreSQL's unsafe enum-value rule for `CLOSED` when all migrations run in one transaction.
- Both issues have targeted fixes and regression assertions in migration tests.

## Known Existing Gate Issue
- `npm run typecheck:tests -- --pretty false` fails on existing repository test debt outside this PR (BRD, AI document parser, work-items/e2e test typing, etc.). No failures were in the new PR 2A files.

## Out of Scope
- No risk readers switched.
- No risk writers switched.
- No legacy `risks` rows deleted.
- No PM risk module changes.
- No frontend orphan `/risks` hook cleanup.

## Future PRs
- PR 2B: switch RiskDetectionService/template presets to write `work_risks`.
- PR 2C: switch portfolio/program rollups, dashboard cards, signals, and knowledge index to read `work_risks`.
- PR 2D: deprecate legacy Risk model after staging proof.
- Separate investigation: PM `Risk` schema drift.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

