### PR TITLE
feat(auth): password reset backend (hashed tokens, session revocation)

### DIFF
--- a/CANONICAL.md
+++ b/CANONICAL.md
@@ -136,6 +136,9 @@ This is the gate for every PR and design decision in this repository.
 - **Location:** `zephix-backend/src/modules/auth/`
 - **Owns:** User auth/session flow (`/auth/*`), profile/password endpoints, sessions, email verification, password reset (`PasswordResetToken` entity, `/auth/forgot-password`, `/auth/reset-password`), org invite auth links.
 - **Deprecated (do not use):** User entity columns `passwordResetToken` and `passwordResetExpires` — superseded by `password_reset_tokens` table (see AD-007). Scheduled for removal in a cleanup PR; application code must not read or write them.
+- **Deprecated entities (scheduled for cleanup PR):**
+  - `users.passwordResetToken` / `users.passwordResetExpires` (replaced by `password_reset_tokens` per AD-007).
+  - `RefreshToken` entity / `refresh_tokens` table — orphaned from the active session model (`auth_sessions` + `current_refresh_token_hash`). Rows are defensively revoked on password reset (see AD-009); drop table/entity after verified empty in staging and production.
 - **Critical infrastructure** — extensive testing required before any changes.
 
 ### 1.18 Workspaces / Organization / Member ✅ CANONICAL
@@ -300,6 +303,12 @@ This is the gate for every PR and design decision in this repository.
 - **Status:** LOCKED (2026-04-29)
 - **Decision:** Query parameter format: `${FRONTEND_URL}/reset-password?token=...`
 - **Rationale:** Common pattern for one-time links; matches `EmailService.sendPasswordResetEmail`; works with `useSearchParams` on the frontend.
+
+### AD-009: Defensive Revocation of Legacy refresh_tokens
+- **Status:** LOCKED (2026-04-29)
+- **Decision:** Password reset defensively revokes rows in legacy `refresh_tokens` for the user (in addition to canonical `auth_sessions` revocation). Wrapped in try/catch — failure does not block password reset.
+- **Rationale:** Active sessions use `auth_sessions` + `current_refresh_token_hash`. The `RefreshToken` entity may reflect legacy deployments; defense-in-depth invalidates any rows that exist.
+- **Cleanup path:** After verifying empty on staging and production, schedule a cleanup PR to drop the entity/table if unused.
 
 ---
 

--- a/CANONICAL.md
+++ b/CANONICAL.md
@@ -134,7 +134,8 @@ This is the gate for every PR and design decision in this repository.
 
 ### 1.17 Auth & Identity ✅ CANONICAL
 - **Location:** `zephix-backend/src/modules/auth/`
-- **Owns:** User auth/session flow (`/auth/*`), profile/password endpoints, sessions, email verification, org invite auth links.
+- **Owns:** User auth/session flow (`/auth/*`), profile/password endpoints, sessions, email verification, password reset (`PasswordResetToken` entity, `/auth/forgot-password`, `/auth/reset-password`), org invite auth links.
+- **Deprecated (do not use):** User entity columns `passwordResetToken` and `passwordResetExpires` — superseded by `password_reset_tokens` table (see AD-007). Scheduled for removal in a cleanup PR; application code must not read or write them.
 - **Critical infrastructure** — extensive testing required before any changes.
 
 ### 1.18 Workspaces / Organization / Member ✅ CANONICAL
@@ -234,6 +235,7 @@ This is the gate for every PR and design decision in this repository.
 ### Auth
 - ✅ CANONICAL: `/auth/*`
 - Subset: `/auth/profile`, `/auth/change-password`, `/auth/sessions/*`
+- ✅ CANONICAL: `POST /auth/forgot-password`, `POST /auth/reset-password` (password reset; public, rate-limited)
 
 ### Organizations
 - ✅ CANONICAL (admin): `/admin/organization/*`
@@ -288,6 +290,16 @@ This is the gate for every PR and design decision in this repository.
 - **Status:** LOCKED
 - **Decision:** While validating Engine A, no new feature work on Engine B.
 - **Rationale:** Prevents “fix scatter” and hidden regressions.
+
+### AD-007: Password Reset Token Storage
+- **Status:** LOCKED (2026-04-29)
+- **Decision:** Dedicated `password_reset_tokens` table with hashed tokens (`TokenHashUtil` pattern). Existing `users.password_reset_token` and `users.password_reset_expires` columns are **DEPRECATED** and scheduled for removal in a future cleanup PR.
+- **Rationale:** Mirrors email verification token handling for consistency. Hashing reduces risk if the database is compromised. Supports single-use tokens and audit-friendly rows.
+
+### AD-008: Reset Token URL Shape
+- **Status:** LOCKED (2026-04-29)
+- **Decision:** Query parameter format: `${FRONTEND_URL}/reset-password?token=...`
+- **Rationale:** Common pattern for one-time links; matches `EmailService.sendPasswordResetEmail`; works with `useSearchParams` on the frontend.
 
 ---
 

--- a/zephix-backend/src/migrations/18000000000075-CreatePasswordResetTokensTable.ts
+++ b/zephix-backend/src/migrations/18000000000075-CreatePasswordResetTokensTable.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Password reset tokens: hashed only, single-use, 1h expiry (enforced in AuthService).
+ * Idempotent: safe to re-run.
+ */
+export class CreatePasswordResetTokensTable18000000000075
+  implements MigrationInterface
+{
+  name = 'CreatePasswordResetTokensTable18000000000075';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "user_id" uuid NOT NULL,
+        "token_hash" character varying(64) NOT NULL,
+        "expires_at" TIMESTAMPTZ NOT NULL,
+        "consumed" boolean NOT NULL DEFAULT false,
+        "consumed_at" TIMESTAMPTZ,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_password_reset_tokens" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_password_reset_tokens_token_hash" UNIQUE ("token_hash"),
+        CONSTRAINT "FK_password_reset_tokens_user" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_password_reset_user_id"
+      ON "password_reset_tokens" ("user_id")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_password_reset_expires_at"
+      ON "password_reset_tokens" ("expires_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_password_reset_expires_at"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_password_reset_user_id"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "password_reset_tokens"`);
+  }
+}

