### PR TITLE
fix(risks): switch system writers to canonical work risks

### DIFF
--- a/zephix-backend/src/modules/risks/risk-detection.service.spec.ts
+++ b/zephix-backend/src/modules/risks/risk-detection.service.spec.ts
@@ -1,0 +1,197 @@
+import { RiskDetectionService } from './risk-detection.service';
+import { RiskSeverity } from '../work-management/entities/work-risk.entity';
+
+const activeProject = {
+  id: 'project-1',
+  organizationId: 'org-1',
+  workspaceId: 'workspace-1',
+};
+
+function makeQb(result: unknown[]) {
+  return {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(result),
+  };
+}
+
+describe('RiskDetectionService canonical WorkRisk writer', () => {
+  let service: RiskDetectionService;
+  let allocationRepo: { qb: jest.Mock };
+  let taskRepo: { find: jest.Mock };
+  let workRisksService: { upsertSystemRisk: jest.Mock };
+  let loggerWarn: jest.SpyInstance;
+  let loggerError: jest.SpyInstance;
+
+  beforeEach(() => {
+    allocationRepo = { qb: jest.fn() };
+    taskRepo = { find: jest.fn().mockResolvedValue([]) };
+    workRisksService = {
+      upsertSystemRisk: jest.fn().mockResolvedValue({
+        action: 'created',
+        risk: { id: 'risk-1' },
+      }),
+    };
+
+    service = new RiskDetectionService(
+      {} as any,
+      taskRepo as any,
+      allocationRepo as any,
+      { runJobWithTenant: jest.fn() } as any,
+      { getRepository: jest.fn() } as any,
+      workRisksService as any,
+    );
+
+    loggerWarn = jest
+      .spyOn((service as any).logger, 'warn')
+      .mockImplementation();
+    loggerError = jest
+      .spyOn((service as any).logger, 'error')
+      .mockImplementation();
+    jest.spyOn((service as any).logger, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes resource overallocation detections to work_risks', async () => {
+    allocationRepo.qb.mockReturnValue(
+      makeQb([
+        {
+          allocationPercentage: 125,
+          resource: { id: 'resource-1', name: 'Alex' },
+        },
+      ]),
+    );
+
+    const count = await service.scanProjectRisks(activeProject as any);
+
+    expect(count).toBe(1);
+    expect(workRisksService.upsertSystemRisk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: 'org-1',
+        workspaceId: 'workspace-1',
+        projectId: 'project-1',
+        source: 'cron_detection',
+        riskType: 'resource_overallocation',
+        severity: RiskSeverity.HIGH,
+        evidence: expect.objectContaining({
+          type: 'resource_overallocation',
+        }),
+      }),
+    );
+  });
+
+  it('writes timeline slippage detections to work_risks', async () => {
+    allocationRepo.qb.mockReturnValue(makeQb([]));
+    const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    taskRepo.find.mockResolvedValue([
+      {
+        id: 'task-1',
+        title: 'Late task',
+        dueDate: oldDate,
+        status: 'in_progress',
+        progressPercentage: 20,
+      },
+    ]);
+
+    const count = await service.scanProjectRisks(activeProject as any);
+
+    expect(count).toBe(1);
+    expect(workRisksService.upsertSystemRisk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        riskType: 'timeline_slippage',
+        severity: RiskSeverity.MEDIUM,
+      }),
+    );
+  });
+
+  it('writes dependency cascade detections to work_risks', async () => {
+    allocationRepo.qb.mockReturnValue(makeQb([]));
+    taskRepo.find.mockResolvedValue([
+      { id: 'blocker-1', title: 'Blocker 1', status: 'in_progress' },
+      { id: 'blocker-2', title: 'Blocker 2', status: 'in_progress' },
+      { id: 'blocker-3', title: 'Blocker 3', status: 'in_progress' },
+      {
+        id: 'task-1',
+        title: 'Blocked 1',
+        status: 'todo',
+        dependencies: ['blocker-1'],
+      },
+      {
+        id: 'task-2',
+        title: 'Blocked 2',
+        status: 'todo',
+        dependencies: ['blocker-2'],
+      },
+      {
+        id: 'task-3',
+        title: 'Blocked 3',
+        status: 'todo',
+        dependencies: ['blocker-3'],
+      },
+      {
+        id: 'task-4',
+        title: 'Blocked 4',
+        status: 'todo',
+        dependencies: ['blocker-1'],
+      },
+    ]);
+
+    const count = await service.scanProjectRisks(activeProject as any);
+
+    expect(count).toBe(1);
+    expect(workRisksService.upsertSystemRisk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        riskType: 'dependency_cascade',
+        severity: RiskSeverity.HIGH,
+      }),
+    );
+  });
+
+  it('skips projects without workspace context', async () => {
+    const count = await service.scanProjectRisks({
+      id: 'project-1',
+      organizationId: 'org-1',
+      workspaceId: null,
+    } as any);
+
+    expect(count).toBe(0);
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'risk_detection.skip_project_without_workspace',
+      }),
+    );
+    expect(workRisksService.upsertSystemRisk).not.toHaveBeenCalled();
+  });
+
+  it('logs failed risk creation and continues scanning other detections', async () => {
+    allocationRepo.qb.mockReturnValue(
+      makeQb([{ allocationPercentage: 130, resource: { name: 'Alex' } }]),
+    );
+    const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    taskRepo.find.mockResolvedValue([
+      {
+        id: 'task-1',
+        title: 'Late task',
+        dueDate: oldDate,
+        status: 'in_progress',
+      },
+    ]);
+    workRisksService.upsertSystemRisk
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce({ action: 'created', risk: { id: 'risk-2' } });
+
+    const count = await service.scanProjectRisks(activeProject as any);
+
+    expect(count).toBe(2);
+    expect(workRisksService.upsertSystemRisk).toHaveBeenCalledTimes(2);
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'risk_detection.upsert_failed',
+        riskType: 'resource_overallocation',
+      }),
+    );
+  });
+});

--- a/zephix-backend/src/modules/risks/risk-detection.service.ts
+++ b/zephix-backend/src/modules/risks/risk-detection.service.ts
@@ -1,6 +1,5 @@
-import { Injectable, Inject } from '@nestjs/common';
-import { Risk } from './entities/risk.entity';
-import { Project } from '../projects/entities/project.entity';
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Project, ProjectStatus } from '../projects/entities/project.entity';
 import { Task } from '../tasks/entities/task.entity';
 import { ResourceAllocation } from '../resources/entities/resource-allocation.entity';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -9,18 +8,25 @@ import { getTenantAwareRepositoryToken } from '../tenancy/tenant-aware.repositor
 import { TenantContextService } from '../tenancy/tenant-context.service';
 import { DataSource } from 'typeorm';
 import { Organization } from '../../organizations/entities/organization.entity';
