### PR TITLE
PR 2C: Migrate legacy risk consumers to canonical work_risks

### DIFF
--- a/zephix-backend/src/modules/dashboards/dashboards.module.ts
+++ b/zephix-backend/src/modules/dashboards/dashboards.module.ts
@@ -29,7 +29,6 @@ import { ProjectDashboardController } from './controllers/project-dashboard.cont
 import { WorkspaceDashboardDataController } from './controllers/workspace-dashboard-data.controller';
 import { WorkspaceDashboardDataService } from './services/workspace-dashboard-data.service';
 import { WorkRisk } from '../work-management/entities/work-risk.entity';
-import { Risk } from '../risks/entities/risk.entity'; // DashboardCardResolverService still injects this
 import { DocumentEntity } from '../documents/entities/document.entity';
 import { WorkResourceAllocation } from '../work-management/entities/work-resource-allocation.entity';
 import { DashboardCardRegistryService } from './services/dashboard-card-registry.service';
@@ -50,7 +49,6 @@ import { OperationalDashboardController } from './controllers/operational-dashbo
       WorkPhase, // Phase 7.5: For project dashboard
       WorkResourceAllocation,
       WorkRisk, // Phase 2D: WorkspaceDashboardDataService reads from work_risks
-      Risk, // DashboardCardResolverService reads from legacy risks table
       DocumentEntity,
     ]),
     SharedModule, // Provides ResponseService

--- a/zephix-backend/src/modules/dashboards/services/dashboard-card-resolver.service.ts
+++ b/zephix-backend/src/modules/dashboards/services/dashboard-card-resolver.service.ts
@@ -5,7 +5,10 @@ import { WorkTask } from '../../work-management/entities/work-task.entity';
 import { TaskStatus } from '../../work-management/enums/task.enums';
 import { Project, ProjectHealth } from '../../projects/entities/project.entity';
 import { WorkResourceAllocation } from '../../work-management/entities/work-resource-allocation.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import {
+  WorkRisk,
+  RiskStatus,
+} from '../../work-management/entities/work-risk.entity';
 import { WorkspaceAccessService } from '../../workspace-access/workspace-access.service';
 import {
   DashboardCardData,
@@ -31,8 +34,8 @@ export class DashboardCardResolverService {
     private readonly projectRepository: Repository<Project>,
     @InjectRepository(WorkResourceAllocation)
     private readonly allocationRepository: Repository<WorkResourceAllocation>,
-    @InjectRepository(Risk)
-    private readonly riskRepository: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private readonly workRiskRepository: Repository<WorkRisk>,
     private readonly workspaceAccessService: WorkspaceAccessService,
   ) {}
 
@@ -476,15 +479,18 @@ export class DashboardCardResolverService {
       );
     }
     // IMPORTANT: visibility scoping happens before aggregate.