--- a/zephix-backend/src/modules/audit/audit.constants.ts
+++ b/zephix-backend/src/modules/audit/audit.constants.ts
@@ -24,6 +24,7 @@ export enum AuditEntityType {
   BOARD_MOVE = 'board_move',
   USER = 'user',
   EMAIL_VERIFICATION = 'email_verification',
+  PASSWORD_RESET = 'password_reset',
 }
 
 export enum AuditAction {
@@ -51,6 +52,8 @@ export enum AuditAction {
   EMAIL_VERIFIED = 'email_verified',
   EMAIL_VERIFICATION_BYPASSED = 'email_verification_bypassed',
   RESEND_VERIFICATION = 'resend_verification',
+  PASSWORD_RESET_REQUESTED = 'password_reset_requested',
+  PASSWORD_RESET_COMPLETED = 'password_reset_completed',
   GOVERNANCE_EVALUATE = 'governance_evaluate',
   /** Soft-removed to trash / Archive & delete (recoverable) */
   SOFT_REMOVE_TO_TRASH = 'soft_remove_to_trash',

--- a/zephix-backend/src/modules/auth/__tests__/auth.password-reset.spec.ts
+++ b/zephix-backend/src/modules/auth/__tests__/auth.password-reset.spec.ts
@@ -6,19 +6,20 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
-import { AuthService } from './auth.service';
-import { User } from '../users/entities/user.entity';
-import { Organization } from '../../organizations/entities/organization.entity';
-import { UserOrganization } from '../../organizations/entities/user-organization.entity';
-import { AuthSession } from './entities/auth-session.entity';
-import { PasswordResetToken } from './entities/password-reset-token.entity';
-import { Workspace } from '../workspaces/entities/workspace.entity';
+import { AuthService } from '../auth.service';
+import { User } from '../../users/entities/user.entity';
+import { Organization } from '../../../organizations/entities/organization.entity';
+import { UserOrganization } from '../../../organizations/entities/user-organization.entity';
+import { AuthSession } from '../entities/auth-session.entity';
+import { PasswordResetToken } from '../entities/password-reset-token.entity';
+import { RefreshToken } from '../entities/refresh-token.entity';
+import { Workspace } from '../../workspaces/entities/workspace.entity';
 import { JwtService } from '@nestjs/jwt';
-import { EmailService } from '../../shared/services/email.service';
-import { AuditService } from '../audit/services/audit.service';
-import { OrgProvisioningService } from './services/org-provisioning.service';
-import { TokenHashUtil } from '../../common/security/token-hash.util';
-import { AUTH_RATE_LIMIT_STORE } from './tokens';
+import { EmailService } from '../../../shared/services/email.service';
+import { AuditService } from '../../audit/services/audit.service';
+import { OrgProvisioningService } from '../services/org-provisioning.service';
+import { TokenHashUtil } from '../../../common/security/token-hash.util';
+import { AUTH_RATE_LIMIT_STORE } from '../tokens';
 
 /** Test-only in-memory store for per-email password-reset rate limits */
 class MemoryPwdResetRateLimitStore {
@@ -46,7 +47,11 @@ describe('AuthService — password reset', () => {
   let userRepo: jest.Mocked<Partial<Repository<User>>>;
   let pwdResetRepo: jest.Mocked<Partial<Repository<PasswordResetToken>>>;
   let sessionRepo: jest.Mocked<Partial<Repository<AuthSession>>>;
-  let emailService: { sendPasswordResetEmail: jest.Mock };
+  let refreshTokenRepo: jest.Mocked<Partial<Repository<RefreshToken>>>;
+  let emailService: {
+    sendPasswordResetEmail: jest.Mock;
+    sendPasswordChangedNotification: jest.Mock;
+  };
   let auditRecord: jest.Mock;
   let rateLimitStore: MemoryPwdResetRateLimitStore;
   let transactionFn: (cb: (manager: any) => Promise<void>) => Promise<void>;
@@ -55,6 +60,8 @@ describe('AuthService — password reset', () => {
     id: 'user-1',
     email: 'u@example.com',
     organizationId: 'org-1',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
     password: 'old-hash',
   };
 
@@ -72,7 +79,10 @@ describe('AuthService — password reset', () => {
 
   beforeEach(async () => {
     auditRecord = jest.fn().mockResolvedValue(undefined);
-    emailService = { sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined) };
+    emailService = {
+      sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+      sendPasswordChangedNotification: jest.fn().mockResolvedValue(undefined),
+    };
     rateLimitStore = new MemoryPwdResetRateLimitStore();
 
     userRepo = {
@@ -85,6 +95,10 @@ describe('AuthService — password reset', () => {
       create: jest.fn((x) => x),
       save: jest.fn().mockImplementation((x) => Promise.resolve(x)),
       findOne: jest.fn(),
+    };
+
+    refreshTokenRepo = {
+      update: jest.fn().mockResolvedValue({ affected: 0 }),
     };
 
     const qbUpdate = jest.fn().mockReturnThis();
@@ -128,6 +142,7 @@ describe('AuthService — password reset', () => {
           provide: getRepositoryToken(PasswordResetToken),
           useValue: pwdResetRepo,
         },
+        { provide: getRepositoryToken(RefreshToken), useValue: refreshTokenRepo },
         { provide: getRepositoryToken(Workspace), useValue: {} },
         {
           provide: JwtService,
@@ -260,6 +275,88 @@ describe('AuthService — password reset', () => {
       const savedUser = (userRepo.save as jest.Mock).mock.calls[0][0];
       expect(savedUser.password).not.toBe('old-hash');
       expect(sessionRepo.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('revokes legacy refresh_tokens rows for the user during password reset', async () => {
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      const row: any = {
+        tokenHash,
+        consumed: false,
+        user: { ...mockUser },
+        isExpired: () => false,
+      };
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue(row);
+
+      await service.resetPasswordWithToken(raw, 'newpass-word-ok');
+
+      expect(refreshTokenRepo.update).toHaveBeenCalledWith(
+        { user_id: 'user-1', revoked: false },
+        { revoked: true },
+      );
+    });
+
+    it('does not fail password reset if legacy refresh_tokens update throws', async () => {
+      refreshTokenRepo.update = jest
+        .fn()
+        .mockRejectedValue(new Error('relation "refresh_tokens" does not exist'));
+
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      const row: any = {
+        tokenHash,
+        consumed: false,
+        user: { ...mockUser },
+        isExpired: () => false,
+      };
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue(row);
+
+      await expect(
+        service.resetPasswordWithToken(raw, 'newpass-word-ok'),
+      ).resolves.toBeUndefined();
+
+      expect(userRepo.save).toHaveBeenCalled();
+    });
+
+    it('sends password changed notification email after successful reset', async () => {
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      const row: any = {
+        tokenHash,
+        consumed: false,
+        user: { ...mockUser },
+        isExpired: () => false,
+      };
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue(row);
+
+      await service.resetPasswordWithToken(raw, 'newpass-word-ok');
+
+      expect(emailService.sendPasswordChangedNotification).toHaveBeenCalledWith(
+        'u@example.com',
+        'Ada Lovelace',
+      );
+    });
+
+    it('does not fail password reset if notification email fails', async () => {
+      emailService.sendPasswordChangedNotification = jest
+        .fn()
+        .mockRejectedValue(new Error('SendGrid unavailable'));
+
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      const row: any = {
+        tokenHash,
+        consumed: false,
+        user: { ...mockUser },
+        isExpired: () => false,
+      };
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue(row);
+
+      await expect(
+        service.resetPasswordWithToken(raw, 'newpass-word-ok'),
+      ).resolves.toBeUndefined();
+
+      expect(emailService.sendPasswordChangedNotification).toHaveBeenCalled();
     });
   });
 });

--- a/zephix-backend/src/modules/auth/auth-security-guards.spec.ts
+++ b/zephix-backend/src/modules/auth/auth-security-guards.spec.ts
@@ -52,6 +52,16 @@ describe('AuthController — Security Guard Enforcement', () => {
     expect(guards).toContain(RateLimiterGuard);
   });
 
+  it('POST /auth/forgot-password has RateLimiterGuard', () => {
+    const guards = getMethodGuards(proto, 'forgotPassword');
+    expect(guards).toContain(RateLimiterGuard);
+  });
+
+  it('POST /auth/reset-password has RateLimiterGuard', () => {
+    const guards = getMethodGuards(proto, 'postResetPassword');
+    expect(guards).toContain(RateLimiterGuard);
+  });
+
   // ── Authenticated endpoints MUST have guard enforcement ────────────────
 
   it('GET /auth/me has OptionalJwtAuthGuard', () => {

--- a/zephix-backend/src/modules/auth/auth.controller.ts
+++ b/zephix-backend/src/modules/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import {
   BadRequestException,
   HttpCode,
   HttpStatus,
+  SetMetadata,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -50,6 +51,8 @@ import { isStagingRuntime } from '../../common/utils/runtime-env';
 import { randomBytes } from 'crypto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { formatResponse } from '../../shared/helpers/response.helper';
 import type {
   Request as ExpressRequest,
@@ -229,6 +232,39 @@ export class AuthController {
       message:
         'If an account with this email exists, you will receive a verification email.',
     };
+  }
+
+  /**
+   * POST /api/auth/forgot-password
+   *
+   * Neutral response (no account enumeration). Rate limited (IP + per-email when store configured).
+   */
+  @Post('forgot-password')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RateLimiterGuard)
+  @SetMetadata('rateLimit', { windowMs: 900000, max: 3 })
+  @ApiOperation({ summary: 'Request password reset email' })
+  async forgotPassword(
+    @Body() dto: ForgotPasswordDto,
+  ): Promise<{ ok: boolean }> {
+    await this.authService.requestPasswordReset(dto.email);
+    return { ok: true };
+  }
+
+  /**
+   * POST /api/auth/reset-password
+   *
+   * Completes reset with token from email link; revokes all sessions for the user.
+   */
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RateLimiterGuard)
+  @ApiOperation({ summary: 'Reset password using email token' })
+  async postResetPassword(
+    @Body() dto: ResetPasswordDto,
+  ): Promise<{ ok: boolean }> {
+    await this.authService.resetPasswordWithToken(dto.token, dto.newPassword);
+    return { ok: true };
   }
 
   /**

--- a/zephix-backend/src/modules/auth/auth.module.ts
+++ b/zephix-backend/src/modules/auth/auth.module.ts
@@ -28,6 +28,7 @@ import { OrgInvite } from './entities/org-invite.entity';
 import { OrgInviteWorkspaceAssignment } from './entities/org-invite-workspace-assignment.entity';
 import { AuthOutbox } from './entities/auth-outbox.entity';
 import { AuthSession } from './entities/auth-session.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { EmailService } from '../../shared/services/email.service';
 import { SessionsController } from './controllers/sessions.controller';
@@ -53,6 +54,7 @@ import { UserSettings } from '../users/entities/user-settings.entity';
       OrgInviteWorkspaceAssignment,
       AuthOutbox,
       AuthSession,
+      RefreshToken,
       UserSettings,
     ]),
     PassportModule.register({ defaultStrategy: 'jwt' }),

--- a/zephix-backend/src/modules/auth/auth.module.ts
+++ b/zephix-backend/src/modules/auth/auth.module.ts
@@ -23,6 +23,7 @@ import { UserOrganization } from '../../organizations/entities/user-organization
 import { Workspace } from '../workspaces/entities/workspace.entity';
 import { WorkspaceMember } from '../workspaces/entities/workspace-member.entity';
 import { EmailVerificationToken } from './entities/email-verification-token.entity';
+import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { OrgInvite } from './entities/org-invite.entity';
 import { OrgInviteWorkspaceAssignment } from './entities/org-invite-workspace-assignment.entity';
 import { AuthOutbox } from './entities/auth-outbox.entity';
@@ -47,6 +48,7 @@ import { UserSettings } from '../users/entities/user-settings.entity';
       Workspace,
       WorkspaceMember,
       EmailVerificationToken,
+      PasswordResetToken,
       OrgInvite,
       OrgInviteWorkspaceAssignment,
       AuthOutbox,

--- a/zephix-backend/src/modules/auth/auth.password-reset.spec.ts
+++ b/zephix-backend/src/modules/auth/auth.password-reset.spec.ts
@@ -1,0 +1,265 @@
+import {
+  BadRequestException,
+  HttpException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { AuthService } from './auth.service';
+import { User } from '../users/entities/user.entity';
+import { Organization } from '../../organizations/entities/organization.entity';
+import { UserOrganization } from '../../organizations/entities/user-organization.entity';
+import { AuthSession } from './entities/auth-session.entity';
+import { PasswordResetToken } from './entities/password-reset-token.entity';
+import { Workspace } from '../workspaces/entities/workspace.entity';
+import { JwtService } from '@nestjs/jwt';
+import { EmailService } from '../../shared/services/email.service';
+import { AuditService } from '../audit/services/audit.service';
+import { OrgProvisioningService } from './services/org-provisioning.service';
+import { TokenHashUtil } from '../../common/security/token-hash.util';
+import { AUTH_RATE_LIMIT_STORE } from './tokens';
+
+/** Test-only in-memory store for per-email password-reset rate limits */
+class MemoryPwdResetRateLimitStore {
+  private hits = new Map<string, number>();
+
+  async hit(
+    key: string,
+    _windowSeconds: number,
+    limit: number,
+  ): Promise<{ allowed: boolean; remaining: number }> {
+    const n = (this.hits.get(key) ?? 0) + 1;
+    this.hits.set(key, n);
+    return {
+      allowed: n <= limit,
+      remaining: Math.max(0, limit - n),
+    };
+  }
+}
+
+describe('AuthService — password reset', () => {
+  const OLD_TOKEN_SECRET = process.env.TOKEN_HASH_SECRET;
+  const OLD_PEPPER = process.env.REFRESH_TOKEN_PEPPER;
+
+  let service: AuthService;
+  let userRepo: jest.Mocked<Partial<Repository<User>>>;
+  let pwdResetRepo: jest.Mocked<Partial<Repository<PasswordResetToken>>>;
+  let sessionRepo: jest.Mocked<Partial<Repository<AuthSession>>>;
+  let emailService: { sendPasswordResetEmail: jest.Mock };
+  let auditRecord: jest.Mock;
+  let rateLimitStore: MemoryPwdResetRateLimitStore;
+  let transactionFn: (cb: (manager: any) => Promise<void>) => Promise<void>;
+
+  const mockUser: Partial<User> = {
+    id: 'user-1',
+    email: 'u@example.com',
+    organizationId: 'org-1',
+    password: 'old-hash',
+  };
+
+  beforeAll(() => {
+    process.env.TOKEN_HASH_SECRET =
+      '01234567890123456789012345678901'; // 32 chars
+    process.env.REFRESH_TOKEN_PEPPER =
+      '01234567890123456789012345678901';
+  });
+
+  afterAll(() => {
+    process.env.TOKEN_HASH_SECRET = OLD_TOKEN_SECRET;
+    process.env.REFRESH_TOKEN_PEPPER = OLD_PEPPER;
+  });
+
+  beforeEach(async () => {
+    auditRecord = jest.fn().mockResolvedValue(undefined);
+    emailService = { sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined) };
+    rateLimitStore = new MemoryPwdResetRateLimitStore();
+
+    userRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+
+    pwdResetRepo = {
+      update: jest.fn().mockResolvedValue({ affected: 0 }),
+      create: jest.fn((x) => x),
+      save: jest.fn().mockImplementation((x) => Promise.resolve(x)),
+      findOne: jest.fn(),
+    };
+
+    const qbUpdate = jest.fn().mockReturnThis();
+    const qbWhere = jest.fn().mockReturnThis();
+    const qbAndWhere = jest.fn().mockReturnThis();
+    const qbExecute = jest.fn().mockResolvedValue({ affected: 2 });
+    sessionRepo = {
+      createQueryBuilder: jest.fn(() => ({
+        update: qbUpdate,
+        set: jest.fn().mockReturnThis(),
+        where: qbWhere,
+        andWhere: qbAndWhere,
+        execute: qbExecute,
+      })),
+    };
+
+    transactionFn = async (cb: (manager: any) => Promise<void>) => {
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === PasswordResetToken) return pwdResetRepo;
+          if (entity === User) return userRepo;
+          if (entity === AuthSession) return sessionRepo;
+          throw new Error('unexpected entity');
+        },
+      };
+      await cb(manager);
+    };
+
+    const dataSource = {
+      transaction: jest.fn((fn: any) => transactionFn(fn)),
+    } as unknown as DataSource;
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Organization), useValue: {} },
+        { provide: getRepositoryToken(UserOrganization), useValue: {} },
+        { provide: getRepositoryToken(AuthSession), useValue: sessionRepo },
+        {
+          provide: getRepositoryToken(PasswordResetToken),
+          useValue: pwdResetRepo,
+        },
+        { provide: getRepositoryToken(Workspace), useValue: {} },
+        {
+          provide: JwtService,
+          useValue: { sign: jest.fn(), verify: jest.fn() },
+        },
+        { provide: DataSource, useValue: dataSource },
+        { provide: EmailService, useValue: emailService },
+        {
+          provide: AUTH_RATE_LIMIT_STORE,
+          useValue: rateLimitStore,
+        },
+        {
+          provide: AuditService,
+          useValue: { record: auditRecord },
+        },
+        {
+          provide: OrgProvisioningService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    service = moduleRef.get(AuthService);
+  });
+
+  describe('requestPasswordReset', () => {
+    it('returns silently when email not found', async () => {
+      userRepo.findOne = jest.fn().mockResolvedValue(null);
+      await service.requestPasswordReset('missing@example.com');
+      expect(emailService.sendPasswordResetEmail).not.toHaveBeenCalled();
+    });
+
+    it('stores hashed token and sends email', async () => {
+      userRepo.findOne = jest.fn().mockResolvedValue(mockUser);
+      await service.requestPasswordReset('u@example.com');
+
+      expect(pwdResetRepo.save).toHaveBeenCalled();
+      const saved = (pwdResetRepo.save as jest.Mock).mock.calls[0][0];
+      expect(saved.tokenHash).toBeDefined();
+      expect(saved.tokenHash).not.toEqual(expect.stringContaining('.')); // not raw base64url
+      expect(emailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+        'u@example.com',
+        expect.any(String),
+      );
+      const raw = emailService.sendPasswordResetEmail.mock.calls[0][1];
+      expect(TokenHashUtil.hashToken(raw)).toBe(saved.tokenHash);
+    });
+
+    it('invalidates prior unconsumed tokens via update', async () => {
+      userRepo.findOne = jest.fn().mockResolvedValue(mockUser);
+      await service.requestPasswordReset('u@example.com');
+      expect(pwdResetRepo.update).toHaveBeenCalledWith(
+        { userId: 'user-1', consumed: false },
+        expect.objectContaining({ consumed: true }),
+      );
+    });
+
+    it('throws 429 after email rate limit exceeded', async () => {
+      userRepo.findOne = jest.fn().mockResolvedValue(mockUser);
+      await service.requestPasswordReset('u@example.com');
+      await service.requestPasswordReset('u@example.com');
+      await service.requestPasswordReset('u@example.com');
+      await expect(service.requestPasswordReset('u@example.com')).rejects.toThrow(
+        HttpException,
+      );
+    });
+  });
+
+  describe('resetPasswordWithToken', () => {
+    it('rejects weak password', async () => {
+      await expect(
+        service.resetPasswordWithToken('any', 'short'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects invalid token hash', async () => {
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue(null);
+      await expect(
+        service.resetPasswordWithToken(
+          TokenHashUtil.generateRawToken(),
+          'newpass-word-ok',
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects consumed token', async () => {
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue({
+        tokenHash,
+        consumed: true,
+        user: mockUser,
+        isExpired: () => false,
+      });
+      await expect(
+        service.resetPasswordWithToken(raw, 'newpass-word-ok'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects expired token', async () => {
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue({
+        tokenHash,
+        consumed: false,
+        user: mockUser,
+        isExpired: () => true,
+      });
+      await expect(
+        service.resetPasswordWithToken(raw, 'newpass-word-ok'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('updates password, consumes token, revokes sessions', async () => {
+      const raw = TokenHashUtil.generateRawToken();
+      const tokenHash = TokenHashUtil.hashToken(raw);
+      const row: any = {
+        tokenHash,
+        consumed: false,
+        user: { ...mockUser },
+        isExpired: () => false,
+      };
+      pwdResetRepo.findOne = jest.fn().mockResolvedValue(row);
+
+      await service.resetPasswordWithToken(raw, 'newpass-word-ok');
+
+      expect(row.consumed).toBe(true);
+      expect(row.consumedAt).toBeInstanceOf(Date);
+      expect(userRepo.save).toHaveBeenCalled();
+      const savedUser = (userRepo.save as jest.Mock).mock.calls[0][0];
+      expect(savedUser.password).not.toBe('old-hash');
+      expect(sessionRepo.createQueryBuilder).toHaveBeenCalled();
+    });
+  });
+});

--- a/zephix-backend/src/modules/auth/auth.service.ts
+++ b/zephix-backend/src/modules/auth/auth.service.ts
@@ -28,6 +28,7 @@ import { Organization } from '../../organizations/entities/organization.entity';
 import { UserOrganization } from '../../organizations/entities/user-organization.entity';
 import { AuthSession } from './entities/auth-session.entity';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
 import { Workspace } from '../workspaces/entities/workspace.entity';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
@@ -64,6 +65,8 @@ export class AuthService {
     private authSessionRepository: Repository<AuthSession>,
     @InjectRepository(PasswordResetToken)
     private passwordResetTokenRepository: Repository<PasswordResetToken>,
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepository: Repository<RefreshToken>,
     @InjectRepository(Workspace)
     private workspaceRepository: Repository<Workspace>,
     private jwtService: JwtService,
@@ -913,6 +916,8 @@ export class AuthService {
 
     let auditUserId: string | null = null;
     let auditOrganizationId: string | null = null;
+    let notifyEmail: string | null = null;
+    let notifyDisplayName: string | undefined;
 
     await this.dataSource.transaction(async (manager) => {
       const tokenRepo = manager.getRepository(PasswordResetToken);
@@ -935,6 +940,10 @@ export class AuthService {
 
       auditUserId = user.id;
       auditOrganizationId = user.organizationId ?? null;
+      notifyEmail = user.email;
+      notifyDisplayName =
+        [user.firstName, user.lastName].filter(Boolean).join(' ').trim() ||
+        undefined;
 
       user.password = await bcrypt.hash(newPassword, 10);
       await userRepo.save(user);
@@ -956,6 +965,21 @@ export class AuthService {
         .execute();
     });
 
+    if (auditUserId) {
+      try {
+        await this.refreshTokenRepository.update(
+          { user_id: auditUserId, revoked: false },
+          { revoked: true },
+        );
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          'Legacy refresh_tokens revocation skipped (table missing or schema mismatch)',
+          { userId: auditUserId, error: message },
+        );
+      }
+    }
+
     if (this.auditService && auditUserId && auditOrganizationId) {
       await this.auditService.record({
         organizationId: auditOrganizationId,
@@ -974,5 +998,20 @@ export class AuthService {
       action: 'password_reset_completed',
       userId: auditUserId,
     });
+
+    if (notifyEmail) {
+      try {
+        await this.emailService.sendPasswordChangedNotification(
+          notifyEmail,
+          notifyDisplayName,
+        );
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error('Failed to send password changed notification', {
+          userId: auditUserId,
+          error: message,
+        });
+      }
+    }
   }
 }

--- a/zephix-backend/src/modules/auth/auth.service.ts
+++ b/zephix-backend/src/modules/auth/auth.service.ts
@@ -16,6 +16,8 @@ import {
   BadRequestException,
   ForbiddenException,
   NotFoundException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -25,6 +27,7 @@ import { User } from '../users/entities/user.entity'; // Fixed path
 import { Organization } from '../../organizations/entities/organization.entity';
 import { UserOrganization } from '../../organizations/entities/user-organization.entity';
 import { AuthSession } from './entities/auth-session.entity';
+import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { Workspace } from '../workspaces/entities/workspace.entity';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
@@ -44,6 +47,7 @@ import type { AuthRateLimitStore } from './services/auth-rate-limit-store';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { OrgProvisioningService } from './services/org-provisioning.service';
+import { EmailService } from '../../shared/services/email.service';
 
 @Injectable()
 export class AuthService {
@@ -58,10 +62,13 @@ export class AuthService {
     private userOrgRepository: Repository<UserOrganization>,
     @InjectRepository(AuthSession)
     private authSessionRepository: Repository<AuthSession>,
+    @InjectRepository(PasswordResetToken)
+    private passwordResetTokenRepository: Repository<PasswordResetToken>,
     @InjectRepository(Workspace)
     private workspaceRepository: Repository<Workspace>,
     private jwtService: JwtService,
     private dataSource: DataSource,
+    private readonly emailService: EmailService,
     @Optional()
     @Inject(AUTH_RATE_LIMIT_STORE)
     private readonly rateLimitStore: AuthRateLimitStore | null,
@@ -806,5 +813,166 @@ export class AuthService {
     await this.userRepository.save(user);
 
     return { message: 'Password updated successfully' };
+  }
+
+  private static readonly PASSWORD_RESET_EMAIL_RATE_WINDOW_SEC = 15 * 60;
+  private static readonly PASSWORD_RESET_EMAIL_RATE_LIMIT = 3;
+
+  /**
+   * Initiate password reset. Neutral to callers (no enumeration).
+   * Per-email rate limit: 3 / 15 minutes when AUTH_RATE_LIMIT_STORE is configured.
+   */
+  async requestPasswordReset(email: string): Promise<void> {
+    const normalizedEmail = email.toLowerCase().trim();
+
+    if (this.rateLimitStore) {
+      const emailKey = createHash('sha256')
+        .update(normalizedEmail)
+        .digest('hex');
+      const key = `pwd_reset_email:${emailKey}`;
+      const hit = await this.rateLimitStore.hit(
+        key,
+        AuthService.PASSWORD_RESET_EMAIL_RATE_WINDOW_SEC,
+        AuthService.PASSWORD_RESET_EMAIL_RATE_LIMIT,
+      );
+      if (!hit.allowed) {
+        throw new HttpException(
+          {
+            message: 'Too many password reset requests for this email. Please try again later.',
+            retryAfter: AuthService.PASSWORD_RESET_EMAIL_RATE_WINDOW_SEC,
+          },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+    }
+
+    const user = await this.userRepository.findOne({
+      where: { email: normalizedEmail },
+    });
+    if (!user) {
+      return;
+    }
+
+    const rawToken = TokenHashUtil.generateRawToken();
+    const tokenHash = TokenHashUtil.hashToken(rawToken);
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+
+    await this.dataSource.transaction(async (manager) => {
+      const tokenRepo = manager.getRepository(PasswordResetToken);
+      await tokenRepo.update(
+        { userId: user.id, consumed: false },
+        { consumed: true, consumedAt: new Date() },
+      );
+
+      const row = tokenRepo.create({
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+        consumed: false,
+        consumedAt: null,
+      });
+      await tokenRepo.save(row);
+    });
+
+    await this.emailService.sendPasswordResetEmail(user.email, rawToken);
+
+    if (this.auditService && user.organizationId) {
+      await this.auditService.record({
+        organizationId: user.organizationId,
+        actorUserId: user.id,
+        actorPlatformRole: 'ADMIN',
+        entityType: AuditEntityType.PASSWORD_RESET,
+        entityId: user.id,
+        action: AuditAction.PASSWORD_RESET_REQUESTED,
+        after: {},
+        ipAddress: undefined,
+        userAgent: undefined,
+      });
+    }
+
+    this.logger.log({
+      action: 'password_reset_requested',
+      userId: user.id,
+    });
+  }
+
+  /**
+   * Complete password reset; revokes all auth sessions for the user.
+   */
+  async resetPasswordWithToken(rawToken: string, newPassword: string): Promise<void> {
+    const trimmed = typeof rawToken === 'string' ? rawToken.trim() : '';
+    if (!trimmed) {
+      throw new UnauthorizedException('Invalid or expired reset token');
+    }
+
+    if (newPassword.length < 8) {
+      throw new BadRequestException('Password must be at least 8 characters long');
+    }
+
+    const tokenHash = TokenHashUtil.hashToken(trimmed);
+
+    let auditUserId: string | null = null;
+    let auditOrganizationId: string | null = null;
+
+    await this.dataSource.transaction(async (manager) => {
+      const tokenRepo = manager.getRepository(PasswordResetToken);
+      const userRepo = manager.getRepository(User);
+      const sessionRepo = manager.getRepository(AuthSession);
+
+      const row = await tokenRepo.findOne({
+        where: { tokenHash },
+        relations: ['user'],
+      });
+
+      if (!row || row.consumed || row.isExpired()) {
+        throw new UnauthorizedException('Invalid or expired reset token');
+      }
+
+      const user = row.user;
+      if (!user) {
+        throw new UnauthorizedException('Invalid or expired reset token');
+      }
+
+      auditUserId = user.id;
+      auditOrganizationId = user.organizationId ?? null;
+
+      user.password = await bcrypt.hash(newPassword, 10);
+      await userRepo.save(user);
+
+      row.consumed = true;
+      row.consumedAt = new Date();
+      await tokenRepo.save(row);
+
+      await sessionRepo
+        .createQueryBuilder()
+        .update(AuthSession)
+        .set({
+          revokedAt: new Date(),
+          revokeReason: 'password_reset',
+          currentRefreshTokenHash: null,
+        })
+        .where('user_id = :userId', { userId: user.id })
+        .andWhere('revoked_at IS NULL')
+        .execute();
+    });
+
+    if (this.auditService && auditUserId && auditOrganizationId) {
+      await this.auditService.record({
+        organizationId: auditOrganizationId,
+        actorUserId: auditUserId,
+        actorPlatformRole: 'ADMIN',
+        entityType: AuditEntityType.PASSWORD_RESET,
+        entityId: auditUserId,
+        action: AuditAction.PASSWORD_RESET_COMPLETED,
+        after: {},
+        ipAddress: undefined,
+        userAgent: undefined,
+      });
+    }
+
+    this.logger.log({
+      action: 'password_reset_completed',
+      userId: auditUserId,
+    });
   }
 }

--- a/zephix-backend/src/modules/auth/dto/reset-password.dto.ts
+++ b/zephix-backend/src/modules/auth/dto/reset-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, MinLength, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordDto {
+  @ApiProperty({ description: 'Raw token from the password reset email link' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @ApiProperty({ description: 'New password (min 8 characters)' })
+  @IsString()
+  @MinLength(8)
+  @MaxLength(128)
+  newPassword: string;
+}

--- a/zephix-backend/src/modules/auth/entities/password-reset-token.entity.ts
+++ b/zephix-backend/src/modules/auth/entities/password-reset-token.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Hashed password reset tokens (raw token never stored).
+ * Single-use; expires after 1 hour (enforced in service).
+ */
+@Entity('password_reset_tokens')
+@Index('IDX_password_reset_token_hash', ['tokenHash'], { unique: true })
+@Index('IDX_password_reset_user_id', ['userId'])
+@Index('IDX_password_reset_expires_at', ['expiresAt'])
+export class PasswordResetToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'token_hash', type: 'varchar', length: 64, unique: true })
+  tokenHash: string;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ name: 'consumed', type: 'boolean', default: false })
+  consumed: boolean;
+
+  @Column({ name: 'consumed_at', type: 'timestamptz', nullable: true })
+  consumedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  isExpired(): boolean {
+    return new Date() > this.expiresAt;
+  }
+}

--- a/zephix-backend/src/modules/auth/entities/refresh-token.entity.ts
+++ b/zephix-backend/src/modules/auth/entities/refresh-token.entity.ts
@@ -3,6 +3,7 @@ import {
   Column,
   PrimaryGeneratedColumn,
   ManyToOne,
+  JoinColumn,
   CreateDateColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
@@ -12,10 +13,11 @@ export class RefreshToken {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
+  @Column({ name: 'user_id' })
   user_id: string;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
   user: User;
 
   @Column({ unique: true })

--- a/zephix-backend/src/modules/auth/guards/csrf.guard.spec.ts
+++ b/zephix-backend/src/modules/auth/guards/csrf.guard.spec.ts
@@ -28,6 +28,16 @@ describe('CsrfGuard', () => {
     expect(guard.canActivate(ctx)).toBe(true);
   });
 
+  it('allows POST /api/auth/forgot-password without CSRF (public reset request)', () => {
+    const ctx = mockContext('POST', '/api/auth/forgot-password', undefined, {});
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('allows POST /api/auth/reset-password without CSRF (public token flow)', () => {
+    const ctx = mockContext('POST', '/api/auth/reset-password', undefined, {});
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
   it('allows POST /api/auth/organization/signup without CSRF', () => {
     const ctx = mockContext('POST', '/api/auth/organization/signup', undefined, {});
     expect(guard.canActivate(ctx)).toBe(true);

--- a/zephix-backend/src/modules/auth/guards/csrf.guard.ts
+++ b/zephix-backend/src/modules/auth/guards/csrf.guard.ts
@@ -33,6 +33,8 @@ export class CsrfGuard implements CanActivate {
       path.includes('/auth/register') ||
       path.includes('/auth/signup') ||
       path.includes('/auth/resend-verification') ||
+      path.includes('/auth/forgot-password') ||
+      path.includes('/auth/reset-password') ||
       path.includes('/auth/organization/signup') ||
       path.includes('/auth/refresh') ||
       path.includes('/auth/csrf') ||

--- a/zephix-backend/src/shared/services/email.service.ts
+++ b/zephix-backend/src/shared/services/email.service.ts
@@ -224,6 +224,62 @@ export class EmailService {
     });
   }
 
+  /**
+   * Security notification after password change (reset or in-app).
+   * Uses same SendGrid gate as other transactional emails.
+   */
+  async sendPasswordChangedNotification(
+    email: string,
+    displayName?: string,
+  ): Promise<void> {
+    const support =
+      process.env.ZEPHIX_SUPPORT_EMAIL ||
+      process.env.SUPPORT_EMAIL ||
+      'support@zephix.dev';
+    const greeting = displayName?.trim()
+      ? `Hi ${displayName.trim()},`
+      : 'Hello,';
+
+    const html = `
+      <!DOCTYPE html>
+      <html>
+      <head><meta charset="utf-8"><title>Password changed</title></head>
+      <body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+        <table align="center" width="600" style="margin: 20px auto; background: white; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.08);">
+          <tr>
+            <td style="padding: 32px 28px; text-align: center; background: linear-gradient(135deg, #5850EC 0%, #6366F1 100%); border-radius: 8px 8px 0 0;">
+              <h1 style="margin: 0; color: white; font-size: 22px;">Your password was changed</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 36px 28px;">
+              <p style="margin: 0 0 16px; color: #1F2937; font-size: 16px;">${greeting}</p>
+              <p style="margin: 0 0 20px; color: #4B5563; font-size: 15px; line-height: 1.5;">
+                Your Zephix account password was just changed. If this was you, no action is needed.
+              </p>
+              <p style="margin: 0 0 24px; color: #4B5563; font-size: 15px; line-height: 1.5;">
+                If you did not change your password, contact support immediately at
+                <a href="mailto:${support}" style="color: #5850EC;">${support}</a>.
+              </p>
+              <hr style="margin: 24px 0; border: none; border-top: 1px solid #E5E7EB;">
+              <p style="margin: 0; color: #9CA3AF; font-size: 12px;">
+                This is an automated security notification from Zephix.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </body>
+      </html>
+    `;
+
+    await this.sendEmail({
+      to: email,
+      subject: 'Your Zephix password was changed',
+      html,
+      text: `Your Zephix password was changed. If this was not you, contact ${support} immediately.`,
+    });
+  }
+
   async sendLoginAlertEmail(
     email: string,
     ipAddress: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Amendment: Defensive refresh_tokens revocation + notification email

Per architect decision (enterprise security standard):

1. **Defensive refresh_tokens revocation** — Password reset now also revokes any rows in legacy `refresh_tokens` for the user (`revoked: true` where `user_id` matches and `revoked` was false). Wrapped in try/catch (table may be empty or schema may differ). Closes potential gap if legacy rows exist. **AD-009** logged in CANONICAL.md.

2. **Post-reset notification email** — After successful reset, the user receives “your password was changed” via `EmailService.sendPasswordChangedNotification` (best-effort; errors are logged and do not roll back the reset).

Both behaviors are covered in `src/modules/auth/__tests__/auth.password-reset.spec.ts`.

**Entity fix:** `RefreshToken` now maps `user_id` with `@JoinColumn` for correct TypeORM queries.

---

## Build: Password Reset Backend (Engine 1 sub-stream)

**Sub-stream:** Password Reset Build (within Engine 1: Auth & Identity validation)
**Sequence:** Pre-validation gap closure — completes partial implementation 
discovered in pre-validation report.

### What this PR does

Builds the backend half of password reset functionality. Frontend follows 
in PR Build-2 after this merges and is verified.

### Architectural decisions (locked in this PR)

- **AD-007:** Dedicated `password_reset_tokens` table with hashed tokens. 
  User entity columns `passwordResetToken`/`passwordResetExpires` deprecated.
- **AD-008:** Query parameter URL format `?token=...`
- **AD-009:** Defensive legacy `refresh_tokens` revocation on password reset.

### Files Added
- `password-reset-token.entity.ts`
- Migration: `18000000000075-CreatePasswordResetTokens.ts`
- `reset-password.dto.ts`
- Test files under `__tests__/`

### Files Modified
- `auth.service.ts` (added requestPasswordReset, resetPasswordWithToken methods)
- `auth.controller.ts` (added /forgot-password, /reset-password endpoints)
- `auth.module.ts` (registered PasswordResetToken entity, RefreshToken for revocation)
- `email.service.ts` — `sendPasswordChangedNotification`
- `refresh-token.entity.ts` — column mapping for `user_id`
- `CANONICAL.md` (Section 1.17, Section 3, AD-007, AD-008, AD-009)

### Files NOT Modified (intentional)
- `user.entity.ts` (deprecated columns left in place — separate cleanup PR later)
- Any frontend file (separate PR Build-2 follows)

### Security properties
- Tokens cryptographically random (32+ bytes)
- Tokens hashed in storage (TokenHashUtil)
- Tokens single-use (consumed flag)
- Tokens expire in 1 hour
- No enumeration (forgot-password always returns ok: true)
- Rate limited (IP guard + optional per-email store when wired)
- Successful reset invalidates all sessions + legacy refresh_tokens rows (defensive)

### Manual verification (Adi to run after deploy)

1. POST /api/auth/forgot-password with valid signed-up email → email arrives
2. POST /api/auth/forgot-password with non-existent email → returns ok, no email
3. Click email link → contains valid token in query param
4. POST /api/auth/reset-password with valid token + new password → success
5. POST /api/auth/reset-password with same token again → rejected
6. POST /api/auth/reset-password with expired token → rejected
7. After successful reset: existing sessions invalidated (try refresh); notification email received
8. Login with new password works

### Tests
- See `auth.password-reset.spec.ts`
- All existing tests pass

### Sub-stream status
- [x] Backend complete (this PR)
- [ ] Frontend (PR Build-2 follows)
- [ ] End-to-end verified
- [ ] Section E in Engine 1 framework reactivates as testable

### Post-merge
After this merges and Adi confirms backend works (manual curl verification), 
Cursor opens PR Build-2 for the frontend.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fe52246-65d1-4c1b-8950-89e6a21e451f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fe52246-65d1-4c1b-8950-89e6a21e451f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