+import { WorkRisksService } from '../work-management/services/work-risks.service';
+import { RiskSeverity } from '../work-management/entities/work-risk.entity';
 
-interface RiskEvidence {
+interface RiskEvidence extends Record<string, unknown> {
   type: string;
   description: string;
-  data: any;
+  data: unknown;
+}
+
+interface BlockedTask {
+  task: Task;
+  blockedBy: Task[];
 }
 
 @Injectable()
 export class RiskDetectionService {
+  private readonly logger = new Logger(RiskDetectionService.name);
+
   constructor(
-    @Inject(getTenantAwareRepositoryToken(Risk))
-    private riskRepository: TenantAwareRepository<Risk>,
     @Inject(getTenantAwareRepositoryToken(Project))
     private projectRepository: TenantAwareRepository<Project>,
     @Inject(getTenantAwareRepositoryToken(Task))
@@ -29,6 +35,7 @@ export class RiskDetectionService {
     private allocationRepository: TenantAwareRepository<ResourceAllocation>,
     private readonly tenantContextService: TenantContextService,
     private readonly dataSource: DataSource,
+    private readonly workRisksService: WorkRisksService,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
@@ -37,12 +44,12 @@ export class RiskDetectionService {
     if (process.env.NODE_ENV === 'test') {
       return;
     }
-    console.log('🔍 Running daily risk scan...');
+    this.logger.log('Running daily risk scan');
 
     // Get all organizations using DataSource (infra-level access is allowed)
     const orgRepo = this.dataSource.getRepository(Organization);
     const organizations = await orgRepo.find({
-      where: { status: 'active' as any },
+      where: { status: 'active' },
       select: ['id'],
     });
 
@@ -54,61 +61,60 @@ export class RiskDetectionService {
           // Get active projects for this organization
           // TenantAwareRepository automatically scopes by organizationId
           const projects = await this.projectRepository.find({
-            where: { status: 'active' as any },
+            where: { status: ProjectStatus.ACTIVE },
           });
 
-          console.log(
-            `  Processing ${projects.length} projects for org ${org.id}`,
+          this.logger.log(
+            `Processing ${projects.length} projects for org ${org.id}`,
           );
 
           for (const project of projects) {
-            await this.scanProjectRisks(project.id, org.id);
+            await this.scanProjectRisks(project);
           }
         },
       );
     }
 
-    console.log('✅ Daily risk scan completed');
+    this.logger.log('Daily risk scan completed');
   }
 
-  async scanProjectRisks(
-    projectId: string,
-    organizationId: string,
-  ): Promise<Risk[]> {
-    const risks: Risk[] = [];
+  async scanProjectRisks(project: Project): Promise<number> {
+    if (!project.workspaceId) {
+      this.logger.warn({
+        action: 'risk_detection.skip_project_without_workspace',
+        organizationId: project.organizationId,
+        projectId: project.id,
+      });
+      return 0;
+    }
+
+    let changedCount = 0;
 
     // Rule 1: Resource Overallocation
-    const overallocationRisk = await this.checkResourceOverallocation(
-      projectId,
-      organizationId,
-    );
-    if (overallocationRisk) risks.push(overallocationRisk);
+    if (await this.checkResourceOverallocation(project)) {
+      changedCount++;
+    }
 
     // Rule 2: Timeline Slippage
-    const timelineRisk = await this.checkTimelineSlippage(
-      projectId,
-      organizationId,
-    );
-    if (timelineRisk) risks.push(timelineRisk);
+    if (await this.checkTimelineSlippage(project)) {
+      changedCount++;
+    }
 
     // Rule 3: Cascade Risk
-    const cascadeRisk = await this.checkCascadeRisk(projectId, organizationId);
-    if (cascadeRisk) risks.push(cascadeRisk);
+    if (await this.checkCascadeRisk(project)) {
+      changedCount++;
+    }
 
-    return risks;
+    return changedCount;
   }
 
   private async checkResourceOverallocation(
-    projectId: string,
-    organizationId: string,
-  ): Promise<Risk | null> {
-    // organizationId parameter kept for backward compatibility
-    // Use tenant-aware query builder - organizationId filter is automatic
+    project: Project,
+  ): Promise<boolean> {
     const allocations = await this.allocationRepository
       .qb('allocation')
-      .leftJoinAndSelect('allocation.task', 'task')
       .leftJoinAndSelect('allocation.resource', 'resource')
-      .andWhere('task.projectId = :projectId', { projectId })
+      .andWhere('allocation.projectId = :projectId', { projectId: project.id })
       .getMany();
 
     const overallocated = allocations.filter(
@@ -126,41 +132,31 @@ export class RiskDetectionService {
         })),
       };
 
-      const risk = this.riskRepository.create({
-        projectId,
-        organizationId,
-        type: 'resource_overallocation',
-        severity: overallocated.some((a) => a.allocationPercentage > 120)
-          ? 'high'
-          : 'medium',
+      const maxAllocation = Math.max(
+        ...overallocated.map((alloc) => alloc.allocationPercentage || 0),
+      );
+
+      await this.upsertDetectedRisk({
+        project,
+        riskType: 'resource_overallocation',
         title: 'Resource Overallocation Detected',
-        description: `Multiple team members are allocated beyond capacity`,
-        evidence: JSON.stringify(evidence),
-        status: 'open',
-        detectedAt: new Date(),
-        mitigation: {
-          suggestions: [
-            'Reassign tasks to available resources',
-            'Extend project timeline',
-            'Hire additional resources',
-          ],
-        },
+        description: 'Multiple team members are allocated beyond capacity',
+        severity: maxAllocation > 120 ? RiskSeverity.HIGH : RiskSeverity.MEDIUM,
+        evidence,
+        mitigationPlan:
+          'Reassign tasks to available resources; extend project timeline; or add capacity.',
       });
 
-      return await this.riskRepository.save(risk);
+      return true;
     }
 
-    return null;
+    return false;
   }
 
-  private async checkTimelineSlippage(
-    projectId: string,
-    organizationId: string,
-  ): Promise<Risk | null> {
-    // organizationId parameter kept for backward compatibility
+  private async checkTimelineSlippage(project: Project): Promise<boolean> {
     // Note: Task entity may need TenantAwareRepository if it has organizationId
     const tasks = await this.taskRepository.find({
-      where: { projectId },
+      where: { projectId: project.id },
     });
 
     const delayedTasks = tasks.filter((task) => {
@@ -170,7 +166,9 @@ export class RiskDetectionService {
       const daysLate = Math.floor(
         (now.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24),
       );
-      return daysLate > 3 && task.status !== 'done';
+      return (
+        daysLate > 3 && task.status !== 'completed' && task.status !== 'done'
+      );
     });
 
     if (delayedTasks.length > 0) {
@@ -185,47 +183,40 @@ export class RiskDetectionService {
         })),
       };
 
-      const risk = this.riskRepository.create({
-        projectId,
-        organizationId,
-        type: 'timeline_slippage',
-        severity: delayedTasks.length > 5 ? 'high' : 'medium',
+      await this.upsertDetectedRisk({
+        project,
+        riskType: 'timeline_slippage',
         title: 'Project Timeline at Risk',
-        description: `Critical tasks are behind schedule`,
-        evidence: JSON.stringify(evidence),
-        status: 'open',
-        detectedAt: new Date(),
-        mitigation: {
-          suggestions: [
-            'Prioritize critical path tasks',
-            'Add resources to delayed tasks',
-            'Adjust project timeline',
-          ],
-        },
+        description: 'Critical tasks are behind schedule',
+        severity:
+          delayedTasks.length > 5 ? RiskSeverity.HIGH : RiskSeverity.MEDIUM,
+        evidence,
+        mitigationPlan:
+          'Prioritize critical path tasks; add resources to delayed work; or adjust the timeline.',
       });
 
-      return await this.riskRepository.save(risk);
+      return true;
     }
 
-    return null;
+    return false;
   }
 
-  private async checkCascadeRisk(
-    projectId: string,
-    organizationId: string,
-  ): Promise<Risk | null> {
-    // organizationId parameter kept for backward compatibility
+  private async checkCascadeRisk(project: Project): Promise<boolean> {
     // Note: Task entity may need TenantAwareRepository if it has organizationId
     const tasks = await this.taskRepository.find({
-      where: { projectId },
+      where: { projectId: project.id },
     });
 
     // Check for dependency chains
-    const blockedTasks = [];
+    const blockedTasks: BlockedTask[] = [];
     for (const task of tasks) {
-      if (task.dependencies && task.dependencies.length > 0) {
+      const dependencyIds = this.getDependencyIds(task);
+      if (dependencyIds.length > 0) {
         const blockingTasks = tasks.filter(
-          (t) => task.dependencies.includes(t.id) && t.status !== 'done',
+          (t) =>
+            dependencyIds.includes(t.id) &&
+            t.status !== 'completed' &&
+            t.status !== 'done',
         );
 
         if (blockingTasks.length > 0) {
@@ -247,28 +238,76 @@ export class RiskDetectionService {
         })),
       };
 
-      const risk = this.riskRepository.create({
-        projectId,
-        organizationId,
-        type: 'dependency_cascade',
-        severity: 'high',
+      await this.upsertDetectedRisk({
+        project,
+        riskType: 'dependency_cascade',
         title: 'Dependency Chain Risk',
-        description: `Multiple tasks blocked creating cascade effect`,
-        evidence: JSON.stringify(evidence),
-        status: 'open',
-        detectedAt: new Date(),
-        mitigation: {
-          suggestions: [
-            'Prioritize blocking tasks',
-            'Review and adjust dependencies',
-            'Consider parallel execution where possible',
-          ],
-        },
+        description: 'Multiple tasks blocked creating cascade effect',
+        severity: RiskSeverity.HIGH,
+        evidence,
+        mitigationPlan:
+          'Prioritize blocking tasks; review dependencies; or split work for parallel execution.',
       });
 
-      return await this.riskRepository.save(risk);
+      return true;
     }
 
-    return null;
+    return false;
+  }
+
+  private async upsertDetectedRisk(input: {
+    project: Project;
+    riskType: string;
+    title: string;
+    description: string;
+    severity: RiskSeverity;
+    evidence: RiskEvidence;
+    mitigationPlan: string;
+  }): Promise<void> {
+    try {
+      const result = await this.workRisksService.upsertSystemRisk({
+        organizationId: input.project.organizationId,
+        workspaceId: input.project.workspaceId,
+        projectId: input.project.id,
+        title: input.title,
+        description: input.description,
+        severity: input.severity,
+        source: 'cron_detection',
+        riskType: input.riskType,
+        evidence: input.evidence,
+        detectedAt: new Date(),
+        mitigationPlan: input.mitigationPlan,
+      });
+
+      this.logger.log({
+        action: 'risk_detection.upserted_work_risk',
+        organizationId: input.project.organizationId,
+        workspaceId: input.project.workspaceId,
+        projectId: input.project.id,
+        riskType: input.riskType,
+        result: result.action,
+        riskId: result.risk.id,
+      });
+    } catch (error) {
+      this.logger.error({
+        action: 'risk_detection.upsert_failed',
+        organizationId: input.project.organizationId,
+        workspaceId: input.project.workspaceId,
+        projectId: input.project.id,
+        riskType: input.riskType,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private getDependencyIds(task: Task): string[] {
+    const dependencies = task.dependencies;
+    if (!Array.isArray(dependencies)) {
+      return [];
+    }
+
+    return dependencies.filter(
+      (id): id is string => typeof id === 'string' && id.length > 0,
+    );
   }
 }

--- a/zephix-backend/src/modules/risks/risks.module.ts
+++ b/zephix-backend/src/modules/risks/risks.module.ts
@@ -5,6 +5,7 @@ import { RiskDetectionService } from './risk-detection.service';
 import { Project } from '../projects/entities/project.entity';
 import { ResourceAllocation } from '../resources/entities/resource-allocation.entity';
 import { Task } from '../tasks/entities/task.entity';
+import { WorkManagementModule } from '../work-management/work-management.module';
 import {
   TenancyModule,
   createTenantAwareRepositoryProvider,
@@ -14,6 +15,7 @@ import {
   imports: [
     TypeOrmModule.forFeature([Risk, Project, ResourceAllocation, Task]),
     TenancyModule, // Required for TenantAwareRepository
+    WorkManagementModule,
   ],
   providers: [
     // Provide TenantAwareRepository for tenant-scoped entities

--- a/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.spec.ts
+++ b/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.spec.ts
@@ -1,0 +1,187 @@
+import { TemplatesInstantiateV51Service } from './templates-instantiate-v51.service';
+import { ProjectState } from '../../projects/entities/project.entity';
+
+describe('TemplatesInstantiateV51Service risk presets', () => {
+  const template = {
+    id: 'tpl-1',
+    templateScope: 'SYSTEM',
+    organizationId: null,
+    workspaceId: null,
+    methodology: 'waterfall',
+    defaultEnabledKPIs: [],
+    defaultGovernanceFlags: {},
+    metadata: null,
+    version: 1,
+    phases: [
+      {
+        name: 'Plan',
+        order: 0,
+        estimatedDurationDays: 5,
+      },
+    ],
+    taskTemplates: [],
+    riskPresets: [
+      {
+        id: 'risk-preset-1',
+        title: 'Compliance risk',
+        description: 'Controls may not pass review',
+        category: 'compliance',
+        severity: 'critical',
+        tags: ['audit'],
+      },
+    ],
+  };
+
+  function createManager(overrides: Partial<Record<string, any>> = {}) {
+    const project = {
+      id: 'project-1',
+      name: 'New Project',
+      organizationId: 'org-1',
+      workspaceId: 'ws-1',
+      state: ProjectState.DRAFT,
+      structureLocked: false,
+      templateId: null,
+      activeKpiIds: [],
+    };
+    const projectRepo = {
+      create: jest.fn((data) => ({ ...project, ...data })),
+      save: jest.fn(async (entity) => ({ ...project, ...entity })),
+      findOne: jest.fn(),
+    };
+    const templateRepo = {
+      findOne: jest.fn().mockResolvedValue(overrides.template ?? template),
+    };
+    const workspaceRepo = {
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'ws-1', organizationId: 'org-1' }),
+    };
+    const phaseRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      find: jest.fn().mockResolvedValue([]),
+      create: jest.fn((data) => ({ id: `phase-${data.sortOrder}`, ...data })),
+      save: jest.fn(async (entity) => entity),
+    };
+    const taskRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      create: jest.fn((data) => ({ id: `task-${data.rank}`, ...data })),
+      save: jest.fn(async (entity) => entity),
+    };
+
+    const manager = {
+      getRepository: jest.fn((entity) => {
+        const name = entity?.name;
+        if (name === 'Template') return templateRepo;
+        if (name === 'Project') return projectRepo;
+        if (name === 'Workspace') return workspaceRepo;
+        if (name === 'WorkPhase') return phaseRepo;
+        if (name === 'WorkTask') return taskRepo;
+        return {};
+      }),
+      query: jest.fn().mockResolvedValue([]),
+    };
+
+    return { manager, projectRepo, templateRepo, phaseRepo, taskRepo };
+  }
+
+  function createService(overrides: { createSystemRisk?: jest.Mock } = {}) {
+    const workRisksService = {
+      createSystemRisk:
+        overrides.createSystemRisk ??
+        jest.fn().mockResolvedValue({ id: 'risk-1' }),
+    };
+    const managerBundle = createManager();
+    const dataSource = {
+      transaction: jest.fn(async (callback) => callback(managerBundle.manager)),
+    };
+    const service = new TemplatesInstantiateV51Service(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      dataSource as any,
+      { canAccessWorkspace: jest.fn().mockResolvedValue(true) } as any,
+      {} as any,
+      { invalidateCache: jest.fn() } as any,
+      {
+        snapshotTemplateGovernanceToProject: jest
+          .fn()
+          .mockResolvedValue(undefined),
+      } as any,
+      workRisksService as any,
+    );
+
+    return { service, workRisksService, dataSource, managerBundle };
+  }
+
+  it('creates canonical work risks for template risk presets in the transaction', async () => {
+    const { service, workRisksService, managerBundle } = createService();
+
+    await service.instantiateV51(
+      'tpl-1',
+      { projectName: 'New Project' },
+      'ws-1',
+      'org-1',
+      'user-1',
+      'ADMIN',
+    );
+
+    expect(workRisksService.createSystemRisk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: 'org-1',
+        workspaceId: 'ws-1',
+        projectId: 'project-1',
+        source: 'template_preset',
+        riskType: 'compliance',
+        title: 'Compliance risk',
+        severity: 'CRITICAL',
+        evidence: expect.objectContaining({
+          presetId: 'risk-preset-1',
+          templateId: 'tpl-1',
+          tags: ['audit'],
+        }),
+      }),
+      managerBundle.manager,
+    );
+  });
+
+  it('skips malformed risk presets and still completes instantiation', async () => {
+    const { service, workRisksService, managerBundle } = createService();
+    managerBundle.templateRepo.findOne.mockResolvedValue({
+      ...template,
+      riskPresets: [{ id: 'bad-preset', severity: 'high' }],
+    });
+
+    const result = await service.instantiateV51(
+      'tpl-1',
+      { projectName: 'New Project' },
+      'ws-1',
+      'org-1',
+      'user-1',
+      'ADMIN',
+    );
+
+    expect(result.projectId).toBe('project-1');
+    expect(workRisksService.createSystemRisk).not.toHaveBeenCalled();
+  });
+
+  it('logs and continues when a risk preset create fails', async () => {
+    const createSystemRisk = jest
+      .fn()
+      .mockRejectedValue(new Error('risk failed'));
+    const { service } = createService({ createSystemRisk });
+
+    const result = await service.instantiateV51(
+      'tpl-1',
+      { projectName: 'New Project' },
+      'ws-1',
+      'org-1',
+      'user-1',
+      'ADMIN',
+    );
+
+    expect(result.projectId).toBe('project-1');
+    expect(createSystemRisk).toHaveBeenCalled();
+  });
+});

--- a/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
+++ b/zephix-backend/src/modules/templates/services/templates-instantiate-v51.service.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, EntityManager } from 'typeorm';
 import { Template } from '../entities/template.entity';
 import { Project, ProjectState } from '../../projects/entities/project.entity';
 import { WorkPhase } from '../../work-management/entities/work-phase.entity';
@@ -15,10 +15,7 @@ import { WorkTask } from '../../work-management/entities/work-task.entity';
 import { Workspace } from '../../workspaces/entities/workspace.entity';
 import { WorkspaceAccessService } from '../../workspace-access/workspace-access.service';
 import { ProjectStructureGuardService } from '../../work-management/services/project-structure-guard.service';
-import {
-  TaskStatus,
-  TaskType,
-} from '../../work-management/enums/task.enums';
+import { TaskStatus, TaskType } from '../../work-management/enums/task.enums';
 import { InstantiateV51Dto } from '../dto/instantiate-v5-1.dto';
 import {
   TemplateOriginMetadata,
@@ -28,6 +25,8 @@ import { normalizeTemplateStructure } from './template-structure-normalizer';
 import { normalizeTemplateTaskPriorityOrDefault } from './template-task-priority-normalizer';
 import { GovernanceRuleResolverService } from '../../governance-rules/services/governance-rule-resolver.service';
 import { GovernanceTemplateService } from '../../governance-rules/services/governance-template.service';
+import { WorkRisksService } from '../../work-management/services/work-risks.service';
+import { RiskSeverity } from '../../work-management/entities/work-risk.entity';
 
 /**
  * Sprint 2.5: Phase 5.1 compliant template instantiation
@@ -53,6 +52,7 @@ export class TemplatesInstantiateV51Service {
     private readonly structureGuard: ProjectStructureGuardService,
     private readonly governanceRuleResolver: GovernanceRuleResolverService,
     private readonly governanceTemplateService: GovernanceTemplateService,
+    private readonly workRisksService: WorkRisksService,
   ) {}
 
   /**
@@ -232,9 +232,9 @@ export class TemplatesInstantiateV51Service {
           origin?.activeKpiIds && origin.activeKpiIds.length > 0
             ? [...origin.activeKpiIds]
             : template.defaultEnabledKPIs &&
-              template.defaultEnabledKPIs.length > 0
-            ? [...template.defaultEnabledKPIs]
-            : [];
+                template.defaultEnabledKPIs.length > 0
+              ? [...template.defaultEnabledKPIs]
+              : [];
 
         const govFlags = template.defaultGovernanceFlags || {};
         project = projectRepo.create({
@@ -523,19 +523,26 @@ export class TemplatesInstantiateV51Service {
       };
 
       const govFlagsExisting = template.defaultGovernanceFlags || {};
-      if (dto.projectId && govFlagsExisting && typeof govFlagsExisting === 'object') {
+      if (
+        dto.projectId &&
+        govFlagsExisting &&
+        typeof govFlagsExisting === 'object'
+      ) {
         const g = govFlagsExisting as Record<string, boolean>;
         if (g.iterationsEnabled !== undefined)
           project.iterationsEnabled = g.iterationsEnabled;
         if (g.costTrackingEnabled !== undefined)
           project.costTrackingEnabled = g.costTrackingEnabled;
-        if (g.baselinesEnabled !== undefined) project.baselinesEnabled = g.baselinesEnabled;
+        if (g.baselinesEnabled !== undefined)
+          project.baselinesEnabled = g.baselinesEnabled;
         if (g.earnedValueEnabled !== undefined)
           project.earnedValueEnabled = g.earnedValueEnabled;
-        if (g.capacityEnabled !== undefined) project.capacityEnabled = g.capacityEnabled;
+        if (g.capacityEnabled !== undefined)
+          project.capacityEnabled = g.capacityEnabled;
         if (g.changeManagementEnabled !== undefined)
           project.changeManagementEnabled = g.changeManagementEnabled;
-        if (g.waterfallEnabled !== undefined) project.waterfallEnabled = g.waterfallEnabled;
+        if (g.waterfallEnabled !== undefined)
+          project.waterfallEnabled = g.waterfallEnabled;
         project.governanceSource = 'TEMPLATE';
       }
 
@@ -546,6 +553,15 @@ export class TemplatesInstantiateV51Service {
       );
 
       await projectRepo.save(project);
+
+      await this.createRiskPresetsForProject(
+        manager,
+        template,
+        project,
+        organizationId,
+        workspaceId,
+        userId,
+      );
 
       return {
         projectId: project.id,
@@ -609,5 +625,97 @@ export class TemplatesInstantiateV51Service {
     }
 
     return reportingKey;
+  }
+
+  private async createRiskPresetsForProject(
+    manager: EntityManager,
+    template: Template,
+    project: Project,
+    organizationId: string,
+    workspaceId: string,
+    userId: string,
+  ): Promise<void> {
+    const riskPresets = Array.isArray(template.riskPresets)
+      ? template.riskPresets
+      : [];
+    if (riskPresets.length === 0) {
+      return;
+    }
+
+    let createdCount = 0;
+    for (const preset of riskPresets) {
+      if (!preset?.title || !preset?.severity) {
+        this.logger.warn({
+          action: 'template_risk_preset_skipped_malformed',
+          templateId: template.id,
+          projectId: project.id,
+          presetId: preset?.id,
+        });
+        continue;
+      }
+
+      try {
+        await this.workRisksService.createSystemRisk(
+          {
+            organizationId,
+            workspaceId,
+            projectId: project.id,
+            title: preset.title,
+            description: preset.description || null,
+            severity: this.mapPresetSeverity(preset.severity),
+            source: 'template_preset',
+            riskType: preset.category || 'general',
+            probability: 3,
+            impact: 3,
+            evidence: {
+              presetId: preset.id,
+              templateId: template.id,
+              ...(Array.isArray((preset as any).tags)
+                ? { tags: (preset as any).tags }
+                : {}),
+            },
+            detectedAt: new Date(),
+            createdBy: userId,
+          },
+          manager,
+        );
+        createdCount++;
+      } catch (error) {
+        this.logger.warn({
+          action: 'template_risk_preset_create_failed',
+          templateId: template.id,
+          projectId: project.id,
+          presetId: preset.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (createdCount > 0) {
+      this.logger.log({
+        action: 'template_risk_presets_created',
+        templateId: template.id,
+        projectId: project.id,
+        organizationId,
+        workspaceId,
+        count: createdCount,
+      });
+    }
+  }
+
+  private mapPresetSeverity(
+    severity: Template['riskPresets'][number]['severity'],
+  ): RiskSeverity {
+    switch (String(severity).toLowerCase()) {
+      case 'low':
+        return RiskSeverity.LOW;
+      case 'high':
+        return RiskSeverity.HIGH;
+      case 'critical':
+        return RiskSeverity.CRITICAL;
+      case 'medium':
+      default:
+        return RiskSeverity.MEDIUM;
+    }
   }
 }

--- a/zephix-backend/src/modules/work-management/services/work-risks.service.spec.ts
+++ b/zephix-backend/src/modules/work-management/services/work-risks.service.spec.ts
@@ -1,0 +1,256 @@
+import { NotFoundException } from '@nestjs/common';
+import { WorkRisksService } from './work-risks.service';
+import {
+  RiskSeverity,
+  RiskStatus,
+  WorkRisk,
+} from '../entities/work-risk.entity';
+import { DOMAIN_EVENTS } from '../../kpi-queue/constants/queue.constants';
+import { AuditAction, AuditEntityType } from '../../audit/audit.constants';
+
+describe('WorkRisksService system writer', () => {
+  const baseInput = {
+    organizationId: '11111111-1111-1111-1111-111111111111',
+    workspaceId: '22222222-2222-2222-2222-222222222222',
+    projectId: '33333333-3333-3333-3333-333333333333',
+    title: 'Detected schedule risk',
+    description: 'Schedule is slipping',
+    severity: RiskSeverity.HIGH,
+    source: 'cron_detection',
+    riskType: 'timeline_slippage',
+    evidence: { delayedTasks: 3 },
+    detectedAt: new Date('2026-04-28T00:00:00.000Z'),
+  };
+
+  function makeQb(result: WorkRisk | null = null) {
+    return {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(result),
+    };
+  }
+
+  function makeService(options: { existingRisk?: WorkRisk | null } = {}) {
+    const qb = makeQb(options.existingRisk ?? null);
+    const saved: WorkRisk[] = [];
+    const riskRepository = {
+      create: jest.fn((risk: Partial<WorkRisk>) => ({
+        id: 'risk-new',
+        ...risk,
+      })),
+      save: jest.fn(async (risk: WorkRisk) => {
+        saved.push(risk);
+        return risk;
+      }),
+      createQueryBuilder: jest.fn(() => qb),
+    };
+    const projectRepository = {
+      findOne: jest.fn().mockResolvedValue({ id: baseInput.projectId }),
+    };
+    const tenantAwareRepo = {
+      getRepository: jest.fn(() => riskRepository),
+      createQueryBuilder: jest.fn(() => qb),
+    };
+    const domainEventEmitter = { emit: jest.fn().mockResolvedValue(undefined) };
+    const auditService = {
+      record: jest.fn().mockResolvedValue({ id: 'audit-1' }),
+    };
+
+    const service = new WorkRisksService(
+      tenantAwareRepo as any,
+      projectRepository as any,
+      {} as any,
+      {} as any,
+      {
+        assertOrganizationId: jest
+          .fn()
+          .mockReturnValue(baseInput.organizationId),
+      } as any,
+      domainEventEmitter as any,
+      auditService as any,
+    );
+
+    return {
+      service,
+      qb,
+      riskRepository,
+      projectRepository,
+      domainEventEmitter,
+      auditService,
+      saved,
+    };
+  }
+
+  it('createSystemRisk validates project tenancy and applies defaults', async () => {
+    const {
+      service,
+      riskRepository,
+      projectRepository,
+      domainEventEmitter,
+      auditService,
+    } = makeService();
+
+    const risk = await service.createSystemRisk({
+      ...baseInput,
+      probability: 9,
+      impact: 0,
+    });
+
+    expect(projectRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: baseInput.projectId,
+        organizationId: baseInput.organizationId,
+        workspaceId: baseInput.workspaceId,
+      },
+      select: ['id'],
+    });
+    expect(riskRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: baseInput.organizationId,
+        workspaceId: baseInput.workspaceId,
+        projectId: baseInput.projectId,
+        status: RiskStatus.OPEN,
+        probability: 5,
+        impact: 1,
+        source: 'cron_detection',
+        riskType: 'timeline_slippage',
+      }),
+    );
+    expect(risk.id).toBe('risk-new');
+    expect(domainEventEmitter.emit).toHaveBeenCalledWith(
+      DOMAIN_EVENTS.RISK_CREATED,
+      expect.objectContaining({
+        workspaceId: baseInput.workspaceId,
+        organizationId: baseInput.organizationId,
+        projectId: baseInput.projectId,
+        entityId: 'risk-new',
+      }),
+    );
+    expect(auditService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: baseInput.organizationId,
+        workspaceId: baseInput.workspaceId,
+        entityType: AuditEntityType.WORK_RISK,
+        action: AuditAction.CREATE,
+      }),
+      undefined,
+    );
+  });
+
+  it('createSystemRisk rejects projects outside organization/workspace scope', async () => {
+    const { service, projectRepository } = makeService();
+    projectRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.createSystemRisk(baseInput)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('createSystemRisk uses a provided transaction manager', async () => {
+    const { service } = makeService();
+    const managerRiskRepo = {
+      create: jest.fn((risk) => ({ id: 'risk-tx', ...risk })),
+      save: jest.fn(async (risk) => risk),
+    };
+    const managerProjectRepo = {
+      findOne: jest.fn().mockResolvedValue({ id: baseInput.projectId }),
+    };
+    const manager = {
+      getRepository: jest.fn((entity) => {
+        if (entity === WorkRisk) return managerRiskRepo;
+        return managerProjectRepo;
+      }),
+      save: jest.fn(async (_entity, value) => value),
+    };
+
+    const risk = await service.createSystemRisk(baseInput, manager as any);
+
+    expect(risk.id).toBe('risk-tx');
+    expect(manager.getRepository).toHaveBeenCalledWith(WorkRisk);
+    expect(managerProjectRepo.findOne).toHaveBeenCalled();
+  });
+
+  it('findExistingSystemRisk returns only OPEN matching system risks', async () => {
+    const existing = {
+      id: 'risk-open',
+      status: RiskStatus.OPEN,
+    } as unknown as WorkRisk;
+    const { service, qb } = makeService({ existingRisk: existing });
+
+    const result = await service.findExistingSystemRisk(baseInput);
+
+    expect(result).toBe(existing);
+    expect(qb.andWhere).toHaveBeenCalledWith('risk.status = :status', {
+      status: RiskStatus.OPEN,
+    });
+  });
+
+  it('upsertSystemRisk creates when no existing risk matches', async () => {
+    const { service } = makeService();
+
+    const result = await service.upsertSystemRisk(baseInput);
+
+    expect(result.action).toBe('created');
+    expect(result.risk.id).toBe('risk-new');
+  });
+
+  it('upsertSystemRisk updates only evidence, detectedAt, and severity for OPEN risk', async () => {
+    const existing = {
+      id: 'risk-open',
+      organizationId: baseInput.organizationId,
+      workspaceId: baseInput.workspaceId,
+      projectId: baseInput.projectId,
+      title: 'Original title',
+      description: 'Human narrative',
+      status: RiskStatus.OPEN,
+      severity: RiskSeverity.MEDIUM,
+      mitigationPlan: 'Human mitigation',
+      source: baseInput.source,
+      riskType: baseInput.riskType,
+      evidence: { old: true },
+      detectedAt: new Date('2026-01-01T00:00:00.000Z'),
+    } as unknown as WorkRisk;
+    const { service, riskRepository } = makeService({ existingRisk: existing });
+
+    const result = await service.upsertSystemRisk({
+      ...baseInput,
+      description: 'New system description',
+      mitigationPlan: 'New system mitigation',
+      status: RiskStatus.CLOSED,
+      evidence: { fresh: true },
+      severity: RiskSeverity.CRITICAL,
+    });
+
+    expect(result.action).toBe('updated');
+    expect(riskRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'risk-open',
+        description: 'Human narrative',
+        mitigationPlan: 'Human mitigation',
+        status: RiskStatus.OPEN,
+        evidence: { fresh: true },
+        severity: RiskSeverity.CRITICAL,
+      }),
+    );
+  });
+
+  it('upsertSystemRisk skips non-OPEN human decisions without creating duplicates', async () => {
+    const openQb = makeQb(null);
+    const accepted = {
+      id: 'risk-accepted',
+      status: RiskStatus.ACCEPTED,
+    } as WorkRisk;
+    const nonOpenQb = makeQb(accepted);
+    const { service, riskRepository } = makeService();
+    riskRepository.createQueryBuilder
+      .mockReturnValueOnce(openQb)
+      .mockReturnValueOnce(nonOpenQb);
+
+    const result = await service.upsertSystemRisk(baseInput);
+
+    expect(result.action).toBe('skipped_non_open');
+    expect(result.risk).toBe(accepted);
+    expect(riskRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/zephix-backend/src/modules/work-management/services/work-risks.service.ts
+++ b/zephix-backend/src/modules/work-management/services/work-risks.service.ts
@@ -17,19 +17,45 @@ import {
   RiskSeverity,
   RiskStatus,
 } from '../entities/work-risk.entity';
-import { CreateWorkRiskDto, UpdateWorkRiskDto, ListWorkRisksQueryDto } from '../dto';
+import {
+  CreateWorkRiskDto,
+  UpdateWorkRiskDto,
+  ListWorkRisksQueryDto,
+} from '../dto';
 import { TenantContextService } from '../../tenancy/tenant-context.service';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, IsNull } from 'typeorm';
+import { EntityManager, Repository, IsNull } from 'typeorm';
 import { Project } from '../../projects/entities/project.entity';
 import { DomainEventEmitterService } from '../../kpi-queue/services/domain-event-emitter.service';
 import { DOMAIN_EVENTS } from '../../kpi-queue/constants/queue.constants';
+import { AuditService } from '../../audit/services/audit.service';
+import { AuditAction, AuditEntityType } from '../../audit/audit.constants';
 
 interface AuthContext {
   organizationId: string;
   userId: string;
   platformRole?: string;
 }
+
+export interface SystemRiskInput {
+  organizationId: string;
+  workspaceId: string;
+  projectId: string;
+  title: string;
+  description?: string | null;
+  severity: RiskSeverity;
+  status?: RiskStatus;
+  probability?: number;
+  impact?: number;
+  mitigationPlan?: string | null;
+  source: string;
+  riskType: string;
+  evidence?: Record<string, unknown> | null;
+  detectedAt?: Date;
+  createdBy?: string | null;
+}
+
+export type SystemRiskUpsertAction = 'created' | 'updated' | 'skipped_non_open';
 
 @Injectable()
 export class WorkRisksService {
@@ -45,6 +71,8 @@ export class WorkRisksService {
     private readonly tenantContext: TenantContextService,
     @Optional()
     private readonly domainEventEmitter?: DomainEventEmitterService,
+    @Optional()
+    private readonly auditService?: AuditService,
   ) {}
 
   // ============================================================
@@ -205,6 +233,108 @@ export class WorkRisksService {
     return saved;
   }
 
+  /**
+   * Trusted system writer for non-HTTP risk producers such as cron detection
+   * and template instantiation. It validates project tenancy explicitly and
+   * can participate in a caller's transaction through EntityManager.
+   */
+  async createSystemRisk(
+    input: SystemRiskInput,
+    manager?: EntityManager,
+  ): Promise<WorkRisk> {
+    const { riskRepository, projectRepository } =
+      this.getSystemRepositories(manager);
+
+    await this.assertSystemProjectScope(input, projectRepository);
+
+    const risk = riskRepository.create({
+      organizationId: input.organizationId,
+      workspaceId: input.workspaceId,
+      projectId: input.projectId,
+      title: input.title.slice(0, 300),
+      description: input.description || null,
+      severity: input.severity || RiskSeverity.MEDIUM,
+      status: input.status || RiskStatus.OPEN,
+      probability: this.clampRiskScale(input.probability),
+      impact: this.clampRiskScale(input.impact),
+      mitigationPlan: input.mitigationPlan || null,
+      ownerUserId: null,
+      dueDate: null,
+      createdBy: input.createdBy || null,
+      source: input.source.slice(0, 50),
+      riskType: input.riskType.slice(0, 50),
+      evidence: input.evidence || null,
+      detectedAt: input.detectedAt || new Date(),
+    });
+
+    const saved = await riskRepository.save(risk);
+    await this.emitRiskDomainEvent(DOMAIN_EVENTS.RISK_CREATED, saved);
+    await this.recordSystemRiskAudit(AuditAction.CREATE, saved, input, manager);
+    return saved;
+  }
+
+  async findExistingSystemRisk(
+    input: {
+      organizationId: string;
+      workspaceId: string;
+      projectId: string;
+      source: string;
+      riskType: string;
+    },
+    manager?: EntityManager,
+  ): Promise<WorkRisk | null> {
+    return this.findSystemRisk(input, manager, RiskStatus.OPEN);
+  }
+
+  async upsertSystemRisk(
+    input: SystemRiskInput,
+    manager?: EntityManager,
+  ): Promise<{ risk: WorkRisk; action: SystemRiskUpsertAction }> {
+    const openRisk = await this.findSystemRisk(input, manager, RiskStatus.OPEN);
+
+    if (openRisk) {
+      const { riskRepository } = this.getSystemRepositories(manager);
+      openRisk.evidence = input.evidence || openRisk.evidence;
+      openRisk.detectedAt = input.detectedAt || new Date();
+      openRisk.severity = input.severity || openRisk.severity;
+
+      const saved = await riskRepository.save(openRisk);
+      await this.emitRiskDomainEvent(DOMAIN_EVENTS.RISK_UPDATED, saved);
+      await this.recordSystemRiskAudit(
+        AuditAction.UPDATE,
+        saved,
+        input,
+        manager,
+      );
+
+      return { risk: saved, action: 'updated' };
+    }
+
+    const nonOpenRisk = await this.findSystemRisk(input, manager);
+    if (nonOpenRisk) {
+      this.logger.log({
+        action: 'risk.redetected.system_skipped_non_open',
+        organizationId: input.organizationId,
+        workspaceId: input.workspaceId,
+        projectId: input.projectId,
+        riskId: nonOpenRisk.id,
+        source: input.source,
+        riskType: input.riskType,
+        status: nonOpenRisk.status,
+      });
+      return { risk: nonOpenRisk, action: 'skipped_non_open' };
+    }
+
+    const risk = await this.createSystemRisk(
+      {
+        ...input,
+        status: input.status || RiskStatus.OPEN,
+      },
+      manager,
+    );
+    return { risk, action: 'created' };
+  }
+
   // ============================================================
   // GET RISK BY ID
   // ============================================================
@@ -252,14 +382,18 @@ export class WorkRisksService {
     const risk = await this.getRiskById(auth, workspaceId, riskId);
 
     if (dto.title !== undefined) risk.title = dto.title;
-    if (dto.description !== undefined) risk.description = dto.description || null;
+    if (dto.description !== undefined)
+      risk.description = dto.description || null;
     if (dto.severity !== undefined) risk.severity = dto.severity;
     if (dto.status !== undefined) risk.status = dto.status;
     if (dto.probability !== undefined) risk.probability = dto.probability;
     if (dto.impact !== undefined) risk.impact = dto.impact;
-    if (dto.mitigationPlan !== undefined) risk.mitigationPlan = dto.mitigationPlan || null;
-    if (dto.ownerUserId !== undefined) risk.ownerUserId = dto.ownerUserId || null;
-    if (dto.dueDate !== undefined) risk.dueDate = dto.dueDate ? new Date(dto.dueDate) : null;
+    if (dto.mitigationPlan !== undefined)
+      risk.mitigationPlan = dto.mitigationPlan || null;
+    if (dto.ownerUserId !== undefined)
+      risk.ownerUserId = dto.ownerUserId || null;
+    if (dto.dueDate !== undefined)
+      risk.dueDate = dto.dueDate ? new Date(dto.dueDate) : null;
 
     const saved = await this.riskRepo.save(risk);
 
@@ -295,5 +429,141 @@ export class WorkRisksService {
     const risk = await this.getRiskById(auth, workspaceId, riskId);
     risk.deletedAt = new Date();
     await this.riskRepo.save(risk);
+  }
+
+  private getSystemRepositories(manager?: EntityManager): {
+    riskRepository: Repository<WorkRisk>;
+    projectRepository: Repository<Project>;
+  } {
+    return {
+      riskRepository: manager
+        ? manager.getRepository(WorkRisk)
+        : this.riskRepo.getRepository(),
+      projectRepository: manager
+        ? manager.getRepository(Project)
+        : this.projectRepository,
+    };
+  }
+
+  private async assertSystemProjectScope(
+    input: Pick<
+      SystemRiskInput,
+      'organizationId' | 'workspaceId' | 'projectId'
+    >,
+    projectRepository: Repository<Project>,
+  ): Promise<void> {
+    const project = await projectRepository.findOne({
+      where: {
+        id: input.projectId,
+        organizationId: input.organizationId,
+        workspaceId: input.workspaceId,
+      },
+      select: ['id'],
+    });
+
+    if (!project) {
+      throw new NotFoundException({
+        code: 'PROJECT_NOT_FOUND',
+        message: 'Project not found in this workspace',
+      });
+    }
+  }
+
+  private async findSystemRisk(
+    input: {
+      organizationId: string;
+      workspaceId: string;
+      projectId: string;
+      source: string;
+      riskType: string;
+    },
+    manager?: EntityManager,
+    status?: RiskStatus,
+  ): Promise<WorkRisk | null> {
+    const { riskRepository } = this.getSystemRepositories(manager);
+    const qb = riskRepository
+      .createQueryBuilder('risk')
+      .where('risk.organizationId = :organizationId', {
+        organizationId: input.organizationId,
+      })
+      .andWhere('risk.workspaceId = :workspaceId', {
+        workspaceId: input.workspaceId,
+      })
+      .andWhere('risk.projectId = :projectId', { projectId: input.projectId })
+      .andWhere('risk.source = :source', { source: input.source })
+      .andWhere('risk.riskType = :riskType', { riskType: input.riskType })
+      .andWhere('risk.deletedAt IS NULL')
+      .orderBy('risk.updatedAt', 'DESC');
+
+    if (status) {
+      qb.andWhere('risk.status = :status', { status });
+    }
+
+    return qb.getOne();
+  }
+
+  private clampRiskScale(value: number | undefined): number {
+    if (value === undefined || Number.isNaN(value)) {
+      return 3;
+    }
+    return Math.max(1, Math.min(5, Math.round(value)));
+  }
+
+  private async emitRiskDomainEvent(
+    eventName: string,
+    risk: WorkRisk,
+  ): Promise<void> {
+    if (!this.domainEventEmitter) {
+      return;
+    }
+
+    await this.domainEventEmitter
+      .emit(eventName, {
+        workspaceId: risk.workspaceId,
+        organizationId: risk.organizationId,
+        projectId: risk.projectId,
+        entityId: risk.id,
+        entityType: 'RISK',
+        meta: { source: risk.source, riskType: risk.riskType },
+      })
+      .catch((err) => this.logger.warn(`Domain event emit failed: ${err}`));
+  }
+
+  private async recordSystemRiskAudit(
+    action: AuditAction,
+    risk: WorkRisk,
+    input: SystemRiskInput,
+    manager?: EntityManager,
+  ): Promise<void> {
+    if (!this.auditService) {
+      return;
+    }
+
+    await this.auditService.record(
+      {
+        organizationId: risk.organizationId,
+        workspaceId: risk.workspaceId,
+        actorUserId: input.createdBy || '00000000-0000-0000-0000-000000000000',
+        actorPlatformRole: 'SYSTEM',
+        entityType: AuditEntityType.WORK_RISK,
+        entityId: risk.id,
+        action,
+        after: {
+          status: risk.status,
+          severity: risk.severity,
+          source: risk.source,
+          riskType: risk.riskType,
+        },
+        metadata: {
+          action:
+            action === AuditAction.CREATE
+              ? 'risk.created.system'
+              : 'risk.updated.system',
+          source: input.source,
+          riskType: input.riskType,
+        },
+      },
+      manager ? { manager } : undefined,
+    );
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add trusted system writer APIs to `WorkRisksService` for canonical `work_risks` creation and idempotent upsert.
- Switch `RiskDetectionService` from writing legacy `risks` rows to upserting canonical `work_risks` rows with `source = 'cron_detection'`.
- Add v5.1 template instantiation risk preset creation into `work_risks` with `source = 'template_preset'`.
- Add focused unit coverage for the system writer, cron detection, and template preset paths.

## Architectural Decisions Applied
- Clean switch, no dual-write.
- `WorkRisksService.createSystemRisk(input, manager?)` is the canonical system writer.
- Transaction-aware via optional `EntityManager` for template instantiation.
- Cron idempotency is keyed by organization/workspace/project/source/riskType.
- Cron reruns update only `evidence`, `detectedAt`, and `severity` for OPEN risks.
- Non-OPEN human decisions are preserved and skipped.
- Malformed template risk presets are skipped and logged.

## Interim Staleness Until PR 2C
These readers still read legacy `risks` and may under-report newly detected/template risks until PR 2C:
- `DashboardCardResolverService.resolveActiveRisks`
- `ProgramsRollupService`
- `ProgramKpiRollupService`
- `PortfoliosRollupService`
- `PortfolioKpiRollupService`
- `SignalsService`
- `KnowledgeIndexService`
- `KnowledgeIndexEventSubscriber`

## Verification
- `npm test -- work-risks.service.spec.ts risk-detection.service.spec.ts templates-instantiate-v51.service.spec.ts --runInBand` — passed, 3 suites / 15 tests
- `npm run build:migrations` — passed
- `npm run build` — passed

## Scope Boundaries
- No reader changes; those are PR 2C.
- No old `risks` table schema changes.
- No PM module changes.
- No legacy `TemplatesInstantiateService` changes; legacy route remains 410 Gone.
- No frontend changes.

## Manual Verification After Merge
- Trigger risk detection manually or wait for the cron window.
- Confirm `risks` does not increase.
- Confirm `work_risks WHERE source = 'cron_detection'` increases/updates without duplicate spam.
- Instantiate a v5.1 template with risk presets and confirm `work_risks WHERE source = 'template_preset'` contains those risks.
- Confirm ProjectRisksTab lists those canonical rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

