### PR TITLE
W-A2: Fix Settings save (account profile, password, organization)

### DIFF
--- a/zephix-frontend/src/pages/settings/__tests__/AccountSettings.test.tsx
+++ b/zephix-frontend/src/pages/settings/__tests__/AccountSettings.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const refreshMe = vi.fn().mockResolvedValue(null);
+
+vi.mock("@/state/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u1",
+      email: "test@example.com",
+      firstName: "John",
+      lastName: "Doe",
+      organizationId: "org-1",
+      permissions: { isAdmin: true },
+    },
+    refreshMe,
+  }),
+}));
+
+import { toast } from "sonner";
+import { apiClient } from "@/lib/api/client";
+import { AccountSettings } from "../components/AccountSettings";
+
+describe("AccountSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(apiClient.get).mockResolvedValue({
+      firstName: "John",
+      lastName: "Doe",
+      email: "test@example.com",
+      profilePicture: "",
+    });
+    vi.mocked(apiClient.patch).mockResolvedValue({});
+    vi.mocked(apiClient.post).mockResolvedValue({});
+  });
+
+  it("loads profile from GET /auth/profile and shows controlled fields", async () => {
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/auth/profile");
+    });
+    expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    expect(screen.getByTestId("settings-account-last-name")).toHaveValue("Doe");
+    expect(screen.getByTestId("settings-account-email")).toHaveValue("test@example.com");
+  });
+
+  it("updates first name input value", async () => {
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    });
+    fireEvent.change(screen.getByTestId("settings-account-first-name"), {
+      target: { value: "Jane" },
+    });
+    expect(screen.getByTestId("settings-account-first-name")).toHaveValue("Jane");
+  });
+
+  it("save profile sends PATCH only with changed fields and calls refreshMe", async () => {
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    });
+
+    fireEvent.change(screen.getByTestId("settings-account-first-name"), {
+      target: { value: "Jane" },
+    });
+    fireEvent.click(screen.getByTestId("settings-account-save-profile"));
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith("/auth/profile", {
+        firstName: "Jane",
+      });
+    });
+    expect(refreshMe).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("Profile saved.");
+  });
+
+  it("save profile shows error and does not clear inputs on failure", async () => {
+    vi.mocked(apiClient.patch).mockRejectedValueOnce(new Error("Validation failed"));
+
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    });
+
+    fireEvent.change(screen.getByTestId("settings-account-first-name"), {
+      target: { value: "Jane" },
+    });
+    fireEvent.click(screen.getByTestId("settings-account-save-profile"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Validation failed");
+    });
+    expect(screen.getByTestId("settings-account-first-name")).toHaveValue("Jane");
+  });
+
+  it("password save validates confirm match", async () => {
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    });
+
+    fireEvent.change(screen.getByTestId("settings-account-current-password"), {
+      target: { value: "oldpass" },
+    });
+    fireEvent.change(screen.getByTestId("settings-account-new-password"), {
+      target: { value: "newpass123" },
+    });
+    fireEvent.change(screen.getByTestId("settings-account-confirm-password"), {
+      target: { value: "different" },
+    });
+    fireEvent.click(screen.getByTestId("settings-account-save-password"));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+    });
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
+  it("password save calls POST /auth/change-password and clears fields on success", async () => {
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    });
+
+    fireEvent.change(screen.getByTestId("settings-account-current-password"), {
+      target: { value: "oldpass123" },
+    });
+    fireEvent.change(screen.getByTestId("settings-account-new-password"), {
+      target: { value: "newpass1234" },
+    });
+    fireEvent.change(screen.getByTestId("settings-account-confirm-password"), {
+      target: { value: "newpass1234" },
+    });
+    fireEvent.click(screen.getByTestId("settings-account-save-password"));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith("/auth/change-password", {
+        currentPassword: "oldpass123",
+        newPassword: "newpass1234",
+      });
+    });
+    expect(screen.getByTestId("settings-account-current-password")).toHaveValue("");
+    expect(screen.getByTestId("settings-account-new-password")).toHaveValue("");
+    expect(screen.getByTestId("settings-account-confirm-password")).toHaveValue("");
+    expect(toast.success).toHaveBeenCalledWith("Password updated.");
+  });
+
+  it("disables profile save button while saving", async () => {
+    let resolvePatch: (v: unknown) => void = () => {};
+    vi.mocked(apiClient.patch).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-first-name")).toHaveValue("John");
+    });
+
+    fireEvent.change(screen.getByTestId("settings-account-first-name"), {
+      target: { value: "Jane" },
+    });
+    fireEvent.click(screen.getByTestId("settings-account-save-profile"));
+
+    expect(screen.getByTestId("settings-account-save-profile")).toBeDisabled();
+    resolvePatch({});
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-account-save-profile")).not.toBeDisabled();
+    });
+  });
+});

