### PR TITLE
fix(ci): remove stale lint:new path reference (DashboardPage.tsx)

### DIFF
--- a/zephix-frontend/package.json
+++ b/zephix-frontend/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview --host 0.0.0.0 --port $PORT",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint 'src/**/*.{ts,tsx}' --fix",
-    "lint:new": "eslint 'src/components/ui/button/**/*.{ts,tsx}' 'src/components/ui/input/**/*.{ts,tsx}' 'src/components/ui/card/**/*.{ts,tsx}' 'src/components/ui/feedback/**/*.{ts,tsx}' 'src/components/ui/layout/**/*.{ts,tsx}' 'src/lib/api/**/*.{ts,tsx}' 'src/lib/providers/**/*.{ts,tsx}' 'src/stores/authStore.ts' 'src/stores/uiStore.ts' 'src/pages/projects/ProjectsPage.tsx' 'src/pages/dashboard/DashboardPage.tsx'",
+    "lint:new": "eslint 'src/components/ui/button/**/*.{ts,tsx}' 'src/components/ui/input/**/*.{ts,tsx}' 'src/components/ui/card/**/*.{ts,tsx}' 'src/components/ui/feedback/**/*.{ts,tsx}' 'src/components/ui/layout/**/*.{ts,tsx}' 'src/lib/api/**/*.{ts,tsx}' 'src/lib/providers/**/*.{ts,tsx}' 'src/stores/authStore.ts' 'src/stores/uiStore.ts' 'src/pages/projects/ProjectsPage.tsx'",
     "lint:legacy": "eslint 'src/**/*.{ts,tsx}' --ignore-pattern 'src/components/ui/**' --ignore-pattern 'src/lib/api/**' --ignore-pattern 'src/lib/providers/**' --ignore-pattern 'src/stores/**' --ignore-pattern 'src/pages/projects/ProjectsPage.tsx' --ignore-pattern 'src/pages/dashboard/DashboardPage.tsx'",
     "type-check": "tsc -p tsconfig.app.json --noEmit",
     "typecheck": "tsc -p tsconfig.app.json --noEmit",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
C1 Gates was failing on PRs because `lint:new` referenced a deleted path: `src/pages/dashboard/DashboardPage.tsx`.

## Fix
Removed the stale DashboardPage path from the `lint:new` script in `zephix-frontend/package.json`.

## Verification
- `cd zephix-frontend && npm run lint:new`
- Result: command runs successfully without the prior `No files matching the pattern ... DashboardPage.tsx` failure.
- Existing lint warnings remain unchanged and are out of scope for this CI unblock.

## Scope
- Single-file change (`zephix-frontend/package.json`)
- No CANONICAL/doc changes
- No backend changes

## Unblocks
- Re-running CI on PR #213 after this lands

## What changed
- [x] Pages touched: none
- [x] Components touched: none

## Evidence (attach or link in repo)
- [ ] Bundle stats (dist/stats.html or report excerpt)
- [ ] Lighthouse scores for touched pages
- [x] Lint/new output summary
- [ ] Test summary (foundation set)

## Risk & rollback
- [x] No backend contract changes
- [x] Safe to revert this PR if needed

## Tech debt impact
- [ ] Added items to reports/frontend/LINT_DEBT.md (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6c4d80-2cb1-4c92-ade1-b74a91c8e36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

