### PR TITLE
W-A1: Fix AI route mismatch (frontend → POST /ai-pm-assistant/ask)

### DIFF
--- a/zephix-frontend/src/features/ai-assistant/AiSuggestionsPanel.tsx
+++ b/zephix-frontend/src/features/ai-assistant/AiSuggestionsPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { Sparkles, AlertCircle, Loader2, Info } from 'lucide-react';
 
 
-import { getAiSuggestions, type AiAssistPayload } from './aiAssistant.api';
+import { postAiPmAssistantAsk, type AiAssistPayload } from './aiAssistant.api';
 import type {
   AiAssistResponse,
   RankedAction,
@@ -49,7 +49,7 @@ export function AiSuggestionsPanel({
       };
 
       try {
-        const result = await getAiSuggestions(payload);
+        const result = await postAiPmAssistantAsk(payload);
         setResponse(result);
       } catch {
         setError(true);
@@ -101,10 +101,15 @@ export function AiSuggestionsPanel({
 
   if (!response) return null;
 
-  const { rankedActions, blockedExplanations, rankedTemplates, debug } = response;
-  const hasContent = rankedActions.length > 0 || blockedExplanations.length > 0 || rankedTemplates.length > 0;
+  const { rankedActions, blockedExplanations, rankedTemplates, debug, narrativeSummary } =
+    response;
+  const hasRanked =
+    rankedActions.length > 0 ||
+    blockedExplanations.length > 0 ||
+    rankedTemplates.length > 0;
+  const hasNarrative = Boolean(narrativeSummary?.trim());
 
-  if (!hasContent) return null;
+  if (!hasRanked && !hasNarrative) return null;
 
   return (
     <div className="border-t border-neutral-100" data-testid="ai-suggestions-panel">
@@ -122,6 +127,12 @@ export function AiSuggestionsPanel({
           {debug.mode === 'FALLBACK' ? 'Fallback mode' : `AI · ${debug.model || 'unknown'}`}
         </span>
       </div>
+
+      {hasNarrative && (
+        <div className="px-3 pb-2 text-xs text-neutral-600 whitespace-pre-wrap border-b border-neutral-100 mb-1">
+          {narrativeSummary}
+        </div>
+      )}
 
       {/* Ranked actions — top 3 */}
       {rankedActions.length > 0 && (

--- a/zephix-frontend/src/features/ai-assistant/aiAssistant.api.test.ts
+++ b/zephix-frontend/src/features/ai-assistant/aiAssistant.api.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+import {
+  mapPmResponseToAiAssist,
+  postAiPmAssistantAsk,
+  type AiAssistPayload,
+} from './aiAssistant.api';
+
+describe('postAiPmAssistantAsk', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.post).mockReset();
+  });
+
+  it('posts to /ai-pm-assistant/ask with question and project context', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      answer: 'Hello',
+      confidence: 0.9,
+      sources: [],
+      recommendations: [],
+      nextActions: [],
+    });
+
+    const payload: AiAssistPayload = {
+      route: { pathname: '/projects/p1' },
+      entityContext: { projectId: 'p1' },
+      userQuery: 'What is blocked?',
+      intentHint: 'GOVERNANCE',
+    };
+
+    await postAiPmAssistantAsk(payload);
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    const [path, body] = vi.mocked(apiClient.post).mock.calls[0];
+    expect(path).toBe('/ai-pm-assistant/ask');
+    expect(body).toMatchObject({
+      question: expect.stringContaining('What is blocked?'),
+      context: { projectId: 'p1' },
+    });
+    expect(String(body.question)).toContain('[intent: GOVERNANCE]');
+  });
+
+  it('mapPmResponseToAiAssist carries answer as narrativeSummary', () => {
+    const out = mapPmResponseToAiAssist(
+      {
+        answer: 'Sync standups.',
+        confidence: 1,
+        sources: [],
+        recommendations: [],
+        nextActions: [],
+      },
+      42,
+    );
+    expect(out.narrativeSummary).toBe('Sync standups.');
+    expect(out.debug.latencyMs).toBe(42);
+    expect(out.rankedActions).toEqual([]);
+  });
+});

--- a/zephix-frontend/src/features/ai-assistant/aiAssistant.api.ts
+++ b/zephix-frontend/src/features/ai-assistant/aiAssistant.api.ts
@@ -2,7 +2,31 @@ import type { AiAssistResponse, AiIntentHint } from './types';
 
 import { apiClient } from '@/lib/api/client';
 
-// ─── Request ─────────────────────────────────────────────────────────────────
+// ─── Backend contract: zephix-backend pm/controllers/ai-pm-assistant.controller.ts ───
+
+/** Mirrors backend `PMQuestionDto` / `ProjectContext` (subset we send from the SPA). */
+export interface AiPmAssistantAskPayload {
+  question: string;
+  context?: {
+    projectId?: string;
+    portfolioId?: string;
+    programId?: string;
+    methodology?: string;
+    domain?: string;
+    processGroup?: string;
+  };
+}
+
+/** Mirrors backend `PMResponse` from `AIPMAssistantService.askPMQuestion`. */
+export interface PmAssistantResponseBody {
+  answer: string;
+  confidence: number;
+  sources: string[];
+  recommendations: string[];
+  nextActions: string[];
+}
+
+// ─── Request shape used by command palette + project tab ──────────────────────
 
 export interface AiAssistPayload {
   route: { pathname: string; search?: string };
@@ -18,12 +42,65 @@ export interface AiAssistPayload {
   intentHint?: AiIntentHint;
 }
 
-// ─── API call ────────────────────────────────────────────────────────────────
+function buildPmQuestion(payload: AiAssistPayload): string {
+  const q = payload.userQuery?.trim();
+  if (q) {
+    const hint = payload.intentHint ? `\n\n[intent: ${payload.intentHint}]` : '';
+    return `${q}${hint}`;
+  }
+  return `Provide concise, actionable guidance for the current screen (${payload.route.pathname}${payload.route.search ?? ''}).`;
+}
 
-export async function getAiSuggestions(
+function buildPmContext(
+  payload: AiAssistPayload,
+): AiPmAssistantAskPayload['context'] | undefined {
+  const projectId = payload.entityContext?.projectId;
+  if (!projectId) {
+    return undefined;
+  }
+  return { projectId };
+}
+
+/** Maps PM assistant JSON to the command-palette `AiAssistResponse` shape (ranked lists often empty). */
+export function mapPmResponseToAiAssist(
+  pm: PmAssistantResponseBody,
+  latencyMs: number,
+): AiAssistResponse {
+  return {
+    rankedActions: [],
+    blockedExplanations: [],
+    rankedTemplates: [],
+    debug: {
+      mode: 'AI',
+      latencyMs,
+      inputHash: '',
+    },
+    narrativeSummary: pm.answer,
+  };
+}
+
+/**
+ * Canonical PM assistant endpoint — matches backend `POST /ai-pm-assistant/ask`.
+ */
+export async function postAiPmAssistantAsk(
   payload: AiAssistPayload,
 ): Promise<AiAssistResponse> {
-  const resp = await apiClient.post<{ data?: AiAssistResponse }>('/ai/assist', payload);
-  const raw = (resp as any)?.data ?? resp;
-  return raw as AiAssistResponse;
+  const started = performance.now();
+  const body: AiPmAssistantAskPayload = {
+    question: buildPmQuestion(payload),
+    context: buildPmContext(payload),
+  };
+
+  const raw = await apiClient.post<PmAssistantResponseBody>(
+    '/ai-pm-assistant/ask',
+    body,
+  );
+  const pm = raw as PmAssistantResponseBody;
+  const latencyMs = Math.round(performance.now() - started);
+
+  if (!pm || typeof pm.answer !== 'string') {
+    throw new Error('Invalid PM assistant response');
+  }
+
+  return mapPmResponseToAiAssist(pm, latencyMs);
 }

--- a/zephix-frontend/src/features/ai-assistant/types.ts
+++ b/zephix-frontend/src/features/ai-assistant/types.ts
@@ -40,6 +40,8 @@ export interface AiAssistResponse {
   blockedExplanations: BlockedExplanation[];
   rankedTemplates: RankedTemplate[];
   debug: AiAssistDebug;
+  /** When the backend returns prose from `POST /ai-pm-assistant/ask` (PM assistant). */
+  narrativeSummary?: string;
 }
 
 export type AiIntentHint = 'NAVIGATION' | 'GOVERNANCE' | 'SETUP' | 'TEMPLATES' | 'GENERAL';

--- a/zephix-frontend/src/features/projects/tabs/ProjectAiTab.tsx
+++ b/zephix-frontend/src/features/projects/tabs/ProjectAiTab.tsx
@@ -20,7 +20,11 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { useWorkspaceStore } from '@/state/workspace.store';
-import { api } from '@/lib/api';
+import {
+  postAiPmAssistantAsk,
+  type AiAssistPayload,
+} from '@/features/ai-assistant/aiAssistant.api';
+import type { AiIntentHint } from '@/features/ai-assistant/types';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -40,6 +44,7 @@ interface AiResult {
     reason: string;
     remediationActionIds: string[];
   }>;
+  narrativeSummary?: string;
   debug: {
     mode: string;
     latencyMs: number;
@@ -55,7 +60,7 @@ interface PresetQuery {
   label: string;
   query: string;
   icon: React.FC<{ className?: string }>;
-  intentHint: string;
+  intentHint: AiIntentHint;
 }
 
 const PRESET_QUERIES: PresetQuery[] = [
@@ -111,7 +116,7 @@ export const ProjectAiTab: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const runQuery = useCallback(
-    async (query: string, intentHint = 'GENERAL') => {
+    async (query: string, intentHint: AiIntentHint = 'GENERAL') => {
       if (!projectId || loading) return;
       setLoading(true);
       setError(null);
@@ -119,7 +124,7 @@ export const ProjectAiTab: React.FC = () => {
       setResult(null);
 
       try {
-        const response = await api.post('/ai/assist', {
+        const payload: AiAssistPayload = {
           route: {
             pathname: `/projects/${projectId}`,
           },
@@ -128,10 +133,17 @@ export const ProjectAiTab: React.FC = () => {
           },
           userQuery: query,
           intentHint,
+        };
+        const data = await postAiPmAssistantAsk(payload);
+        setResult({
+          rankedActions: data.rankedActions as AiResult['rankedActions'],
+          blockedExplanations: data.blockedExplanations as AiResult['blockedExplanations'],
+          narrativeSummary: data.narrativeSummary,
+          debug: {
+            mode: data.debug.mode,
+            latencyMs: data.debug.latencyMs,
+          },
         });
-
-        const data = response.data?.data ?? response.data;
-        setResult(data as AiResult);
       } catch (err: any) {
         console.error('AI assist failed:', err);
         setError(
@@ -262,6 +274,12 @@ export const ProjectAiTab: React.FC = () => {
             </div>
           )}
 
+          {result.narrativeSummary?.trim() && (
+            <div className="p-4 bg-white border border-slate-200 rounded-lg text-sm text-slate-700 whitespace-pre-wrap">
+              {result.narrativeSummary}
+            </div>
+          )}
+
           {/* Ranked suggestions */}
           {result.rankedActions.length > 0 && (
             <div>
@@ -336,7 +354,8 @@ export const ProjectAiTab: React.FC = () => {
 
           {/* No results */}
           {result.rankedActions.length === 0 &&
-            result.blockedExplanations.length === 0 && (
+            result.blockedExplanations.length === 0 &&
+            !result.narrativeSummary?.trim() && (
               <div className="p-4 bg-slate-50 rounded-lg text-center">
                 <p className="text-sm text-slate-500">
                   No specific suggestions for this query. Try asking something


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## W-A1: Fix AI Route Mismatch

First PR in Workstream A (Critical Fixes), Block 2.

### Bug

The SPA called `POST /api/ai/assist`, which has no backend handler. The PM assistant exposes **`POST /api/ai-pm-assistant/ask`** (`AIPMAssistantController`).

### Root Cause

Frontend API layer used a non-existent path; Nest returns **404** for unknown routes.

### Strategy: Option 1 (frontend-only)

Align the client with the existing backend route. No backend changes.

### Phase 0 summary

| Layer | Finding |
|-------|---------|
| Backend | `@Controller('ai-pm-assistant')` → `@Post('ask')` with body `{ question, context? }` → `PMResponse` (`answer`, `confidence`, `sources`, `recommendations`, `nextActions`) |
| Frontend call sites | `aiAssistant.api.ts` (`getAiSuggestions`), `ProjectAiTab.tsx` (`api.post('/ai/assist', ...)`) |
| Other AI controllers | Separate: `ai/suggestions`, `ai-chat`, etc. — **not** part of this mismatch |

### Additional finding (response shape)

The old frontend expected ranked-command payloads; **`ask`** returns prose **`answer`**. This PR maps **`PMResponse.answer`** → **`AiAssistResponse.narrativeSummary`** and keeps ranked arrays empty so existing panels still render. **`AiSuggestionsPanel`** and **`ProjectAiTab`** show the narrative when present.

### Files changed

- `zephix-frontend/src/features/ai-assistant/aiAssistant.api.ts` — `postAiPmAssistantAsk()`, mapping helpers
- `zephix-frontend/src/features/ai-assistant/types.ts` — optional `narrativeSummary`
- `zephix-frontend/src/features/ai-assistant/AiSuggestionsPanel.tsx` — call rename + narrative block
- `zephix-frontend/src/features/projects/tabs/ProjectAiTab.tsx` — use shared API + narrative UI
- `zephix-frontend/src/features/ai-assistant/aiAssistant.api.test.ts` — path + mapper tests

### Verification

- `grep '/ai/assist'` under `zephix-frontend/src` → **no matches** (backup `App.tsx.enterprise-backup` unchanged)
- `npm run typecheck` — pass
- `npm run build` — pass
- `vitest run aiAssistant.api.test.ts` — pass

### Manual post-merge

1. Open a project → AI tab → run a preset or custom query.
2. Network: **`POST .../api/ai-pm-assistant/ask`** → **200**, body includes `answer`.

### Workstream A

- [x] W-A1 (this PR)
- [ ] W-A2–W-A6 — follow separately

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