--- a/zephix-frontend/src/pages/settings/__tests__/OrganizationSettings.test.tsx
+++ b/zephix-frontend/src/pages/settings/__tests__/OrganizationSettings.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+const mockSetCurrent = vi.fn();
+const mockSetOrgs = vi.fn();
+
+vi.mock("@/stores/organizationStore", () => ({
+  useOrganizationStore: (sel: (s: unknown) => unknown) =>
+    sel({
+      currentOrganization: { id: "org-1", name: "Acme" },
+      organizations: [{ id: "org-1", name: "Acme" }],
+      setCurrentOrganization: mockSetCurrent,
+      setOrganizations: mockSetOrgs,
+    }),
+}));
+
+vi.mock("@/state/AuthContext", () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: "u1", organizationId: "org-1", permissions: { isAdmin: true } },
+  })),
+}));
+
+import { toast } from "sonner";
+import { apiClient } from "@/lib/api/client";
+import { useAuth } from "@/state/AuthContext";
+import { OrganizationSettings } from "../components/OrganizationSettings";
+
+const mockUseAuth = vi.mocked(useAuth);
+
+const baseOrg = {
+  id: "org-1",
+  name: "Acme Corp",
+  slug: "acme",
+  status: "active" as const,
+  description: "Desc",
+  website: "https://acme.com",
+  industry: "Tech",
+  size: "medium" as const,
+  settings: {},
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("OrganizationSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(apiClient.get).mockResolvedValue(baseOrg);
+    vi.mocked(apiClient.patch).mockImplementation(async (_url, body) => ({
+      ...baseOrg,
+      ...(body as object),
+    }));
+  });
+
+  it("loads organization and renders fields", async () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "u1",
+        organizationId: "org-1",
+        permissions: { isAdmin: true },
+      },
+    } as any);
+
+    render(<OrganizationSettings />);
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/organizations/org-1");
+    });
+    expect(screen.getByTestId("settings-org-name")).toHaveValue("Acme Corp");
+    expect(screen.getByTestId("settings-org-website")).toHaveValue("https://acme.com");
+  });
+
+  it("non-admin: disables inputs and save", async () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "u1",
+        organizationId: "org-1",
+        permissions: { isAdmin: false },
+      },
+    } as any);
+
+    render(<OrganizationSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-org-name")).toBeDisabled();
+    });
+    expect(
+      screen.getByText(/Only organization admins can edit/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("settings-organization-save")).toBeDisabled();
+  });
+
+  it("admin: PATCH diff only and toast success", async () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "u1",
+        organizationId: "org-1",
+        permissions: { isAdmin: true },
+      },
+    } as any);
+
+    render(<OrganizationSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-org-name")).toHaveValue("Acme Corp");
+    });
+
+    fireEvent.change(screen.getByTestId("settings-org-industry"), {
+      target: { value: "Finance" },
+    });
+    fireEvent.click(screen.getByTestId("settings-organization-save"));
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith("/organizations/org-1", {
+        industry: "Finance",
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith("Organization settings saved.");
+    expect(mockSetOrgs).toHaveBeenCalled();
+  });
+
+  it("size select lists enum options", async () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "u1",
+        organizationId: "org-1",
+        permissions: { isAdmin: true },
+      },
+    } as any);
+
+    render(<OrganizationSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-org-size")).toBeInTheDocument();
+    });
+    const sel = screen.getByTestId("settings-org-size") as HTMLSelectElement;
+    const texts = Array.from(sel.options).map((o) => o.textContent);
+    expect(texts).toContain("Enterprise");
+  });
+});

--- a/zephix-frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/zephix-frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -1,295 +1,68 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { SettingsPage } from '../SettingsPage';
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 
-// Mock the API client
-vi.mock('../../../lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-    patch: vi.fn(),
-  },
+vi.mock("@/state/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u1",
+      email: "a@test.com",
+      organizationId: "org-1",
+      permissions: { isAdmin: true },
+    },
+  }),
 }));
 
-const createTestQueryClient = () => new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-    mutations: { retry: false },
-  },
-});
+vi.mock("../components/AccountSettings", () => ({
+  AccountSettings: () => (
+    <div data-testid="mock-account-settings">Account mock</div>
+  ),
+}));
 
-const renderWithQueryClient = (component: React.ReactElement) => {
-  const queryClient = createTestQueryClient();
+vi.mock("../components/WorkspaceSettings", () => ({
+  WorkspaceSettings: () => (
+    <div data-testid="mock-workspace-settings">Workspace mock</div>
+  ),
+}));
+
+vi.mock("../components/OrganizationSettings", () => ({
+  OrganizationSettings: () => (
+    <div data-testid="mock-org-settings">Organization mock</div>
+  ),
+}));
+
+vi.mock("../../billing/BillingPage", () => ({
+  default: () => <div data-testid="mock-billing">Billing mock</div>,
+}));
+
+import SettingsPage from "../SettingsPage";
+
+function renderSettings(initialPath = "/settings") {
   return render(
-    <QueryClientProvider client={queryClient}>
-      {component}
-    </QueryClientProvider>
+    <MemoryRouter initialEntries={[initialPath]}>
+      <SettingsPage />
+    </MemoryRouter>,
   );
-};
+}
 