-    const rows = await this.riskRepository.find({
+    // Migrated from legacy risks → work_risks (PR 2C). Counts OPEN only per Decision A1.
+    const rows = await this.workRiskRepository.find({
       where: {
         organizationId: params.organizationId,
+        workspaceId: params.scopeId,
         projectId: In(visibleProjectIds),
+        deletedAt: IsNull(),
       },
       select: ['id', 'status', 'severity', 'updatedAt'],
       order: { updatedAt: 'DESC' },
     });
-    const open = rows.filter((item) => (item.status || 'open') !== 'closed');
+    const open = rows.filter((item) => item.status === RiskStatus.OPEN);
     const severityCounts = open.reduce<Record<string, number>>((acc, item) => {
       const key = String(item.severity || 'unknown').toLowerCase();
       acc[key] = (acc[key] || 0) + 1;
@@ -540,10 +546,11 @@ export class DashboardCardResolverService {
     );
     const isProjectOnly = workspaceRole === null;
     if (isProjectOnly) {
-      // Project-only users have limited visibility — return empty for card resolver.
-      // Full project-only scoping requires WorkspaceAccessService.getProjectOnlyVisibleProjectIdsInWorkspace
-      // which is not yet implemented on this branch.
-      return [];
+      return this.workspaceAccessService.getProjectOnlyVisibleProjectIdsInWorkspace(
+        params.organizationId,
+        params.userId,
+        params.scopeId,
+      );
     }
     const rows = await this.projectRepository.find({
       where: {

--- a/zephix-backend/src/modules/domain-events/domain-events.module.ts
+++ b/zephix-backend/src/modules/domain-events/domain-events.module.ts
@@ -5,7 +5,7 @@ import { DomainEventsPublisher } from './domain-events.publisher';
 import { AnalyticsEventSubscriber } from './subscribers/analytics-event.subscriber';
 import { KnowledgeIndexEventSubscriber } from './subscribers/knowledge-index-event.subscriber';
 import { Task } from '../tasks/entities/task.entity';
-import { Risk } from '../risks/entities/risk.entity';
+import { WorkRisk } from '../work-management/entities/work-risk.entity';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import { KnowledgeIndexModule } from '../knowledge-index/knowledge-index.module';
 
@@ -16,7 +16,7 @@ import { KnowledgeIndexModule } from '../knowledge-index/knowledge-index.module'
 @Module({
   imports: [
     EventEmitterModule.forRoot(),
-    TypeOrmModule.forFeature([Task, Risk]),
+    TypeOrmModule.forFeature([Task, WorkRisk]),
     AnalyticsModule,
     KnowledgeIndexModule,
   ],

--- a/zephix-backend/src/modules/domain-events/subscribers/knowledge-index-event.subscriber.ts
+++ b/zephix-backend/src/modules/domain-events/subscribers/knowledge-index-event.subscriber.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { KnowledgeIndexService } from '../../knowledge-index/services/knowledge-index.service';
 import { Task } from '../../tasks/entities/task.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import { WorkRisk } from '../../work-management/entities/work-risk.entity';
 import type {
   TaskCreatedEvent,
   TaskUpdatedEvent,
@@ -25,8 +25,8 @@ export class KnowledgeIndexEventSubscriber {
     private readonly knowledgeIndexService: KnowledgeIndexService,
     @InjectRepository(Task)
     private taskRepo: Repository<Task>,
-    @InjectRepository(Risk)
-    private riskRepo: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private workRiskRepo: Repository<WorkRisk>,
   ) {}
 
   @OnEvent('task.created')
@@ -56,7 +56,9 @@ export class KnowledgeIndexEventSubscriber {
   @OnEvent('risk.created')
   async handleRiskCreated(event: RiskCreatedEvent) {
     try {
-      const risk = await this.riskRepo.findOne({ where: { id: event.riskId } });
+      const risk = await this.workRiskRepo.findOne({
+        where: { id: event.riskId },
+      });
       if (risk) {
         await this.knowledgeIndexService.indexRisk(risk);
       }
@@ -68,7 +70,9 @@ export class KnowledgeIndexEventSubscriber {
   @OnEvent('risk.updated')
   async handleRiskUpdated(event: RiskUpdatedEvent) {
     try {
-      const risk = await this.riskRepo.findOne({ where: { id: event.riskId } });
+      const risk = await this.workRiskRepo.findOne({
+        where: { id: event.riskId },
+      });
       if (risk) {
         await this.knowledgeIndexService.indexRisk(risk);
       }

--- a/zephix-backend/src/modules/home/services/member-home.service.ts
+++ b/zephix-backend/src/modules/home/services/member-home.service.ts
@@ -110,13 +110,13 @@ export class MemberHomeService {
     let risksIOwnCount = 0;
     try {
       let riskQuery = `
-        SELECT COUNT(*) as count
-        FROM risks r
-        INNER JOIN projects p ON r.project_id = p.id
+        SELECT COUNT(*)::int AS count
+        FROM work_risks wr
+        INNER JOIN projects p ON wr.project_id = p.id
         WHERE p.organization_id = $1
-        AND r.owner_id = $2
-        AND r.deleted_at IS NULL
-        AND r.status = 'active'
+        AND wr.owner_user_id = $2
+        AND wr.deleted_at IS NULL
+        AND wr.status = 'OPEN'
       `;
       const riskParams: any[] = [organizationId, userId];
 

--- a/zephix-backend/src/modules/knowledge-index/knowledge-index.module.ts
+++ b/zephix-backend/src/modules/knowledge-index/knowledge-index.module.ts
@@ -4,10 +4,10 @@ import { KnowledgeIndexService } from './services/knowledge-index.service';
 import { RagIndex } from './entities/rag-index.entity';
 import { AIModule } from '../../ai/ai.module';
 import { Task } from '../tasks/entities/task.entity';
-import { Risk } from '../risks/entities/risk.entity';
+import { WorkRisk } from '../work-management/entities/work-risk.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RagIndex, Task, Risk]), AIModule],
+  imports: [TypeOrmModule.forFeature([RagIndex, Task, WorkRisk]), AIModule],
   controllers: [],
   providers: [KnowledgeIndexService],
   exports: [KnowledgeIndexService],

--- a/zephix-backend/src/modules/knowledge-index/services/knowledge-index.service.ts
+++ b/zephix-backend/src/modules/knowledge-index/services/knowledge-index.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { RagIndex } from '../entities/rag-index.entity';
 import { EmbeddingService } from '../../../ai/embedding.service';
 import { Task } from '../../tasks/entities/task.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import { WorkRisk } from '../../work-management/entities/work-risk.entity';
 
 /**
  * Phase 8: Knowledge Index Service
@@ -19,8 +19,8 @@ export class KnowledgeIndexService {
     private ragIndexRepo: Repository<RagIndex>,
     @InjectRepository(Task)
     private taskRepo: Repository<Task>,
-    @InjectRepository(Risk)
-    private riskRepo: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private workRiskRepo: Repository<WorkRisk>,
     private embeddingService: EmbeddingService,
   ) {}
 
@@ -77,11 +77,12 @@ export class KnowledgeIndexService {
   }
 
   /**
-   * Index a risk
+   * Index a risk (canonical work_risks).
+   * Migrated from legacy Risk → WorkRisk (PR 2C). Uses mitigationPlan text per Decision C1. Post-merge: reindex existing risk docs.
    */
-  async indexRisk(risk: Risk): Promise<void> {
-    const text =
-      `${risk.title}\n${risk.description || ''}\n${JSON.stringify(risk.mitigation || {})}`.trim();
+  async indexRisk(risk: WorkRisk): Promise<void> {
+    const mitigation = (risk.mitigationPlan || '').trim();
+    const text = `${risk.title}\n${risk.description || ''}\n${mitigation}`.trim();
     if (!text) return;
 
     try {
@@ -103,6 +104,7 @@ export class KnowledgeIndexService {
       if (existing) {
         existing.embedding = embeddingResponse.embedding;
         existing.text = text;
+        existing.workspaceId = risk.workspaceId;
         existing.updatedAt = new Date();
         await this.ragIndexRepo.save(existing);
       } else {
@@ -111,11 +113,12 @@ export class KnowledgeIndexService {
           documentType: 'risk',
           documentId: risk.id,
           organizationId: risk.organizationId,
+          workspaceId: risk.workspaceId,
           projectId: risk.projectId,
           text,
           metadata: {
             severity: risk.severity,
-            type: risk.type,
+            riskType: risk.riskType,
             status: risk.status,
           },
         });

--- a/zephix-backend/src/modules/portfolios/portfolios.module.ts
+++ b/zephix-backend/src/modules/portfolios/portfolios.module.ts
@@ -8,7 +8,7 @@ import { ResourceAllocation } from '../resources/entities/resource-allocation.en
 import { ResourceConflict } from '../resources/entities/resource-conflict.entity';
 import { Resource } from '../resources/entities/resource.entity';
 import { WorkItem } from '../work-items/entities/work-item.entity';
-import { Risk } from '../risks/entities/risk.entity';
+import { WorkRisk } from '../work-management/entities/work-risk.entity';
 import { PortfoliosService } from './services/portfolios.service';
 import { PortfoliosRollupService } from './services/portfolios-rollup.service';
 import { PortfolioAnalyticsService } from './services/portfolio-analytics.service';
@@ -47,7 +47,7 @@ import { WorkspaceMember } from '../workspaces/entities/workspace-member.entity'
       ResourceConflict,
       Resource,
       WorkItem,
-      Risk,
+      WorkRisk,
       Workspace, // PHASE 7.4.3: Fix DI - RequireWorkspaceAccessGuard needs this
       WorkspaceMember, // PHASE 7.4.3: Fix DI - RequireWorkspaceAccessGuard needs this
       // Phase 2D: Waterfall entities for portfolio analytics

--- a/zephix-backend/src/modules/portfolios/services/portfolio-kpi-rollup.service.ts
+++ b/zephix-backend/src/modules/portfolios/services/portfolio-kpi-rollup.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, LessThanOrEqual } from 'typeorm';
+import { Repository, In, LessThanOrEqual, IsNull } from 'typeorm';
 import { createHash } from 'crypto';
 import { Portfolio } from '../entities/portfolio.entity';
 import { PortfolioProject } from '../entities/portfolio-project.entity';
@@ -9,7 +9,10 @@ import { ProjectKpiValueEntity } from '../../kpis/entities/project-kpi-value.ent
 import { ProjectBudgetEntity } from '../../budgets/entities/project-budget.entity';
 import { ChangeRequestEntity } from '../../change-requests/entities/change-request.entity';
 import { ChangeRequestStatus } from '../../change-requests/types/change-request.enums';
-import { Risk } from '../../risks/entities/risk.entity';
+import {
+  WorkRisk,
+  RiskStatus,
+} from '../../work-management/entities/work-risk.entity';
 
 export const PORTFOLIO_ROLLUP_ENGINE_VERSION = '1.0.0';
 
@@ -55,7 +58,7 @@ interface RollupContext {
   projectKpis: Map<string, ProjectKpiValueEntity[]>;
   budgets: ProjectBudgetEntity[];
   changeRequests: ChangeRequestEntity[];
-  risks: Risk[];
+  risks: WorkRisk[];
   projectIds: string[];
 }
 
@@ -202,8 +205,8 @@ export class PortfolioKpiRollupService {
     private readonly budgetRepo: Repository<ProjectBudgetEntity>,
     @InjectRepository(ChangeRequestEntity)
     private readonly crRepo: Repository<ChangeRequestEntity>,
-    @InjectRepository(Risk)
-    private readonly riskRepo: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private readonly workRiskRepo: Repository<WorkRisk>,
   ) {}
 
   async computeForPortfolio(
@@ -225,7 +228,7 @@ export class PortfolioKpiRollupService {
       this.loadProjectKpis(projectIds, workspaceId, effectiveDate),
       this.loadBudgets(projectIds, workspaceId),
       this.loadChangeRequests(projectIds, workspaceId),
-      this.loadRisks(projectIds, organizationId),
+      this.loadRisks(projectIds, organizationId, workspaceId),
     ]);
 
     const ctx: RollupContext = { projectKpis, budgets, changeRequests, risks, projectIds };
@@ -370,10 +373,20 @@ export class PortfolioKpiRollupService {
     });
   }
 
-  private async loadRisks(projectIds: string[], organizationId: string): Promise<Risk[]> {
+  private async loadRisks(
+    projectIds: string[],
+    organizationId: string,
+    workspaceId: string,
+  ): Promise<WorkRisk[]> {
     if (projectIds.length === 0) return [];
-    return this.riskRepo.find({
-      where: { projectId: In(projectIds), organizationId, status: 'open' },
+    return this.workRiskRepo.find({
+      where: {
+        projectId: In(projectIds),
+        organizationId,
+        workspaceId,
+        status: RiskStatus.OPEN,
+        deletedAt: IsNull(),
+      },
     });
   }
 

--- a/zephix-backend/src/modules/portfolios/services/portfolios-rollup.service.ts
+++ b/zephix-backend/src/modules/portfolios/services/portfolios-rollup.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, IsNull } from 'typeorm';
 import { Portfolio } from '../entities/portfolio.entity';
 import { PortfolioProject } from '../entities/portfolio-project.entity';
 import { Program } from '../../programs/entities/program.entity';
@@ -10,7 +10,10 @@ import {
   WorkItemStatus,
 } from '../../work-items/entities/work-item.entity';
 import { ResourceConflict } from '../../resources/entities/resource-conflict.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import {
+  WorkRisk,
+  RiskStatus,
+} from '../../work-management/entities/work-risk.entity';
 import { computeHealthV1 } from '../../shared/rollups/health-v1';
 import {
   PortfolioRollupResponseDto,
@@ -40,8 +43,8 @@ export class PortfoliosRollupService {
     private readonly workItemRepository: Repository<WorkItem>,
     @InjectRepository(ResourceConflict)
     private readonly conflictRepository: Repository<ResourceConflict>,
-    @InjectRepository(Risk)
-    private readonly riskRepository: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private readonly workRiskRepository: Repository<WorkRisk>,
   ) {}
 
   /**
@@ -322,11 +325,13 @@ export class PortfoliosRollupService {
     // Risks - filter by projectId and status
     const risks =
       projectIds.length > 0
-        ? await this.riskRepository.find({
+        ? await this.workRiskRepository.find({
             where: {
               projectId: In(projectIds),
               organizationId,
-              status: 'open',
+              workspaceId,
+              status: RiskStatus.OPEN,
+              deletedAt: IsNull(),
             },
           })
         : [];

--- a/zephix-backend/src/modules/programs/programs.module.ts
+++ b/zephix-backend/src/modules/programs/programs.module.ts
@@ -6,7 +6,7 @@ import { WorkItem } from '../work-items/entities/work-item.entity';
 import { ResourceConflict } from '../resources/entities/resource-conflict.entity';
 import { ResourceAllocation } from '../resources/entities/resource-allocation.entity';
 import { Resource } from '../resources/entities/resource.entity';
-import { Risk } from '../risks/entities/risk.entity';
+import { WorkRisk } from '../work-management/entities/work-risk.entity';
 import { ProgramsService } from './services/programs.service';
 import { ProgramsRollupService } from './services/programs-rollup.service';
 import { ProgramKpiRollupService } from './services/program-kpi-rollup.service';
@@ -36,7 +36,7 @@ import { WorkspaceMember } from '../workspaces/entities/workspace-member.entity'
       ResourceConflict,
       ResourceAllocation, // PHASE 7.4.3: Fix DI - ProgramsService needs this
       Resource, // PHASE 7.4.3: Fix DI - ProgramsService needs this
-      Risk,
+      WorkRisk,
       Workspace, // PHASE 7.4.3: Fix DI - RequireWorkspaceAccessGuard needs this
       WorkspaceMember, // PHASE 7.4.3: Fix DI - RequireWorkspaceAccessGuard needs this
       // Wave 8: KPI rollup dependencies

--- a/zephix-backend/src/modules/programs/services/program-kpi-rollup.service.ts
+++ b/zephix-backend/src/modules/programs/services/program-kpi-rollup.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, LessThanOrEqual } from 'typeorm';
+import { Repository, In, LessThanOrEqual, IsNull } from 'typeorm';
 import { createHash } from 'crypto';
 import { Program } from '../entities/program.entity';
 import { Project } from '../../projects/entities/project.entity';
@@ -9,7 +9,10 @@ import { ProjectKpiValueEntity } from '../../kpis/entities/project-kpi-value.ent
 import { ProjectBudgetEntity } from '../../budgets/entities/project-budget.entity';
 import { ChangeRequestEntity } from '../../change-requests/entities/change-request.entity';
 import { ChangeRequestStatus } from '../../change-requests/types/change-request.enums';
-import { Risk } from '../../risks/entities/risk.entity';
+import {
+  WorkRisk,
+  RiskStatus,
+} from '../../work-management/entities/work-risk.entity';
 
 export const PROGRAM_ROLLUP_ENGINE_VERSION = '1.0.0';
 
@@ -48,7 +51,7 @@ interface RollupContext {
   projectKpis: Map<string, ProjectKpiValueEntity[]>;
   budgets: ProjectBudgetEntity[];
   changeRequests: ChangeRequestEntity[];
-  risks: Risk[];
+  risks: WorkRisk[];
   projectIds: string[];
 }
 
@@ -203,8 +206,8 @@ export class ProgramKpiRollupService {
     private readonly budgetRepo: Repository<ProjectBudgetEntity>,
     @InjectRepository(ChangeRequestEntity)
     private readonly crRepo: Repository<ChangeRequestEntity>,
-    @InjectRepository(Risk)
-    private readonly riskRepo: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private readonly workRiskRepo: Repository<WorkRisk>,
   ) {}
 
   async computeForProgram(
@@ -226,7 +229,7 @@ export class ProgramKpiRollupService {
       this.loadProjectKpis(projectIds, workspaceId, effectiveDate),
       this.loadBudgets(projectIds, workspaceId),
       this.loadChangeRequests(projectIds, workspaceId),
-      this.loadRisks(projectIds, organizationId),
+      this.loadRisks(projectIds, organizationId, workspaceId),
     ]);
 
     const ctx: RollupContext = { projectKpis, budgets, changeRequests, risks, projectIds };
@@ -392,10 +395,20 @@ export class ProgramKpiRollupService {
     });
   }
 
-  private async loadRisks(projectIds: string[], organizationId: string): Promise<Risk[]> {
+  private async loadRisks(
+    projectIds: string[],
+    organizationId: string,
+    workspaceId: string,
+  ): Promise<WorkRisk[]> {
     if (projectIds.length === 0) return [];
-    return this.riskRepo.find({
-      where: { projectId: In(projectIds), organizationId, status: 'open' },
+    return this.workRiskRepo.find({
+      where: {
+        projectId: In(projectIds),
+        organizationId,
+        workspaceId,
+        status: RiskStatus.OPEN,
+        deletedAt: IsNull(),
+      },
     });
   }
 

--- a/zephix-backend/src/modules/programs/services/programs-rollup.service.ts
+++ b/zephix-backend/src/modules/programs/services/programs-rollup.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, IsNull } from 'typeorm';
 import { Program } from '../entities/program.entity';
 import { Project } from '../../projects/entities/project.entity';
 import {
@@ -8,7 +8,10 @@ import {
   WorkItemStatus,
 } from '../../work-items/entities/work-item.entity';
 import { ResourceConflict } from '../../resources/entities/resource-conflict.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import {
+  WorkRisk,
+  RiskStatus,
+} from '../../work-management/entities/work-risk.entity';
 import { computeHealthV1 } from '../../shared/rollups/health-v1';
 import {
   ProgramRollupResponseDto,
@@ -33,8 +36,8 @@ export class ProgramsRollupService {
     private readonly workItemRepository: Repository<WorkItem>,
     @InjectRepository(ResourceConflict)
     private readonly conflictRepository: Repository<ResourceConflict>,
-    @InjectRepository(Risk)
-    private readonly riskRepository: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private readonly workRiskRepository: Repository<WorkRisk>,
   ) {}
 
   /**
@@ -198,11 +201,13 @@ export class ProgramsRollupService {
 
     // Risks - filter by projectId and status
     // Risk entity has projectId, so we can query directly
-    const risks = await this.riskRepository.find({
+    const risks = await this.workRiskRepository.find({
       where: {
         projectId: In(projectIds),
         organizationId,
-        status: 'open',
+        workspaceId,
+        status: RiskStatus.OPEN,
+        deletedAt: IsNull(),
       },
     });
 

--- a/zephix-backend/src/modules/signals/services/signals.service.ts
+++ b/zephix-backend/src/modules/signals/services/signals.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan, MoreThan } from 'typeorm';
 import { SignalsReport } from '../entities/signals-report.entity';
-import { Risk } from '../../risks/entities/risk.entity';
+import { WorkRisk } from '../../work-management/entities/work-risk.entity';
 import { Task } from '../../tasks/entities/task.entity';
 import { MaterializedProjectMetrics } from '../../analytics/entities/materialized-project-metrics.entity';
 
@@ -17,8 +17,8 @@ export class SignalsService {
   constructor(
     @InjectRepository(SignalsReport)
     private signalsReportRepo: Repository<SignalsReport>,
-    @InjectRepository(Risk)
-    private riskRepo: Repository<Risk>,
+    @InjectRepository(WorkRisk)
+    private workRiskRepo: Repository<WorkRisk>,
     @InjectRepository(Task)
     private taskRepo: Repository<Task>,
     @InjectRepository(MaterializedProjectMetrics)
@@ -87,8 +87,8 @@ export class SignalsService {
     predictions: any[];
     actions: any[];
   }> {
-    // Get all risks created or updated in the week
-    const recentRisks = await this.riskRepo.find({
+    // Risks created in the reporting window (createdAt only — matches query; see PR 2C Decision B1).
+    const recentRisks = await this.workRiskRepo.find({
       where: {
         organizationId,
         createdAt: MoreThan(weekStart),
@@ -140,15 +140,15 @@ export class SignalsService {
   /**
    * Identify top risks by severity and recency
    */
-  private identifyTopRisks(risks: Risk[]): any[] {
+  private identifyTopRisks(risks: WorkRisk[]): any[] {
     return risks
       .map((risk) => ({
         id: risk.id,
         title: risk.title,
         severity: risk.severity,
-        type: risk.type,
+        type: risk.riskType,
         projectId: risk.projectId,
-        detectedAt: risk.detectedAt,
+        detectedAt: risk.detectedAt ?? risk.createdAt,
         score: this.calculateRiskScore(risk),
       }))
       .sort((a, b) => b.score - a.score)
@@ -159,7 +159,7 @@ export class SignalsService {
    * Generate predictions based on patterns
    */
   private generatePredictions(
-    risks: Risk[],
+    risks: WorkRisk[],
     blockedTasks: Task[],
     overdueTasks: Task[],
     projectMetrics: MaterializedProjectMetrics[],
@@ -181,8 +181,10 @@ export class SignalsService {
     // Vendor commitment decay detection
     const vendorRisks = risks.filter(
       (r) =>
-        r.type?.toLowerCase().includes('vendor') ||
-        r.type?.toLowerCase().includes('supplier'),
+        (r.riskType || '')
+          .toLowerCase()
+          .includes('vendor') ||
+        (r.riskType || '').toLowerCase().includes('supplier'),
     );
     if (vendorRisks.length > 3) {
       predictions.push({
@@ -283,7 +285,7 @@ export class SignalsService {
   /**
    * Calculate risk score for prioritization
    */
-  private calculateRiskScore(risk: Risk): number {
+  private calculateRiskScore(risk: WorkRisk): number {
     const severityScores: Record<string, number> = {
       low: 1,
       medium: 3,
@@ -293,8 +295,9 @@ export class SignalsService {
     const baseScore = severityScores[risk.severity?.toLowerCase()] || 1;
 
     // Boost score for recent risks
+    const detectionRef = risk.detectedAt ?? risk.createdAt;
     const daysSinceDetection = Math.floor(
-      (Date.now() - new Date(risk.detectedAt).getTime()) /
+      (Date.now() - new Date(detectionRef).getTime()) /
         (1000 * 60 * 60 * 24),
     );
     const recencyBoost = Math.max(0, 5 - daysSinceDetection);

--- a/zephix-backend/src/modules/workspace-access/workspace-access.module.ts
+++ b/zephix-backend/src/modules/workspace-access/workspace-access.module.ts
@@ -3,6 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { WorkspaceMember } from '../workspaces/entities/workspace-member.entity';
 import { Workspace } from '../workspaces/entities/workspace.entity';
+import { Project } from '../projects/entities/project.entity';
+import { WorkItem } from '../work-items/entities/work-item.entity';
 import { WorkspaceAccessService } from './workspace-access.service';
 import { WorkspaceRoleGuardService } from './workspace-role-guard.service';
 import {
@@ -26,7 +28,7 @@ import {
  */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Workspace, WorkspaceMember]),
+    TypeOrmModule.forFeature([Workspace, WorkspaceMember, Project, WorkItem]),
     TenancyModule, // Required for TenantAwareRepository
     ConfigModule, // Required for ConfigService
     // Do NOT import ResourcesModule, WorkspacesModule, PortfoliosModule, or SharedModule
@@ -34,6 +36,8 @@ import {
   providers: [
     // Provide TenantAwareRepository for WorkspaceMember
     createTenantAwareRepositoryProvider(WorkspaceMember),
+    createTenantAwareRepositoryProvider(Project),
+    createTenantAwareRepositoryProvider(WorkItem),
     WorkspaceAccessService,
     WorkspaceRoleGuardService,
   ],

--- a/zephix-backend/src/modules/workspace-access/workspace-access.service.ts
+++ b/zephix-backend/src/modules/workspace-access/workspace-access.service.ts
@@ -10,6 +10,9 @@ import {
 import { TenantAwareRepository } from '../tenancy/tenant-aware.repository';
 import { getTenantAwareRepositoryToken } from '../tenancy/tenant-aware.repository';
 import { TenantContextService } from '../tenancy/tenant-context.service';
+import { Project } from '../projects/entities/project.entity';
+import { WorkItem } from '../work-items/entities/work-item.entity';
+import { IsNull } from 'typeorm';
 
 /**
  * Service to determine which workspaces a user can access and their roles
@@ -20,6 +23,10 @@ export class WorkspaceAccessService {
   constructor(
     @Inject(getTenantAwareRepositoryToken(WorkspaceMember))
     private memberRepo: TenantAwareRepository<WorkspaceMember>,
+    @Inject(getTenantAwareRepositoryToken(Project))
+    private projectRepo: TenantAwareRepository<Project>,
+    @Inject(getTenantAwareRepositoryToken(WorkItem))
+    private workItemRepo: TenantAwareRepository<WorkItem>,
     private configService: ConfigService,
     private readonly tenantContextService: TenantContextService,
   ) {}
@@ -111,6 +118,40 @@ export class WorkspaceAccessService {
    * @param platformRole - User's platform role (ADMIN, MEMBER, VIEWER) - can be string for backward compatibility
    * @returns WorkspaceRole or null if no membership
    */
+  /**
+   * Project-only users: projects visible via delivery ownership or assigned work items.
+   * Used by workspace-scoped dashboard cards (PR 2C).
+   */
+  async getProjectOnlyVisibleProjectIdsInWorkspace(
+    organizationId: string,
+    userId: string,
+    workspaceId: string,
+  ): Promise<string[]> {
+    this.tenantContextService.assertOrganizationId();
+    const deliveryProjects = await this.projectRepo.find({
+      where: {
+        organizationId,
+        workspaceId,
+        deliveryOwnerUserId: userId,
+        deletedAt: IsNull(),
+      },
+      select: ['id'],
+    });
+    const fromDelivery = deliveryProjects.map((p) => p.id);
+
+    const assignedRows = await this.workItemRepo
+      .qb('wi')
+      .select('DISTINCT wi.projectId', 'projectId')
+      .where('wi.organizationId = :organizationId', { organizationId })
+      .andWhere('wi.workspaceId = :workspaceId', { workspaceId })
+      .andWhere('wi.assigneeId = :userId', { userId })
+      .andWhere('wi.deletedAt IS NULL')
+      .getRawMany<{ projectId: string }>();
+
+    const fromAssign = assignedRows.map((r) => r.projectId).filter(Boolean);
+    return Array.from(new Set([...fromDelivery, ...fromAssign]));
+  }
+
   async getUserWorkspaceRole(
     organizationId: string,
     workspaceId: string,

--- a/zephix-backend/src/modules/workspaces/services/workspace-access.service.spec.ts
+++ b/zephix-backend/src/modules/workspaces/services/workspace-access.service.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { WorkspaceAccessService } from '../../workspace-access/workspace-access.service';
 import { WorkspaceMember } from '../entities/workspace-member.entity';
+import { Project } from '../../projects/entities/project.entity';
+import { WorkItem } from '../../work-items/entities/work-item.entity';
 import { PlatformRole } from '../../../shared/enums/platform-roles.enum';
 import { AuditService } from '../../audit/services/audit.service';
 import { getTenantAwareRepositoryToken } from '../../tenancy/tenant-aware.repository';
@@ -14,6 +16,19 @@ describe('WorkspaceAccessService', () => {
   const mockMemberRepo = {
     findOne: jest.fn(),
     find: jest.fn(),
+  };
+
+  const mockProjectRepo = {
+    find: jest.fn().mockResolvedValue([]),
+  };
+
+  const mockWorkItemRepo = {
+    qb: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    }),
   };
 
   const mockConfigService = {
@@ -31,6 +46,14 @@ describe('WorkspaceAccessService', () => {
         {
           provide: getTenantAwareRepositoryToken(WorkspaceMember),
           useValue: mockMemberRepo,
+        },
+        {
+          provide: getTenantAwareRepositoryToken(Project),
+          useValue: mockProjectRepo,
+        },
+        {
+          provide: getTenantAwareRepositoryToken(WorkItem),
+          useValue: mockWorkItemRepo,
         },
         {
           provide: ConfigService,
@@ -176,6 +199,37 @@ describe('WorkspaceAccessService', () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getProjectOnlyVisibleProjectIdsInWorkspace', () => {
+    it('merges delivery-owner projects and projects from assigned work items', async () => {
+      mockProjectRepo.find.mockResolvedValueOnce([{ id: 'p-delivery' }]);
+      mockWorkItemRepo.qb.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ projectId: 'p-delivery' }, { projectId: 'p-assigned' }]),
+      });
+
+      const ids = await service.getProjectOnlyVisibleProjectIdsInWorkspace(
+        'org-123',
+        'user-1',
+        'ws-1',
+      );
+
+      expect(ids.sort()).toEqual(['p-assigned', 'p-delivery']);
+      expect(mockProjectRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organizationId: 'org-123',
+            workspaceId: 'ws-1',
+            deliveryOwnerUserId: 'user-1',
+          }),
+        }),
+      );
     });
   });
 

--- a/zephix-backend/src/modules/workspaces/services/workspace-health.service.ts
+++ b/zephix-backend/src/modules/workspaces/services/workspace-health.service.ts
@@ -110,14 +110,14 @@ export class WorkspaceHealthService {
     try {
       const riskCount = await this.dataSource.query(
         `
-        SELECT COUNT(*) as count
-        FROM risks r
-        INNER JOIN projects p ON r.project_id = p.id
+        SELECT COUNT(*)::int AS count
+        FROM work_risks wr
+        INNER JOIN projects p ON wr.project_id = p.id
         WHERE p.workspace_id = $1
         AND p.organization_id = $2
-        AND r.deleted_at IS NULL
-        AND r.status = 'active'
-        AND (r.risk_level = 'high' OR r.risk_level = 'very-high')
+        AND wr.deleted_at IS NULL
+        AND wr.status = 'OPEN'
+        AND (wr.severity = 'HIGH' OR wr.severity = 'CRITICAL')
       `,
         [workspace.id, organizationId],
       );

--- a/zephix-backend/src/pm/risk-management/risk-management.module.ts
+++ b/zephix-backend/src/pm/risk-management/risk-management.module.ts
@@ -3,9 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { RiskManagementController } from './risk-management.controller';
 import { RiskManagementService } from './risk-management.service';
 import { Project } from '../../modules/projects/entities/project.entity';
-import { Risk } from '../entities/risk.entity';
-import { RiskAssessment } from '../entities/risk-assessment.entity';
-import { RiskResponse } from '../entities/risk-response.entity';
+import { WorkRisk } from '../../modules/work-management/entities/work-risk.entity';
 import { RiskMonitoring } from '../entities/risk-monitoring.entity';
 // AccessControlModule removed - using built-in NestJS guards instead
 import { AIModule } from '../../ai/ai.module';
@@ -13,13 +11,7 @@ import { AIModule } from '../../ai/ai.module';
 @Module({
   imports: [
     // AccessControlModule removed - using built-in NestJS guards instead
-    TypeOrmModule.forFeature([
-      Project,
-      Risk,
-      RiskAssessment,
-      RiskResponse,
-      RiskMonitoring,
-    ]),
+    TypeOrmModule.forFeature([Project, WorkRisk, RiskMonitoring]),
     AIModule, // Provides ClaudeService
   ],
   controllers: [RiskManagementController],

--- a/zephix-backend/src/pm/risk-management/risk-management.service.ts
+++ b/zephix-backend/src/pm/risk-management/risk-management.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, IsNull } from 'typeorm';
 import { Project } from '../../modules/projects/entities/project.entity';
-import { Risk } from '../entities/risk.entity';
-import { RiskAssessment } from '../entities/risk-assessment.entity';
-import { RiskResponse } from '../entities/risk-response.entity';
+import {
+  WorkRisk,
+  RiskSeverity,
+  RiskStatus,
+} from '../../modules/work-management/entities/work-risk.entity';
 import { RiskMonitoring } from '../entities/risk-monitoring.entity';
 import { ClaudeService } from '../../ai/claude.service';
 
@@ -198,12 +200,8 @@ export class RiskManagementService {
   constructor(
     @InjectRepository(Project)
     private projectRepository: Repository<Project>,
-    @InjectRepository(Risk)
-    private riskRepository: Repository<Risk>,
-    @InjectRepository(RiskAssessment)
-    private riskAssessmentRepository: Repository<RiskAssessment>,
-    @InjectRepository(RiskResponse)
-    private riskResponseRepository: Repository<RiskResponse>,
+    @InjectRepository(WorkRisk)
+    private workRiskRepository: Repository<WorkRisk>,
     @InjectRepository(RiskMonitoring)
     private riskMonitoringRepository: Repository<RiskMonitoring>,
     private claudeService: ClaudeService,
@@ -620,93 +618,107 @@ export class RiskManagementService {
     return matrix;
   }
 
+  private mapPmRiskLevelToSeverity(riskLevel: string): RiskSeverity {
+    const level = (riskLevel || '').toLowerCase();
+    if (level === 'very-high' || level === 'high') {
+      return RiskSeverity.HIGH;
+    }
+    if (level === 'medium') {
+      return RiskSeverity.MEDIUM;
+    }
+    return RiskSeverity.LOW;
+  }
+
+  private mapInitialPmStatusToWorkRiskStatus(): RiskStatus {
+    return RiskStatus.OPEN;
+  }
+
+  private mapPmStatusStringToWorkRiskStatus(status: string): RiskStatus {
+    const s = (status || '').toLowerCase();
+    if (s === 'closed') {
+      return RiskStatus.CLOSED;
+    }
+    if (s === 'resolved' || s === 'mitigated' || s === 'monitoring') {
+      return RiskStatus.MITIGATED;
+    }
+    if (s === 'accepted') {
+      return RiskStatus.ACCEPTED;
+    }
+    return RiskStatus.OPEN;
+  }
+
   private async persistRiskAnalysis(
     risks: RiskData[],
     responses: RiskResponsePlan[],
     projectId: string,
     userId: string,
   ): Promise<void> {
-    // Save risks to database
+    const project = await this.projectRepository.findOne({
+      where: { id: projectId },
+      select: ['id', 'organizationId', 'workspaceId'],
+    });
+    if (!project) {
+      throw new Error('Project not found');
+    }
+
+    // Migrated from legacy pm/Risk → WorkRisk (PR 2C). Rich PM fields stored in evidence JSONB.
+    // Response rows are not persisted separately; folded into evidence when present.
     for (const riskData of risks) {
-      const risk = this.riskRepository.create({
+      const responseForRisk = responses.find((r) => r.riskId === riskData.id);
+      const evidence: Record<string, unknown> = {
+        pmRiskAnalysis: {
+          category: riskData.category,
+          subcategory: riskData.subcategory,
+          riskScore: riskData.riskScore,
+          riskLevel: riskData.riskLevel,
+          triggers: riskData.triggers,
+          dependencies: riskData.dependencies,
+          source: riskData.source,
+          confidence: riskData.confidence,
+          probabilityRationale: riskData.probability.rationale,
+          evidencePoints: riskData.probability.evidencePoints,
+          impactBreakdown: {
+            schedule: riskData.impact.schedule,
+            budget: riskData.impact.budget,
+            scope: riskData.impact.scope,
+            quality: riskData.impact.quality,
+          },
+          originalAssessment: riskData,
+        },
+      };
+      if (responseForRisk) {
+        evidence.pmResponsePlan = responseForRisk;
+      }
+
+      const risk = this.workRiskRepository.create({
+        organizationId: project.organizationId,
+        workspaceId: project.workspaceId,
         projectId,
         title: riskData.title,
         description: riskData.description,
-        category: riskData.category,
-        subcategory: riskData.subcategory,
-        probability: riskData.probability.score,
-        impact: riskData.impact.overall,
-        impactBreakdown: {
-          schedule: riskData.impact.schedule,
-          budget: riskData.impact.budget,
-          scope: riskData.impact.scope,
-          quality: riskData.impact.quality,
-        },
-        riskScore: riskData.riskScore,
-        riskLevel: riskData.riskLevel,
-        status: 'identified',
-        triggers: riskData.triggers,
-        dependencies: riskData.dependencies,
-        source: riskData.source,
-        confidence: riskData.confidence,
-        probabilityRationale: riskData.probability.rationale,
-        evidencePoints: riskData.probability.evidencePoints,
-        riskData: {
-          originalAssessment: riskData,
-          aiAnalysis: null,
-          historicalContext: null,
-          externalFactors: null,
-        },
+        severity: this.mapPmRiskLevelToSeverity(riskData.riskLevel),
+        status: this.mapInitialPmStatusToWorkRiskStatus(),
+        probability: Math.min(
+          5,
+          Math.max(1, Math.round(Number(riskData.probability.score) || 3)),
+        ),
+        impact: Math.min(
+          5,
+          Math.max(1, Math.round(Number(riskData.impact.overall) || 3)),
+        ),
+        mitigationPlan: null,
+        ownerUserId: null,
+        dueDate: null,
         createdBy: userId,
+        source: 'pm_ai_analysis',
+        riskType: riskData.category,
+        evidence,
+        detectedAt: new Date(),
+        legacyRiskId: null,
+        deletedAt: null,
       });
 
-      const savedRisk = await this.riskRepository.save(risk);
-
-      // Save response plan if exists
-      const responseForRisk = responses.find((r) => r.riskId === riskData.id);
-      if (responseForRisk) {
-        const riskResponse = this.riskResponseRepository.create({
-          riskId: savedRisk.id,
-          strategy: responseForRisk.responseStrategy,
-          rationale: responseForRisk.rationale,
-          description: '',
-          actions: responseForRisk.actions,
-          contingencyPlan: responseForRisk.contingencyPlan
-            ? {
-                description: responseForRisk.contingencyPlan.description,
-                triggerConditions:
-                  responseForRisk.contingencyPlan.triggerConditions,
-                activationCriteria: [],
-                actions: responseForRisk.contingencyPlan.actions,
-                requiredResources:
-                  responseForRisk.contingencyPlan.requiredResources.map(
-                    (resource) => ({
-                      type: 'other' as const,
-                      description: resource,
-                      quantity: 1,
-                      cost: 0,
-                    }),
-                  ),
-                estimatedCost: responseForRisk.contingencyPlan.estimatedCost,
-                timeline: 'TBD',
-                decisionAuthority: 'Project Manager',
-              }
-            : undefined,
-          transferDetails: responseForRisk.transferDetails,
-          monitoring: responseForRisk.monitoring,
-          effectiveness: responseForRisk.effectiveness,
-          status: 'draft',
-          responseData: {
-            originalPlan: responseForRisk,
-            modifications: [],
-            performanceHistory: [],
-            stakeholderFeedback: [],
-          },
-          createdBy: userId,
-        });
-
-        await this.riskResponseRepository.save(riskResponse);
-      }
+      await this.workRiskRepository.save(risk);
     }
   }
 
@@ -714,32 +726,29 @@ export class RiskManagementService {
     projectId: string,
     organizationId?: string,
   ): Promise<any> {
-    // Add organization filtering for tenant isolation
-    const queryBuilder = this.riskRepository
-      .createQueryBuilder('risk')
-      .leftJoinAndSelect('risk.responses', 'responses')
-      .leftJoinAndSelect('risk.monitoring', 'monitoring')
-      .where('risk.projectId = :projectId', { projectId });
-
-    // If organization ID is provided, filter by it for tenant isolation
+    const where: Record<string, unknown> = {
+      projectId,
+      deletedAt: IsNull(),
+    };
     if (organizationId) {
-      queryBuilder.andWhere('risk.organizationId = :organizationId', {
-        organizationId,
-      });
+      where.organizationId = organizationId;
     }
 
-    const risks = await queryBuilder
-      .orderBy('risk.riskScore', 'DESC')
-      .getMany();
+    const risks = await this.workRiskRepository.find({
+      where: where as any,
+      order: { updatedAt: 'DESC' },
+    });
 
     return {
       risks,
       summary: {
         total: risks.length,
         highPriority: risks.filter(
-          (r) => r.riskLevel === 'high' || r.riskLevel === 'very-high',
+          (r) =>
+            r.severity === RiskSeverity.HIGH ||
+            r.severity === RiskSeverity.CRITICAL,
         ).length,
-        active: risks.filter((r) => r.status === 'active').length,
+        active: risks.filter((r) => r.status === RiskStatus.OPEN).length,
       },
     };
   }
@@ -749,18 +758,27 @@ export class RiskManagementService {
     status: string,
     notes: string,
     userId: string,
-  ): Promise<Risk> {
-    const risk = await this.riskRepository.findOne({ where: { id: riskId } });
+  ): Promise<WorkRisk> {
+    const risk = await this.workRiskRepository.findOne({
+      where: { id: riskId, deletedAt: IsNull() },
+    });
     if (!risk) {
       throw new Error('Risk not found');
     }
 
-    risk.status = status;
-    risk.statusNotes = notes;
-    risk.lastUpdatedBy = userId;
-    risk.updatedAt = new Date();
+    risk.status = this.mapPmStatusStringToWorkRiskStatus(status);
+    const prevEvidence =
+      risk.evidence && typeof risk.evidence === 'object'
+        ? { ...risk.evidence }
+        : {};
+    risk.evidence = {
+      ...prevEvidence,
+      pmStatusNotes: notes,
+      pmStatusUpdatedBy: userId,
+      pmStatusUpdatedAt: new Date().toISOString(),
+    };
 
-    return await this.riskRepository.save(risk);
+    return await this.workRiskRepository.save(risk);
   }
 
   async createRiskMonitoring(
@@ -768,6 +786,7 @@ export class RiskManagementService {
     monitoringPlan: any,
     userId: string,
   ): Promise<RiskMonitoring> {
+    // riskId references work_risks.id (canonical).
     const monitoring = this.riskMonitoringRepository.create({
       riskId,
       monitoringDate: new Date(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the final legacy `risks` consumers to canonical `work_risks` (consumer migration PR, not read-only: PM `RiskManagementService` writes `WorkRisk`).

### Consumers (11)

1. `DashboardCardResolverService` — OPEN-only active risks (Decision A1); workspace + visible projects
2. `ProgramsRollupService` — OPEN count with org + workspace scope
3. `ProgramKpiRollupService` — `open_risk_count` from OPEN `work_risks`
4. `PortfoliosRollupService` — same
5. `PortfolioKpiRollupService` — same
6. `SignalsService` — `WorkRisk`; comment aligned with `createdAt` filter (Decision B1)
7. `KnowledgeIndexService` — `mitigationPlan` text for embeddings (Decision C1); `workspaceId` on RAG rows
8. `KnowledgeIndexEventSubscriber` — loads `WorkRisk` by id
9. `WorkspaceHealthService` — SQL → `work_risks` (OPEN, HIGH/CRITICAL)
10. `MemberHomeService` — SQL → `work_risks` (OPEN, `owner_user_id`)
11. `RiskManagementService` — persists AI analysis as `WorkRisk` with rich fields in `evidence`; response plans folded into `evidence` (no separate `risk_responses` rows). `getRiskRegister` / `updateRiskStatus` use `WorkRisk`.

### Supporting change

- `WorkspaceAccessService.getProjectOnlyVisibleProjectIdsInWorkspace` — delivery owner + assignee work items; used by dashboard card resolver for project-only users (fixes empty card + contract test).

### Verification

- `npx tsc --noEmit`
- `npm run build`, `npm run build:migrations`
- Jest: `workspace-access.service.spec`, `program-kpi-rollup`, `portfolio-kpi-rollup`, `dashboard-workspace`

### Intentional behavior notes

- Dashboard active risk count: **OPEN only** (may decrease vs legacy string filter).
- `RiskManagementService` API return shape for register/status may differ (now `WorkRisk` entities); callers should treat as canonical risk rows.

### Pre-merge verification: `risk_monitoring` FK (reviewer-required)

`createRiskMonitoring` passes `riskId` as a **canonical `work_risks.id`**. Before merge, run on staging (or a DB with staging schema):

```sql
-- Table exists?
SELECT EXISTS (
  SELECT FROM information_schema.tables
  WHERE table_schema = 'public' AND table_name = 'risk_monitoring'
);

-- If table exists, list FKs on risk_monitoring
SELECT
  tc.constraint_name,
  kcu.column_name,
  ccu.table_name AS foreign_table_name,
  ccu.column_name AS foreign_column_name
FROM information_schema.table_constraints tc
JOIN information_schema.key_column_usage kcu
  ON tc.constraint_name = kcu.constraint_name
  AND tc.table_schema = kcu.table_schema
JOIN information_schema.constraint_column_usage ccu
  ON ccu.constraint_name = tc.constraint_name
  AND ccu.table_schema = tc.table_schema
WHERE tc.table_schema = 'public'
  AND tc.table_name = 'risk_monitoring'
  AND tc.constraint_type = 'FOREIGN KEY';
```

**Outcomes to document in review:** (a) table missing → endpoint may fail at runtime (pre-existing); (b) FK → `risks` → must not merge until migration or call is guarded; (c) FK → `work_risks` or no FK → OK.

Repo note: disabled migration `pm/database/migrations/disabled/004_CreateRiskManagementTables.ts` defines `risk_monitoring.riskId` → `risks(id)` when that path was used; production schema must be confirmed with SQL above.

### Pre-merge verification: `risk_responses` consumers (reviewer-required)

`RiskManagementService` no longer writes `risk_responses`; response plans live under `evidence.pmResponsePlan` on `WorkRisk`. Grep of `zephix-backend/src` for active services/controllers reading `risk_responses` / `RiskResponse` found only entity wiring and disabled migrations—**no active read path** beyond PM entity module registration. Re-verify if new code paths appear before merge.

### Follow-ups (tracked separately)

- Reindex RAG risk documents after `mitigationPlan` text path.
- Issue: SignalsService consider `updatedAt` in weekly window.
- v1.1: consolidate user/system writers under `WorkRisksService`.

### Pre-existing

- Full-repo `npm run lint` reports large historical debt; not addressed here.
- `workflow.project-only-dashboard-signal-ai.contract.spec.ts` still has broken imports / outdated `SignalsService` ctor (pre-existing). Track: update contract spec to post–PR 2C API; confirm no *additional* compile failures introduced by this PR.

### Merge order

Rebase this branch onto `staging` **after** PR #197 (2B) merges so `WorkRisksService` system-writer APIs exist on base.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