-const mockOrganizationSettings = {
-  id: 'org-1',
-  name: 'Test Organization',
-  domain: 'test.com',
-  timezone: 'UTC',
-  language: 'en',
-  dateFormat: 'MM/DD/YYYY',
-  currency: 'USD',
-  organizationId: 'org-1',
-};
-
-const mockUserSettings = {
-  id: 'user-1',
-  email: 'test@example.com',
-  firstName: 'John',
-  lastName: 'Doe',
-  timezone: 'UTC',
-  language: 'en',
-  emailNotifications: true,
-  pushNotifications: true,
-  theme: 'light' as const,
-  organizationId: 'org-1',
-};
-
-const mockSecuritySettings = {
-  id: 'security-1',
-  twoFactorEnabled: false,
-  sessionTimeout: 30,
-  passwordPolicy: 'basic',
-  ipWhitelist: [],
-  organizationId: 'org-1',
-};
-
-describe('SettingsPage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+describe("SettingsPage", () => {
+  it("renders header and tab buttons", () => {
+    renderSettings();
+    expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
+    expect(screen.getByTestId("settings-tab-account")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-tab-workspace")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-tab-organization")).toBeInTheDocument();
   });
 
-  it('renders page header and tabs', () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    expect(screen.getByText('Settings')).toBeInTheDocument();
-    expect(screen.getByText('Manage your account and organization settings')).toBeInTheDocument();
-    expect(screen.getByText('Organization')).toBeInTheDocument();
-    expect(screen.getByText('Account')).toBeInTheDocument();
-    expect(screen.getByText('Security')).toBeInTheDocument();
+  it("shows Account tab content by default", () => {
+    renderSettings();
+    expect(screen.getByTestId("mock-account-settings")).toBeInTheDocument();
   });
 
-  it('shows loading state initially', () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation(() => new Promise(() => {})); // Never resolves
-
-    renderWithQueryClient(<SettingsPage />);
-
-    expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
-  });
-
-  it('displays organization settings form', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/organization name/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/domain/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
-    });
-
-    // Check that form fields are populated
-    expect(screen.getByDisplayValue('Test Organization')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('test.com')).toBeInTheDocument();
-  });
-
-  it('displays account settings form when account tab is selected', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Account')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByText('Account'));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/last name/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
-    });
-
-    // Check that form fields are populated
-    expect(screen.getByDisplayValue('John')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('Doe')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument();
-  });
-
-  it('displays security settings form when security tab is selected', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Security')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByText('Security'));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/two-factor authentication/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/session timeout/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/password requirements/i)).toBeInTheDocument();
-    });
-  });
-
-  it('handles form submission for organization settings', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-    apiClient.patch.mockResolvedValueOnce({ data: {} });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Save Organization Settings')).toBeInTheDocument();
-    });
-
-    const saveButton = screen.getByText('Save Organization Settings');
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(apiClient.patch).toHaveBeenCalledWith('/api/settings/organization', {
-        name: 'Test Organization',
-        domain: 'test.com',
-        timezone: 'UTC',
-        language: 'en',
-        dateFormat: 'MM/DD/YYYY',
-        currency: 'USD',
-      });
-    });
-  });
-
-  it('shows error banner when API fails', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockRejectedValueOnce(new Error('API Error'));
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Failed to load settings')).toBeInTheDocument();
-      expect(screen.getByText('Retry')).toBeInTheDocument();
-    });
-  });
-
-  it('validates required fields', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/organization name/i)).toBeInTheDocument();
-    });
-
-    const orgNameInput = screen.getByLabelText(/organization name/i);
-    expect(orgNameInput).toHaveAttribute('required');
-  });
-
-  it('supports keyboard navigation between tabs', async () => {
-    const { apiClient } = require('../../../lib/api/client');
-    apiClient.get.mockImplementation((url: string) => {
-      if (url.includes('organization')) {
-        return Promise.resolve({ data: mockOrganizationSettings });
-      }
-      if (url.includes('user')) {
-        return Promise.resolve({ data: mockUserSettings });
-      }
-      if (url.includes('security')) {
-        return Promise.resolve({ data: mockSecuritySettings });
-      }
-      return Promise.resolve({ data: {} });
-    });
-
-    renderWithQueryClient(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Account')).toBeInTheDocument();
-    });
-
-    const accountTab = screen.getByText('Account');
-    accountTab.focus();
-
-    fireEvent.keyDown(accountTab, { key: 'Enter' });
-    expect(accountTab).toHaveAttribute('data-state', 'active');
+  it("switches to Organization tab when clicked", () => {
+    renderSettings();
+    fireEvent.click(screen.getByTestId("settings-tab-organization"));
+    expect(screen.getByTestId("mock-org-settings")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-account-settings")).not.toBeInTheDocument();
   });
 });

--- a/zephix-frontend/src/pages/settings/components/AccountSettings.tsx
+++ b/zephix-frontend/src/pages/settings/components/AccountSettings.tsx
@@ -1,26 +1,292 @@
-import { track } from "@/lib/telemetry";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 
-export function AccountSettings(){
-  const handleSave = () => {
-    track('settings.account.saved', {});
-    // TODO: Implement save functionality
+import { track } from "@/lib/telemetry";
+import { useAuth } from "@/state/AuthContext";
+import { apiClient } from "@/lib/api/client";
+import { getAxiosErrorMessage } from "../settingsErrors";
+
+const PASSWORD_MIN = 8;
+
+type ProfilePayload = {
+  firstName?: string;
+  lastName?: string;
+  profilePicture?: string;
+};
+
+export function AccountSettings() {
+  const { user, refreshMe } = useAuth();
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [profilePictureUrl, setProfilePictureUrl] = useState("");
+  const [emailDisplay, setEmailDisplay] = useState("");
+
+  const initialProfile = useRef<ProfilePayload | null>(null);
+
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [savingPassword, setSavingPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  const hydrateFromServer = useCallback(async () => {
+    try {
+      const data = await apiClient.get<{
+        firstName?: string | null;
+        lastName?: string | null;
+        profilePicture?: string | null;
+        email?: string;
+      }>("/auth/profile");
+      const fn = data.firstName ?? "";
+      const ln = data.lastName ?? "";
+      const pic = data.profilePicture ?? "";
+      const em = data.email ?? user?.email ?? "";
+      setFirstName(fn);
+      setLastName(ln);
+      setProfilePictureUrl(pic);
+      setEmailDisplay(em);
+      initialProfile.current = {
+        firstName: fn,
+        lastName: ln,
+        profilePicture: pic,
+      };
+    } catch {
+      const fn = user?.firstName ?? "";
+      const ln = user?.lastName ?? "";
+      const pic = user?.profilePicture ?? "";
+      setFirstName(fn);
+      setLastName(ln);
+      setProfilePictureUrl(pic);
+      setEmailDisplay(user?.email ?? "");
+      initialProfile.current = {
+        firstName: fn,
+        lastName: ln,
+        profilePicture: pic,
+      };
+    }
+  }, [user?.email, user?.firstName, user?.lastName, user?.profilePicture]);
+
+  useEffect(() => {
+    void hydrateFromServer();
+  }, [hydrateFromServer]);
+
+  const handleSaveProfile = async () => {
+    setProfileError(null);
+    const fn = firstName.trim();
+    const ln = lastName.trim();
+    const pic = profilePictureUrl.trim();
+
+    if (!fn || fn.length > 100 || !ln || ln.length > 100) {
+      setProfileError("First and last name are required (max 100 characters each).");
+      return;
+    }
+    if (pic.length > 500) {
+      setProfileError("Profile picture URL must be at most 500 characters.");
+      return;
+    }
+
+    const base = initialProfile.current;
+    const payload: ProfilePayload = {};
+    if (!base || fn !== (base.firstName ?? "").trim()) payload.firstName = fn;
+    if (!base || ln !== (base.lastName ?? "").trim()) payload.lastName = ln;
+    if (!base || pic !== (base.profilePicture ?? "").trim()) {
+      payload.profilePicture = pic || undefined;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      toast.info("No profile changes to save.");
+      return;
+    }
+
+    setSavingProfile(true);
+    track("settings.account.profile_save_attempt", {});
+    try {
+      await apiClient.patch("/auth/profile", payload);
+      toast.success("Profile saved.");
+      initialProfile.current = {
+        firstName: fn,
+        lastName: ln,
+        profilePicture: pic,
+      };
+      try {
+        await refreshMe();
+      } catch {
+        toast.warning("Profile saved, but refreshing your session failed. Reload the page if something looks stale.");
+      }
+    } catch (e) {
+      setProfileError(getAxiosErrorMessage(e, "Could not save profile."));
+      toast.error(getAxiosErrorMessage(e, "Could not save profile."));
+    } finally {
+      setSavingProfile(false);
+    }
+  };
+
+  const handleChangePassword = async () => {
+    setPasswordError(null);
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      setPasswordError("Fill in current password, new password, and confirmation.");
+      return;
+    }
+    if (newPassword.length < PASSWORD_MIN) {
+      setPasswordError(`New password must be at least ${PASSWORD_MIN} characters.`);
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError("New password and confirmation do not match.");
+      return;
+    }
+    if (newPassword === currentPassword) {
+      setPasswordError("New password must be different from your current password.");
+      return;
+    }
+
+    setSavingPassword(true);
+    track("settings.account.password_change_attempt", {});
+    try {
+      await apiClient.post("/auth/change-password", {
+        currentPassword,
+        newPassword,
+      });
+      toast.success("Password updated.");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (e) {
+      const msg = getAxiosErrorMessage(e, "Could not change password.");
+      setPasswordError(msg);
+      toast.error(msg);
+    } finally {
+      setSavingPassword(false);
+    }
   };
 
   return (
-    <section data-testid="settings-account" className="space-y-3">
-      <h2 className="font-medium">Account</h2>
-      <div className="grid gap-2">
-        <label className="grid">
-          <span>Name</span>
-          <input data-testid="settings-account-name" className="input" />
-        </label>
-        <label className="grid">
-          <span>Password</span>
-          <input type="password" data-testid="settings-account-password" className="input" />
-        </label>
-      </div>
-      <button type="button" data-testid="settings-account-save" onClick={handleSave} className="btn-primary">Save</button>
-    </section>
+    <div className="space-y-8" data-testid="settings-account">
+      {/* Profile */}
+      <section className="space-y-3">
+        <h2 className="font-medium">Account profile</h2>
+        <div className="grid gap-2 max-w-lg">
+          <label className="grid">
+            <span>First name</span>
+            <input
+              data-testid="settings-account-first-name"
+              className="input"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              autoComplete="given-name"
+            />
+          </label>
+          <label className="grid">
+            <span>Last name</span>
+            <input
+              data-testid="settings-account-last-name"
+              className="input"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              autoComplete="family-name"
+            />
+          </label>
+          <label className="grid">
+            <span>Email</span>
+            <input
+              data-testid="settings-account-email"
+              className="input bg-slate-50 text-slate-600"
+              value={emailDisplay}
+              readOnly
+              aria-readonly="true"
+            />
+          </label>
+          <p className="text-xs text-slate-500">
+            Email cannot be changed here. Contact support if you need to update it.
+          </p>
+          <label className="grid">
+            <span>Profile picture URL</span>
+            <input
+              data-testid="settings-account-profile-picture-url"
+              className="input"
+              value={profilePictureUrl}
+              onChange={(e) => setProfilePictureUrl(e.target.value)}
+              placeholder="https://..."
+              autoComplete="off"
+            />
+          </label>
+        </div>
+        {profileError && (
+          <p className="text-sm text-red-600" role="alert">
+            {profileError}
+          </p>
+        )}
+        <button
+          type="button"
+          data-testid="settings-account-save-profile"
+          onClick={() => void handleSaveProfile()}
+          disabled={savingProfile}
+          className="btn-primary inline-flex items-center gap-2"
+        >
+          {savingProfile && <Loader2 className="h-4 w-4 animate-spin" />}
+          Save profile
+        </button>
+      </section>
+
+      {/* Password */}
+      <section className="space-y-3 border-t border-slate-200 pt-8">
+        <h2 className="font-medium">Change password</h2>
+        <div className="grid gap-2 max-w-lg">
+          <label className="grid">
+            <span>Current password</span>
+            <input
+              type="password"
+              data-testid="settings-account-current-password"
+              className="input"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+          </label>
+          <label className="grid">
+            <span>New password</span>
+            <input
+              type="password"
+              data-testid="settings-account-new-password"
+              className="input"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+            />
+          </label>
+          <label className="grid">
+            <span>Confirm new password</span>
+            <input
+              type="password"
+              data-testid="settings-account-confirm-password"
+              className="input"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+            />
+          </label>
+        </div>
+        {passwordError && (
+          <p className="text-sm text-red-600" role="alert">
+            {passwordError}
+          </p>
+        )}
+        <button
+          type="button"
+          data-testid="settings-account-save-password"
+          onClick={() => void handleChangePassword()}
+          disabled={savingPassword}
+          className="btn-primary inline-flex items-center gap-2"
+        >
+          {savingPassword && <Loader2 className="h-4 w-4 animate-spin" />}
+          Update password
+        </button>
+      </section>
+    </div>
   );
 }
-

--- a/zephix-frontend/src/pages/settings/components/OrganizationSettings.tsx
+++ b/zephix-frontend/src/pages/settings/components/OrganizationSettings.tsx
@@ -1,22 +1,298 @@
-import { track } from "@/lib/telemetry";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 
-export function OrganizationSettings(){
-  const handleSave = () => {
-    track('settings.organization.saved', {});
-    // TODO: Implement save functionality
+import { track } from "@/lib/telemetry";
+import { useAuth } from "@/state/AuthContext";
+import { apiClient } from "@/lib/api/client";
+import { isOrganizationAdminUser } from "@/utils/access";
+import { useOrganizationStore } from "@/stores/organizationStore";
+import type { Organization } from "@/types/organization";
+import { getAxiosErrorMessage } from "../settingsErrors";
+
+const SIZE_OPTIONS: Array<{
+  value: "" | "startup" | "small" | "medium" | "large" | "enterprise";
+  label: string;
+}> = [
+  { value: "", label: "Not specified" },
+  { value: "startup", label: "Startup" },
+  { value: "small", label: "Small" },
+  { value: "medium", label: "Medium" },
+  { value: "large", label: "Large" },
+  { value: "enterprise", label: "Enterprise" },
+];
+
+type OrgForm = {
+  name: string;
+  website: string;
+  industry: string;
+  size: "" | "startup" | "small" | "medium" | "large" | "enterprise";
+  description: string;
+};
+
+export function OrganizationSettings() {
+  const { user } = useAuth();
+  const orgId = user?.organizationId ?? null;
+  const canEditOrg = isOrganizationAdminUser(user);
+
+  const setCurrentOrganization = useOrganizationStore((s) => s.setCurrentOrganization);
+  const organizations = useOrganizationStore((s) => s.organizations);
+  const setOrganizations = useOrganizationStore((s) => s.setOrganizations);
+  const currentOrganization = useOrganizationStore((s) => s.currentOrganization);
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [website, setWebsite] = useState("");
+  const [industry, setIndustry] = useState("");
+  const [size, setSize] = useState<OrgForm["size"]>("");
+  const [description, setDescription] = useState("");
+
+  const initialRef = useRef<OrgForm | null>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const loadOrganization = useCallback(async () => {
+    if (!orgId) {
+      setLoading(false);
+      return;
+    }
+    setLoadError(null);
+    setLoading(true);
+    try {
+      const data = await apiClient.get<Organization>(`/organizations/${orgId}`);
+      const next: OrgForm = {
+        name: data.name ?? "",
+        website: data.website ?? "",
+        industry: data.industry ?? "",
+        size: (data.size as OrgForm["size"]) || "",
+        description: data.description ?? "",
+      };
+      setName(next.name);
+      setWebsite(next.website);
+      setIndustry(next.industry);
+      setSize(next.size);
+      setDescription(next.description);
+      initialRef.current = next;
+    } catch (e) {
+      setLoadError(getAxiosErrorMessage(e, "Could not load organization."));
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    void loadOrganization();
+  }, [loadOrganization]);
+
+  const handleSave = async () => {
+    if (!orgId || !canEditOrg) return;
+    setSaveError(null);
+
+    const trimmedName = name.trim();
+    if (trimmedName.length < 2 || trimmedName.length > 255) {
+      setSaveError("Organization name must be between 2 and 255 characters.");
+      return;
+    }
+
+    const ws = website.trim();
+    if (ws) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(ws);
+      } catch {
+        setSaveError("Website must be a valid URL (e.g. https://example.com).");
+        return;
+      }
+    }
+
+    const base = initialRef.current;
+    if (!base) {
+      setSaveError("Organization data not loaded yet.");
+      return;
+    }
+
+    const payload: Record<string, unknown> = {};
+    if (trimmedName !== base.name.trim()) payload.name = trimmedName;
+    const websiteVal = ws || undefined;
+    if ((websiteVal ?? "") !== (base.website.trim() || "")) {
+      payload.website = websiteVal;
+    }
+    const ind = industry.trim();
+    if (ind !== base.industry.trim()) payload.industry = ind || undefined;
+    const sizeVal = size || undefined;
+    const baseSize = base.size || "";
+    if ((sizeVal ?? "") !== (baseSize || "")) {
+      payload.size = sizeVal;
+    }
+    const desc = description.trim();
+    if (desc !== base.description.trim()) payload.description = desc || undefined;
+
+    if (Object.keys(payload).length === 0) {
+      toast.info("No organization changes to save.");
+      return;
+    }
+
+    setSaving(true);
+    track("settings.organization.save_attempt", {});
+    try {
+      const updated = await apiClient.patch<Organization>(
+        `/organizations/${orgId}`,
+        payload,
+      );
+
+      const next: OrgForm = {
+        name: updated.name ?? "",
+        website: updated.website ?? "",
+        industry: updated.industry ?? "",
+        size: (updated.size as OrgForm["size"]) || "",
+        description: updated.description ?? "",
+      };
+      initialRef.current = next;
+
+      const idx = organizations.findIndex((o) => o.id === orgId);
+      const nextOrgs =
+        idx >= 0
+          ? organizations.map((o) => (o.id === orgId ? updated : o))
+          : [...organizations, updated];
+      setOrganizations(nextOrgs);
+      if (currentOrganization?.id === orgId) {
+        setCurrentOrganization(updated);
+      }
+
+      toast.success("Organization settings saved.");
+    } catch (e) {
+      const msg = getAxiosErrorMessage(e, "Could not save organization settings.");
+      setSaveError(msg);
+      toast.error(msg);
+    } finally {
+      setSaving(false);
+    }
   };
+
+  if (!orgId) {
+    return (
+      <section data-testid="settings-organization" className="space-y-3">
+        <h2 className="font-medium">Organization</h2>
+        <p className="text-sm text-slate-600">No organization is associated with your account.</p>
+      </section>
+    );
+  }
+
+  if (loading) {
+    return (
+      <section data-testid="settings-organization" className="flex items-center gap-2 text-slate-600">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading organization…
+      </section>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <section data-testid="settings-organization" className="space-y-3">
+        <h2 className="font-medium">Organization</h2>
+        <p className="text-sm text-red-600">{loadError}</p>
+        <button type="button" className="btn" onClick={() => void loadOrganization()}>
+          Retry
+        </button>
+      </section>
+    );
+  }
+
+  const disabled = !canEditOrg || saving;
 
   return (
     <section data-testid="settings-organization" className="space-y-3">
       <h2 className="font-medium">Organization</h2>
-      <div className="grid gap-2">
+      {!canEditOrg && (
+        <p className="text-sm text-slate-600 max-w-xl">
+          Only organization admins can edit these settings. Contact an admin if you need changes.
+        </p>
+      )}
+      <div className="grid gap-2 max-w-xl">
         <label className="grid">
-          <span>Invite URL</span>
-          <input data-testid="settings-org-invite-url" className="input" placeholder="https://..." />
+          <span>Organization name</span>
+          <input
+            data-testid="settings-org-name"
+            className="input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={disabled}
+            minLength={2}
+            maxLength={255}
+            required
+            aria-required="true"
+          />
+        </label>
+        <label className="grid">
+          <span>Website</span>
+          <input
+            data-testid="settings-org-website"
+            className="input"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+            disabled={disabled}
+            placeholder="https://..."
+          />
+        </label>
+        <label className="grid">
+          <span>Industry</span>
+          <input
+            data-testid="settings-org-industry"
+            className="input"
+            value={industry}
+            onChange={(e) => setIndustry(e.target.value)}
+            disabled={disabled}
+          />
+        </label>
+        <label className="grid">
+          <span>Size</span>
+          <select
+            data-testid="settings-org-size"
+            className="input"
+            value={size}
+            onChange={(e) =>
+              setSize(e.target.value as OrgForm["size"])
+            }
+            disabled={disabled}
+          >
+            {SIZE_OPTIONS.map((o) => (
+              <option key={o.value || "none"} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="grid">
+          <span>Description</span>
+          <textarea
+            data-testid="settings-org-description"
+            className="input min-h-[100px]"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={disabled}
+            rows={4}
+          />
         </label>
       </div>
-      <button type="button" data-testid="settings-organization-save" onClick={handleSave} className="btn-primary">Save</button>
+      {saveError && (
+        <p className="text-sm text-red-600" role="alert">
+          {saveError}
+        </p>
+      )}
+      <button
+        type="button"
+        data-testid="settings-organization-save"
+        onClick={() => void handleSave()}
+        disabled={!canEditOrg || saving}
+        className="btn-primary inline-flex items-center gap-2"
+      >
+        {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+        Save organization settings
+      </button>
     </section>
   );
 }
-

--- a/zephix-frontend/src/pages/settings/settingsErrors.ts
+++ b/zephix-frontend/src/pages/settings/settingsErrors.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+/** Pull server message from axios error after api client unwrap. */
+export function getAxiosErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | string | undefined;
+    if (typeof data === 'object' && data?.message && typeof data.message === 'string') {
+      return data.message;
+    }
+    if (typeof data === 'string' && data.trim()) {
+      return data;
+    }
+    if (error.message) return error.message;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/zephix-frontend/src/state/AuthContext.tsx
+++ b/zephix-frontend/src/state/AuthContext.tsx
@@ -72,11 +72,15 @@ type AuthUser = {
   email: string;
   firstName?: string | null;
   lastName?: string | null;
+  profilePicture?: string | null;
   platformRole?: PlatformRole;
   /** @deprecated Use platformRole instead */
   role?: string;
   organizationId?: string;
-  permissions?: string[];
+  /** From /auth/me: either legacy string[] or object with isAdmin (org admin / owner). */
+  permissions?: string[] | { isAdmin?: boolean; [k: string]: unknown } | null;
+  /** Subset of org from /auth/me (id, name, slug). */
+  organization?: { id: string; name: string; slug: string } | null;
 };
 
 type AuthContextValue = {
@@ -155,17 +159,36 @@ async function fetchMeSingleFlight(): Promise<AuthUser | null> {
         return null;
       }
 
+      const perms = source.permissions as
+        | string[]
+        | { isAdmin?: boolean; [k: string]: unknown }
+        | null
+        | undefined;
+      const orgFromMe = source.organization as
+        | { id?: string; name?: string; slug?: string }
+        | null
+        | undefined;
+
       const normalized: AuthUser = {
         id,
         email: (source.email as string | undefined) || "",
         firstName: (source.firstName as string | null | undefined) ?? null,
         lastName: (source.lastName as string | null | undefined) ?? null,
+        profilePicture: (source.profilePicture as string | null | undefined) ?? null,
         platformRole: (source.platformRole as PlatformRole | undefined) || undefined,
         role: (source.role as string | undefined) || undefined,
         organizationId:
           (source.organizationId as string | undefined) ||
-          ((source.organization as { id?: string } | undefined)?.id ?? undefined),
-        permissions: (source.permissions as string[] | undefined) || undefined,
+          (orgFromMe?.id ?? undefined),
+        permissions: perms ?? undefined,
+        organization:
+          orgFromMe?.id && orgFromMe.name && orgFromMe.slug
+            ? {
+                id: orgFromMe.id,
+                name: orgFromMe.name,
+                slug: orgFromMe.slug,
+              }
+            : null,
       };
 
       return normalized;

--- a/zephix-frontend/src/utils/access.ts
+++ b/zephix-frontend/src/utils/access.ts
@@ -56,6 +56,21 @@ export function canCreateOrgWorkspace(user: UserLike): boolean {
   return isPlatformAdmin(user);
 }
 
+/** True when user can PATCH organization (org owner/admin per /auth/me permissions). */
+export function isOrganizationAdminUser(
+  user:
+    | {
+        permissions?: string[] | { isAdmin?: boolean } | null;
+      }
+    | null
+    | undefined,
+): boolean {
+  if (!user?.permissions || Array.isArray(user.permissions)) {
+    return false;
+  }
+  return user.permissions.isAdmin === true;
+}
+
 // ── Workspace role checks ─────────────────────────────────────────────
 
 export function isWorkspaceOwner(role: string | null | undefined): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## W-A2: Fix Settings Save (Account + Organization)

Workstream A — Critical Fixes.

### Bug

`/settings` **Account** and **Organization** tabs were stubs: uncontrolled inputs, Save only fired telemetry + TODOs. No API calls.

### Root cause

**Scenario C:** Save handlers never wired. Stub fields also mismatched backend (single “Name”, single “Password”, “Invite URL”).

### Fix

**Account — Profile**

- Controlled: First name, Last name, Email (read-only), Profile picture URL.
- Load: `GET /api/auth/profile`.
- Save: `PATCH /api/auth/profile` with **changed fields only**; `refreshMe()` on success; `sonner` toasts; inline errors preserved on failure.
- If `refreshMe` fails after successful PATCH: warning toast.

**Account — Password**

- Current / New / Confirm with client validation (min length 8, match, new ≠ current).
- `POST /api/auth/change-password` with `{ currentPassword, newPassword }`.
- Success: toast + clear password fields only.

**Organization**

- Fields: Name (required 2–255), Website (optional, validated URL if set), Industry, Size (enum dropdown), Description (textarea).
- Load: `GET /api/organizations/:orgId`.
- Save: `PATCH /api/organizations/:orgId` with **diff only**; updates Zustand org list/current org when IDs match.
- **Admin UX:** `permissions.isAdmin === true` from `/auth/me` (`isOrganizationAdminUser`). Non-admins: read-only + message (backend `RolesGuard` still authoritative).

**Auth normalization**

- `/auth/me` payload now keeps `permissions` as object when present and attaches `organization` `{ id, name, slug }` when returned.

### Files

- `src/pages/settings/components/AccountSettings.tsx`
- `src/pages/settings/components/OrganizationSettings.tsx`
- `src/pages/settings/settingsErrors.ts`
- `src/state/AuthContext.tsx`
- `src/utils/access.ts` (`isOrganizationAdminUser`)
- Tests: `AccountSettings.test.tsx`, `OrganizationSettings.test.tsx`, `SettingsPage.test.tsx` (shell)

### Validation

- `npm run typecheck` — pass  
- `npm run build` — pass  
- Vitest: `AccountSettings`, `OrganizationSettings`, `SettingsPage` — pass  

### Manual verification (staging)

1. Account → change first name → Save profile → reload → persists; Network `PATCH /api/auth/profile`.
2. Password → wrong current → error; correct trio → success, fields clear.
3. Org (admin) → change industry → Save → persists; Network `PATCH /api/organizations/:id`.
4. Org (non-admin) → fields disabled + admin-only message.

### Follow-ups (not this PR)

- Profile picture **upload**
- Email change + verification
- Org logo
- `beforeunload` unsaved warning

### Workstream A

- [x] W-A1  
- [x] W-A2 (this PR)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

