### PR TITLE
cleanup: Engine 1 — orphan token fix + pm org-role migration to member (AD-011)

### DIFF
--- a/zephix-backend/scripts/sanity-check-guard.ts
+++ b/zephix-backend/scripts/sanity-check-guard.ts
@@ -43,7 +43,7 @@ const testUsers: TestUser[] = [
   {
     email: 'member@zephix.ai',
     password: 'member123456',
-    expectedRole: 'pm',
+    expectedRole: 'MEMBER',
     expectedOrgRole: 'project_manager',
   },
   {

--- a/zephix-backend/scripts/setup-tester-org.ts
+++ b/zephix-backend/scripts/setup-tester-org.ts
@@ -100,7 +100,7 @@ async function setupTesterOrg() {
         firstName: 'Tester',
         lastName: 'Member',
         role: 'member',
-        orgRole: 'pm',
+        orgRole: 'member',
       },
       {
         email: 'tester-viewer@zephix.ai',

--- a/zephix-backend/src/admin/admin.controller.ts
+++ b/zephix-backend/src/admin/admin.controller.ts
@@ -569,12 +569,10 @@ export class AdminController {
       const { organizationId, userId: currentUserId } = getAuthContext(req);
       // TODO: Implement full user update logic
       if (body.role) {
-        // Map 'member' to 'pm' for backend compatibility
-        const backendRole = body.role === 'member' ? 'pm' : body.role;
         await this.organizationsService.updateUserRole(
           organizationId,
           userId,
-          backendRole,
+          body.role,
           currentUserId,
         );
       }
@@ -618,12 +616,10 @@ export class AdminController {
   ) {
     try {
       const { organizationId, userId: currentUserId } = getAuthContext(req);
-      // Map 'member' to 'pm' for backend compatibility
-      const backendRole = body.role === 'member' ? 'pm' : body.role;
       await this.organizationsService.updateUserRole(
         organizationId,
         userId,
-        backendRole,
+        body.role,
         currentUserId,
       );
       return { message: 'User role updated successfully' };

--- a/zephix-backend/src/admin/modules/organization/organization.controller.ts
+++ b/zephix-backend/src/admin/modules/organization/organization.controller.ts
@@ -139,7 +139,7 @@ export class OrganizationAdminController {
           email: 'pm@zephix.ai',
           firstName: 'Project',
           lastName: 'Manager',
-          role: 'pm',
+          role: 'member',
           status: 'active',
           lastActive: new Date(),
           joinedAt: new Date('2024-01-15'),
@@ -217,7 +217,7 @@ export class OrganizationAdminController {
           isCustom: false,
         },
         {
-          name: 'pm',
+          name: 'member',
           description: 'Project management access',
           permissions: ['projects.manage', 'templates.view', 'reports.view'],
           userCount: 15,

--- a/zephix-backend/src/bootstrap/demo-bootstrap.service.ts
+++ b/zephix-backend/src/bootstrap/demo-bootstrap.service.ts
@@ -26,7 +26,7 @@ export class DemoBootstrapService implements OnModuleInit {
       password: 'member123456',
       firstName: 'Member',
       lastName: 'User',
-      role: 'pm',
+      role: 'member',
     },
     {
       email: 'guest@zephix.ai',
@@ -104,7 +104,7 @@ export class DemoBootstrapService implements OnModuleInit {
       // Upsert UserOrganization record using TypeORM entity
       // Map user.role to UserOrganization.role:
       // - 'admin' → 'admin' (or 'owner' for first user)
-      // - 'pm' → 'pm'
+      // - 'member' → 'member'
       // - 'viewer' → 'viewer'
       const orgRole = u.role === 'admin' ? 'admin' : u.role;
 
@@ -117,7 +117,7 @@ export class DemoBootstrapService implements OnModuleInit {
 
       if (userOrg) {
         // Update existing record
-        userOrg.role = orgRole as 'owner' | 'admin' | 'pm' | 'viewer';
+        userOrg.role = orgRole as 'owner' | 'admin' | 'member' | 'viewer';
         userOrg.isActive = true;
         await userOrgRepo.save(userOrg);
       } else {
@@ -125,7 +125,7 @@ export class DemoBootstrapService implements OnModuleInit {
         userOrg = userOrgRepo.create({
           userId,
           organizationId: orgId,
-          role: orgRole as 'owner' | 'admin' | 'pm' | 'viewer',
+          role: orgRole as 'owner' | 'admin' | 'member' | 'viewer',
           isActive: true,
         });
         await userOrgRepo.save(userOrg);

--- a/zephix-backend/src/migrations/18000000000076-ReplaceLegacyOrgRolePmWithMember.ts
+++ b/zephix-backend/src/migrations/18000000000076-ReplaceLegacyOrgRolePmWithMember.ts
@@ -1,0 +1,92 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * AD-011 alignment: remove persisted org-level role `pm` in favor of `member`
+ * (same PlatformRole.MEMBER semantics as before).
+ *
+ * - Migrates `user_organizations.role` rows from `pm` → `member`.
+ * - When `invitations` exists, migrates `invitations.role` the same way (invite store,
+ *   not `users.role`; avoids breaking reads after entity/DTO enum removes `pm`).
+ *
+ * Handles varchar columns (bootstrap schema) and PostgreSQL enums (`*_role_enum`).
+ *
+ * Down is intentionally a no-op: PostgreSQL cannot safely restore removed enum labels,
+ * and reverting data from `member` back to `pm` would contradict AD-011.
+ */
+export class ReplaceLegacyOrgRolePmWithMember18000000000076
+  implements MigrationInterface
+{
+  name = 'ReplaceLegacyOrgRolePmWithMember18000000000076';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.migrateRoleColumn(queryRunner, 'user_organizations', 'role');
+    const invitationsExists = await queryRunner.hasTable('invitations');
+    if (invitationsExists) {
+      await this.migrateRoleColumn(queryRunner, 'invitations', 'role');
+    }
+
+    const orgInvitesExists = await queryRunner.hasTable('org_invites');
+    if (orgInvitesExists) {
+      await queryRunner.query(
+        `UPDATE org_invites SET role = 'member' WHERE role = 'pm'`,
+      );
+    }
+  }
+
+  /**
+   * Normalize quoted PostgreSQL identifiers for dynamic SQL.
+   */
+  private quoteIdent(ident: string): string {
+    return `"${ident.replace(/"/g, '""')}"`;
+  }
+
+  private async migrateRoleColumn(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<void> {
+    const tableExists = await queryRunner.hasTable(tableName);
+    if (!tableExists) {
+      return;
+    }
+
+    const meta = await queryRunner.query(
+      `
+      SELECT data_type, udt_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1
+        AND column_name = $2
+      `,
+      [tableName, columnName],
+    );
+
+    if (!meta?.length) {
+      return;
+    }
+
+    const { data_type: dataType, udt_name: udtName } = meta[0];
+
+    const qTable = this.quoteIdent(tableName);
+    const qCol = this.quoteIdent(columnName);
+
+    if (dataType === 'USER-DEFINED' && udtName) {
+      await queryRunner.query(
+        `ALTER TYPE "${udtName}" ADD VALUE IF NOT EXISTS 'member'`,
+      );
+      await queryRunner.query(
+        `UPDATE ${qTable} SET ${qCol} = 'member'::"${udtName}" WHERE ${qCol}::text = 'pm'`,
+      );
+      return;
+    }
+
+    await queryRunner.query(
+      `UPDATE ${qTable} SET ${qCol} = 'member' WHERE ${qCol} = 'pm'`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Irreversible: cannot drop enum label `pm` or safely revert member → pm without
+    // violating AD-011. Fresh installs created after `up` never stored `pm`.
+  }
+}

--- a/zephix-backend/src/migrations/__tests__/18000000000076-ReplaceLegacyOrgRolePmWithMember.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000076-ReplaceLegacyOrgRolePmWithMember.spec.ts
@@ -1,0 +1,76 @@
+import { ReplaceLegacyOrgRolePmWithMember18000000000076 } from '../18000000000076-ReplaceLegacyOrgRolePmWithMember';
+
+describe('Migration 18000000000076 — replace legacy org role pm with member', () => {
+  it('adds member label and updates user_organizations when role is a postgres enum', async () => {
+    const queries: string[] = [];
+    const mockQueryRunner = {
+      hasTable: jest.fn(async (name: string) =>
+        name === 'user_organizations' ? true : false,
+      ),
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes('information_schema.columns')) {
+          return [
+            {
+              data_type: 'USER-DEFINED',
+              udt_name: 'user_organizations_role_enum',
+            },
+          ];
+        }
+        return [];
+      }),
+    };
+
+    const migration = new ReplaceLegacyOrgRolePmWithMember18000000000076();
+    await migration.up(mockQueryRunner as any);
+
+    expect(
+      queries.some((q) =>
+        q.includes(
+          `ALTER TYPE "user_organizations_role_enum" ADD VALUE IF NOT EXISTS 'member'`,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((q) =>
+        q.includes(
+          `UPDATE "user_organizations" SET "role" = 'member'::"user_organizations_role_enum" WHERE "role"::text = 'pm'`,
+        ),
+      ),
+    ).toBe(true);
+    expect(queries.some((q) => q.includes('UPDATE org_invites'))).toBe(false);
+  });
+
+  it('runs varchar update for user_organizations and updates org_invites when present', async () => {
+    const queries: string[] = [];
+    const mockQueryRunner = {
+      hasTable: jest.fn(async (name: string) =>
+        ['user_organizations', 'org_invites'].includes(name),
+      ),
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes('information_schema.columns')) {
+          return [{ data_type: 'character varying', udt_name: 'varchar' }];
+        }
+        return [];
+      }),
+    };
+
+    const migration = new ReplaceLegacyOrgRolePmWithMember18000000000076();
+    await migration.up(mockQueryRunner as any);
+
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('UPDATE') &&
+          q.includes('user_organizations') &&
+          q.includes(`= 'member' WHERE`),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some((q) =>
+        q.includes(`UPDATE org_invites SET role = 'member' WHERE role = 'pm'`),
+      ),
+    ).toBe(true);
+  });
+});

--- a/zephix-backend/src/modules/auth/__tests__/auth.password-reset.spec.ts
+++ b/zephix-backend/src/modules/auth/__tests__/auth.password-reset.spec.ts
@@ -45,7 +45,7 @@ describe('AuthService — password reset', () => {
 
   let service: AuthService;
   let userRepo: jest.Mocked<Partial<Repository<User>>>;
-  let pwdResetRepo: jest.Mocked<Partial<Repository<PasswordResetToken>>>;
+  let pwdResetRepo: any;
   let sessionRepo: jest.Mocked<Partial<Repository<AuthSession>>>;
   let refreshTokenRepo: jest.Mocked<Partial<Repository<RefreshToken>>>;
   let emailService: {
@@ -54,7 +54,9 @@ describe('AuthService — password reset', () => {
   };
   let auditRecord: jest.Mock;
   let rateLimitStore: MemoryPwdResetRateLimitStore;
-  let transactionFn: (cb: (manager: any) => Promise<void>) => Promise<void>;
+  let transactionFn: (
+    cb: (manager: any) => Promise<unknown>,
+  ) => Promise<unknown>;
 
   const mockUser: Partial<User> = {
     id: 'user-1',
@@ -90,12 +92,16 @@ describe('AuthService — password reset', () => {
       save: jest.fn(),
     };
 
+    // Loose typing: partial Repository mocks don't satisfy TypeORM's full generic signatures.
     pwdResetRepo = {
       update: jest.fn().mockResolvedValue({ affected: 0 }),
       create: jest.fn((x) => x),
-      save: jest.fn().mockImplementation((x) => Promise.resolve(x)),
+      save: jest.fn().mockImplementation((x) =>
+        Promise.resolve({ ...x, id: 'pwd-reset-token-row-1' }),
+      ),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
       findOne: jest.fn(),
-    };
+    } as any;
 
     refreshTokenRepo = {
       update: jest.fn().mockResolvedValue({ affected: 0 }),
@@ -113,9 +119,10 @@ describe('AuthService — password reset', () => {
         andWhere: qbAndWhere,
         execute: qbExecute,
       })),
-    };
+    } as any;
 
-    transactionFn = async (cb: (manager: any) => Promise<void>) => {
+    // Must return the callback result — requestPasswordReset reads token id from the transaction.
+    transactionFn = async (cb: (manager: any) => Promise<unknown>) => {
       const manager = {
         getRepository: (entity: unknown) => {
           if (entity === PasswordResetToken) return pwdResetRepo;
@@ -124,7 +131,7 @@ describe('AuthService — password reset', () => {
           throw new Error('unexpected entity');
         },
       };
-      await cb(manager);
+      return await cb(manager);
     };
 
     const dataSource = {
@@ -189,6 +196,28 @@ describe('AuthService — password reset', () => {
       );
       const raw = emailService.sendPasswordResetEmail.mock.calls[0][1];
       expect(TokenHashUtil.hashToken(raw)).toBe(saved.tokenHash);
+      expect(auditRecord).toHaveBeenCalled();
+    });
+
+    /**
+     * Compensation path: transactional repo (`pwdResetRepo`) is what `save` uses inside
+     * `dataSource.transaction`. `passwordResetTokenRepository.delete` is the injected repo used
+     * after commit — same mock instance here so we assert `delete` on `pwdResetRepo`.
+     */
+    it('deletes token and returns neutral response when email send fails', async () => {
+      userRepo.findOne = jest.fn().mockResolvedValue(mockUser);
+      emailService.sendPasswordResetEmail.mockRejectedValueOnce(
+        new Error('Failed to send email'),
+      );
+
+      await expect(
+        service.requestPasswordReset('u@example.com'),
+      ).resolves.toBeUndefined();
+
+      expect(pwdResetRepo.delete).toHaveBeenCalledWith({
+        id: 'pwd-reset-token-row-1',
+      });
+      expect(auditRecord).not.toHaveBeenCalled();
     });
 
     it('invalidates prior unconsumed tokens via update', async () => {

--- a/zephix-backend/src/modules/auth/auth.service.ts
+++ b/zephix-backend/src/modules/auth/auth.service.ts
@@ -1,6 +1,6 @@
 /**
  * ROLE MAPPING SUMMARY:
- * - Database layer: UserOrganization.role = 'owner' | 'admin' | 'pm' | 'viewer'
+ * - Database layer: UserOrganization.role = 'owner' | 'admin' | 'member' | 'viewer'
  * - Database layer: User.role = legacy string (e.g., 'admin', 'pm', 'viewer')
  * - API responses: role = 'ADMIN' | 'MEMBER' | 'VIEWER' (normalized PlatformRole)
  * - API responses: platformRole = same as role (explicit enum field)
@@ -500,7 +500,7 @@ export class AuthService {
    * Used by both login and /auth/me to ensure consistent structure
    *
    * @param user - User entity from database
-   * @param orgRoleFromUserOrg - Optional role from UserOrganization ('owner' | 'admin' | 'pm' | 'viewer')
+   * @param orgRoleFromUserOrg - Optional role from UserOrganization ('owner' | 'admin' | 'member' | 'viewer')
    *                             If provided, this takes precedence over user.role
    */
   public buildUserResponse(

--- a/zephix-backend/src/modules/auth/auth.service.ts
+++ b/zephix-backend/src/modules/auth/auth.service.ts
@@ -860,7 +860,7 @@ export class AuthService {
     const tokenHash = TokenHashUtil.hashToken(rawToken);
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
 
-    await this.dataSource.transaction(async (manager) => {
+    const tokenId = await this.dataSource.transaction(async (manager) => {
       const tokenRepo = manager.getRepository(PasswordResetToken);
       await tokenRepo.update(
         { userId: user.id, consumed: false },
@@ -874,29 +874,38 @@ export class AuthService {
         consumed: false,
         consumedAt: null,
       });
-      await tokenRepo.save(row);
+      const saved = await tokenRepo.save(row);
+      return saved.id;
     });
 
-    await this.emailService.sendPasswordResetEmail(user.email, rawToken);
+    try {
+      await this.emailService.sendPasswordResetEmail(user.email, rawToken);
 
-    if (this.auditService && user.organizationId) {
-      await this.auditService.record({
-        organizationId: user.organizationId,
-        actorUserId: user.id,
-        actorPlatformRole: 'ADMIN',
-        entityType: AuditEntityType.PASSWORD_RESET,
-        entityId: user.id,
-        action: AuditAction.PASSWORD_RESET_REQUESTED,
-        after: {},
-        ipAddress: undefined,
-        userAgent: undefined,
+      if (this.auditService && user.organizationId) {
+        await this.auditService.record({
+          organizationId: user.organizationId,
+          actorUserId: user.id,
+          actorPlatformRole: 'ADMIN',
+          entityType: AuditEntityType.PASSWORD_RESET,
+          entityId: user.id,
+          action: AuditAction.PASSWORD_RESET_REQUESTED,
+          after: {},
+          ipAddress: undefined,
+          userAgent: undefined,
+        });
+      }
+
+      this.logger.log({
+        action: 'password_reset_requested',
+        userId: user.id,
       });
+    } catch (error: unknown) {
+      console.error(
+        'Password reset email failed after token persisted; compensating delete',
+        error,
+      );
+      await this.passwordResetTokenRepository.delete({ id: tokenId });
     }
-
-    this.logger.log({
-      action: 'password_reset_requested',
-      userId: user.id,
-    });
   }
 
   /**

--- a/zephix-backend/src/modules/auth/dto/invite.dto.ts
+++ b/zephix-backend/src/modules/auth/dto/invite.dto.ts
@@ -7,7 +7,7 @@ import {
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export type InviteRole = 'owner' | 'admin' | 'pm' | 'viewer';
+export type InviteRole = 'owner' | 'admin' | 'member' | 'viewer';
 
 /**
  * Create Invite DTO
@@ -23,10 +23,10 @@ export class CreateInviteDto {
 
   @ApiProperty({
     description: 'Organization role for the invite',
-    enum: ['owner', 'admin', 'pm', 'viewer'],
-    example: 'pm',
+    enum: ['owner', 'admin', 'member', 'viewer'],
+    example: 'member',
   })
-  @IsEnum(['owner', 'admin', 'pm', 'viewer'])
+  @IsEnum(['owner', 'admin', 'member', 'viewer'])
   @IsNotEmpty()
   role: InviteRole;
 

--- a/zephix-backend/src/modules/auth/services/org-invites.service.ts
+++ b/zephix-backend/src/modules/auth/services/org-invites.service.ts
@@ -27,7 +27,7 @@ import { NotificationDispatchService } from '../../notifications/notification-di
 export interface CreateInviteInput {
   orgId: string;
   email: string;
-  role: 'owner' | 'admin' | 'pm' | 'viewer';
+  role: 'owner' | 'admin' | 'member' | 'viewer';
   createdBy: string;
   message?: string;
 }
@@ -277,7 +277,7 @@ export class OrgInvitesService {
       const membership = userOrgRepo.create({
         userId,
         organizationId: invite.orgId,
-        role: invite.role as 'owner' | 'admin' | 'pm' | 'viewer',
+        role: invite.role as 'owner' | 'admin' | 'member' | 'viewer',
         isActive: true,
         joinedAt: new Date(),
       });
@@ -359,7 +359,7 @@ export class OrgInvitesService {
     }
 
     // Map platform role to legacy role
-    const legacyRole = platformRole === 'Member' ? 'pm' : 'viewer';
+    const legacyRole = platformRole === 'Member' ? 'member' : 'viewer';
 
     const results: Array<{
       email: string;

--- a/zephix-backend/src/modules/dashboards/dashboards-mutations.integration.spec.ts
+++ b/zephix-backend/src/modules/dashboards/dashboards-mutations.integration.spec.ts
@@ -372,7 +372,7 @@ describe('Dashboards Mutations Authorization (e2e)', () => {
       firstName: 'Member',
       lastName: 'User',
       organizationId: orgId,
-      role: 'pm',
+      role: 'member',
       isEmailVerified: true,
       emailVerifiedAt: new Date(),
     });
@@ -382,7 +382,7 @@ describe('Dashboards Mutations Authorization (e2e)', () => {
       firstName: 'NonMember',
       lastName: 'User',
       organizationId: orgId,
-      role: 'pm',
+      role: 'member',
       isEmailVerified: true,
       emailVerifiedAt: new Date(),
     });
@@ -404,12 +404,12 @@ describe('Dashboards Mutations Authorization (e2e)', () => {
       {
         userId: memberUserId,
         organizationId: orgId,
-        role: 'pm',
+        role: 'member',
       },
       {
         userId: nonMemberUserId,
         organizationId: orgId,
-        role: 'pm',
+        role: 'member',
       },
     ]);
 

--- a/zephix-backend/src/modules/workspaces/workspaces.service.ts
+++ b/zephix-backend/src/modules/workspaces/workspaces.service.ts
@@ -373,12 +373,11 @@ export class WorkspacesService {
           if (isDev && ownerUser.organizationId === input.organizationId) {
             const roleMapping: Record<
               string,
-              'owner' | 'admin' | 'pm' | 'viewer'
+              'owner' | 'admin' | 'member' | 'viewer'
             > = {
               owner: 'owner',
               admin: 'admin',
-              member: 'pm',
-              pm: 'pm',
+              member: 'member',
               guest: 'viewer',
               viewer: 'viewer',
             };

--- a/zephix-backend/src/organizations/controllers/invitation-acceptance.controller.ts
+++ b/zephix-backend/src/organizations/controllers/invitation-acceptance.controller.ts
@@ -36,7 +36,7 @@ export class InvitationAcceptanceController {
       type: 'object',
       properties: {
         email: { type: 'string' },
-        role: { type: 'string', enum: ['admin', 'pm', 'viewer'] },
+        role: { type: 'string', enum: ['admin', 'member', 'viewer'] },
         organization: {
           type: 'object',
           properties: {

--- a/zephix-backend/src/organizations/controllers/organizations.controller.ts
+++ b/zephix-backend/src/organizations/controllers/organizations.controller.ts
@@ -161,7 +161,7 @@ export class OrganizationsController {
   async updateUserRole(
     @Param('organizationId') organizationId: string,
     @Param('userId') userId: string,
-    @Body() body: { role: 'admin' | 'pm' | 'viewer' },
+    @Body() body: { role: 'admin' | 'member' | 'viewer' },
     @Request() req: AuthRequest,
   ) {
     const { userId: actorUserId } = getAuthContext(req);

--- a/zephix-backend/src/organizations/dto/invite-team-member.dto.ts
+++ b/zephix-backend/src/organizations/dto/invite-team-member.dto.ts
@@ -11,11 +11,11 @@ export class InviteTeamMemberDto {
 
   @ApiProperty({
     description: 'Role to assign to the invited user',
-    enum: ['admin', 'pm', 'viewer'],
-    example: 'pm',
+    enum: ['admin', 'member', 'viewer'],
+    example: 'member',
   })
-  @IsEnum(['admin', 'pm', 'viewer'])
-  role: 'admin' | 'pm' | 'viewer';
+  @IsEnum(['admin', 'member', 'viewer'])
+  role: 'admin' | 'member' | 'viewer';
 
   @ApiPropertyOptional({
     description: 'Custom invitation message',

--- a/zephix-backend/src/organizations/dto/invite-user.dto.ts
+++ b/zephix-backend/src/organizations/dto/invite-user.dto.ts
@@ -11,11 +11,11 @@ export class InviteUserDto {
 
   @ApiProperty({
     description: 'Role to assign to the invited user',
-    enum: ['admin', 'pm', 'viewer'],
-    example: 'pm',
+    enum: ['admin', 'member', 'viewer'],
+    example: 'member',
   })
-  @IsEnum(['admin', 'pm', 'viewer'])
-  role: 'admin' | 'pm' | 'viewer';
+  @IsEnum(['admin', 'member', 'viewer'])
+  role: 'admin' | 'member' | 'viewer';
 
   @ApiPropertyOptional({
     description: 'First name of the invited user',

--- a/zephix-backend/src/organizations/dto/team-member-response.dto.ts
+++ b/zephix-backend/src/organizations/dto/team-member-response.dto.ts
@@ -12,8 +12,8 @@ export class TeamMemberResponseDto {
     lastName: string;
   };
 
-  @ApiProperty({ enum: ['owner', 'admin', 'pm', 'viewer'] })
-  role: 'owner' | 'admin' | 'pm' | 'viewer';
+  @ApiProperty({ enum: ['owner', 'admin', 'member', 'viewer'] })
+  role: 'owner' | 'admin' | 'member' | 'viewer';
 
   @ApiProperty({ enum: ['active', 'pending', 'inactive'] })
   status: 'active' | 'pending' | 'inactive';
@@ -29,8 +29,8 @@ export class InvitationResponseDto {
   @ApiProperty()
   email: string;
 
-  @ApiProperty({ enum: ['admin', 'pm', 'viewer'] })
-  role: 'admin' | 'pm' | 'viewer';
+  @ApiProperty({ enum: ['admin', 'member', 'viewer'] })
+  role: 'admin' | 'member' | 'viewer';
 
   @ApiProperty({ enum: ['pending', 'accepted', 'expired', 'cancelled'] })
   status: 'pending' | 'accepted' | 'expired' | 'cancelled';

--- a/zephix-backend/src/organizations/dto/update-member-role.dto.ts
+++ b/zephix-backend/src/organizations/dto/update-member-role.dto.ts
@@ -4,9 +4,9 @@ import { ApiProperty } from '@nestjs/swagger';
 export class UpdateMemberRoleDto {
   @ApiProperty({
     description: 'New role for the team member',
-    enum: ['admin', 'pm', 'viewer'],
+    enum: ['admin', 'member', 'viewer'],
     example: 'admin',
   })
-  @IsEnum(['admin', 'pm', 'viewer'])
-  role: 'admin' | 'pm' | 'viewer';
+  @IsEnum(['admin', 'member', 'viewer'])
+  role: 'admin' | 'member' | 'viewer';
 }

--- a/zephix-backend/src/organizations/entities/invitation.entity.ts
+++ b/zephix-backend/src/organizations/entities/invitation.entity.ts
@@ -28,9 +28,9 @@ export class Invitation {
 
   @Column({
     type: 'enum',
-    enum: ['admin', 'pm', 'viewer'],
+    enum: ['admin', 'member', 'viewer'],
   })
-  role: 'admin' | 'pm' | 'viewer';
+  role: 'admin' | 'member' | 'viewer';
 
   @Column({
     type: 'enum',

--- a/zephix-backend/src/organizations/entities/user-organization.entity.ts
+++ b/zephix-backend/src/organizations/entities/user-organization.entity.ts
@@ -1,7 +1,7 @@
 /**
  * ROLE MAPPING SUMMARY:
- * - Database enum: role = 'owner' | 'admin' | 'pm' | 'viewer'
- * - Maps to PlatformRole: 'owner'/'admin' → ADMIN, 'pm' → MEMBER, 'viewer' → VIEWER
+ * - Database enum: role = 'owner' | 'admin' | 'member' | 'viewer'
+ * - Maps to PlatformRole: 'owner'/'admin' → ADMIN, 'member' → MEMBER, 'viewer' → VIEWER
  * - This is the primary source of truth for organization-level roles
  */
 import {
@@ -34,10 +34,10 @@ export class UserOrganization {
 
   @Column({
     type: 'enum',
-    enum: ['owner', 'admin', 'pm', 'viewer'],
+    enum: ['owner', 'admin', 'member', 'viewer'],
     default: 'viewer',
   })
-  role: 'owner' | 'admin' | 'pm' | 'viewer';
+  role: 'owner' | 'admin' | 'member' | 'viewer';
 
   @Column({ default: true })
   isActive: boolean;
@@ -78,7 +78,7 @@ export class UserOrganization {
   }
 
   canManageProjects(): boolean {
-    return ['owner', 'admin', 'pm'].includes(this.role);
+    return ['owner', 'admin', 'member'].includes(this.role);
   }
 
   canViewOnly(): boolean {

--- a/zephix-backend/src/organizations/guards/roles.guard.ts
+++ b/zephix-backend/src/organizations/guards/roles.guard.ts
@@ -30,11 +30,11 @@ export class RolesGuard implements CanActivate {
       );
     }
 
-    // Role hierarchy: owner > admin > pm > viewer
+    // Role hierarchy: owner > admin > member > viewer
     const roleHierarchy = {
       owner: 4,
       admin: 3,
-      pm: 2,
+      member: 2,
       viewer: 1,
     };
 

--- a/zephix-backend/src/organizations/services/organizations.service.ts
+++ b/zephix-backend/src/organizations/services/organizations.service.ts
@@ -279,7 +279,7 @@ export class OrganizationsService {
   async updateUserRole(
     organizationId: string,
     userIdToUpdate: string,
-    newRole: 'admin' | 'pm' | 'viewer',
+    newRole: 'admin' | 'member' | 'viewer',
     updatingUserId: string,
   ): Promise<void> {
     // Check if updater has permission
@@ -362,7 +362,7 @@ export class OrganizationsService {
       search?: string;
       /** Admin People pills: all memberships, or segmented by lifecycle state. */
       peopleFilter?: 'all' | 'active' | 'suspended' | 'invited';
-      /** Maps UI platform role to `user_organizations.role` (owner/admin, pm, viewer). */
+      /** Maps UI platform role to `user_organizations.role` (owner/admin, member, viewer). */
       platformRole?: 'all' | 'admin' | 'member' | 'viewer';
     },
   ): Promise<{ users: any[]; total: number }> {
@@ -406,7 +406,7 @@ export class OrganizationsService {
         adminRoles: ['owner', 'admin'],
       });
     } else if (platformRole === 'member') {
-      queryBuilder.andWhere('uo.role = :pmRole', { pmRole: 'pm' });
+      queryBuilder.andWhere('uo.role = :memberRole', { memberRole: 'member' });
     } else if (platformRole === 'viewer') {
       queryBuilder.andWhere('uo.role = :viewerRole', { viewerRole: 'viewer' });
     }

--- a/zephix-backend/src/scripts/dev-seed.ts
+++ b/zephix-backend/src/scripts/dev-seed.ts
@@ -60,16 +60,16 @@ async function devSeed() {
         password: 'Owner123!',
         firstName: 'Workspace',
         lastName: 'Owner',
-        role: 'pm',
-        orgRole: 'pm' as const,
+        role: 'member',
+        orgRole: 'member' as const,
       },
       {
         email: 'member@template-proofs.test',
         password: 'Member123!',
         firstName: 'Member',
         lastName: 'User',
-        role: 'pm',
-        orgRole: 'pm' as const,
+        role: 'member',
+        orgRole: 'member' as const,
       },
     ];
 

--- a/zephix-backend/src/scripts/scale-seed/generators/audit.generator.ts
+++ b/zephix-backend/src/scripts/scale-seed/generators/audit.generator.ts
@@ -20,7 +20,7 @@ const ACTIONS = [
   'attach', 'detach', 'upload_complete', 'role_change',
 ];
 
-const PLATFORM_ROLES = ['admin', 'pm', 'pm', 'pm', 'viewer'];
+const PLATFORM_ROLES = ['admin', 'member', 'member', 'member', 'viewer'];
 
 export async function generateAudit(
   ds: { query: (sql: string, params?: any[]) => Promise<any> },

--- a/zephix-backend/src/scripts/scale-seed/generators/users.generator.ts
+++ b/zephix-backend/src/scripts/scale-seed/generators/users.generator.ts
@@ -3,7 +3,7 @@
  * Creates scaled user count with deterministic emails and role distribution.
  *
  * Platform roles via user_organizations:
- *   5% admin, 85% pm (MEMBER), 10% viewer
+ *   5% admin, 85% member (MEMBER), 10% viewer
  *
  * Adapts to actual DB column names (user_organizations may use camelCase).
  */
@@ -16,7 +16,7 @@ import {
 
 const PLATFORM_ROLE_DIST: DistributionEntry<string>[] = [
   { value: 'admin', pct: 5 },
-  { value: 'pm', pct: 85 },
+  { value: 'member', pct: 85 },
   { value: 'viewer', pct: 10 },
 ];
 

--- a/zephix-backend/src/scripts/seed-users.ts
+++ b/zephix-backend/src/scripts/seed-users.ts
@@ -53,8 +53,8 @@ async function seedUsers() {
         password: 'Member123!',
         firstName: 'Member',
         lastName: 'User',
-        role: 'pm' as const,
-        orgRole: 'pm' as const,
+        role: 'member' as const,
+        orgRole: 'member' as const,
       },
       {
         email: 'viewer@zephix.ai',

--- a/zephix-backend/test/dashboards.e2e-spec.ts
+++ b/zephix-backend/test/dashboards.e2e-spec.ts
@@ -53,13 +53,13 @@ describe('Dashboards E2E Tests', () => {
   async function createUserOrganization(
     userId: string,
     orgId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const uoRepo = dataSource.getRepository(UserOrganization);
     return uoRepo.save({
       userId,
       organizationId: orgId,
-      role: role as 'owner' | 'admin' | 'pm' | 'viewer',
+      role: role as 'owner' | 'admin' | 'member' | 'viewer',
     });
   }
 

--- a/zephix-backend/test/helpers/auth-test-helpers.ts
+++ b/zephix-backend/test/helpers/auth-test-helpers.ts
@@ -192,7 +192,7 @@ export async function createInvite(
   accessToken: string,
   orgId: string,
   email: string,
-  role: 'owner' | 'admin' | 'pm' | 'viewer' = 'pm',
+  role: 'owner' | 'admin' | 'member' | 'viewer' = 'member',
   message?: string,
 ): Promise<{ message: string }> {
   const response = await request(app.getHttpServer())

--- a/zephix-backend/test/invites.e2e-spec.ts
+++ b/zephix-backend/test/invites.e2e-spec.ts
@@ -81,7 +81,7 @@ describe('Organization Invites (E2E)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .send({
           email: `invitee-${timestamp}@test.com`,
-          role: 'pm',
+          role: 'member',
         })
         .expect(403);
     });
@@ -111,7 +111,7 @@ describe('Organization Invites (E2E)', () => {
         accessToken,
         orgId,
         inviteeEmail,
-        'pm',
+        'member',
       );
 
       expect(response.message).toContain('successfully');
@@ -159,7 +159,7 @@ describe('Organization Invites (E2E)', () => {
       );
 
       // Create invite
-      await createInvite(app, inviterToken, orgId, inviteeEmail, 'pm');
+      await createInvite(app, inviterToken, orgId, inviteeEmail, 'member');
 
       // Register invitee
       const { userId: inviteeId } = await registerUser(
@@ -201,7 +201,7 @@ describe('Organization Invites (E2E)', () => {
       });
 
       expect(membership).toBeDefined();
-      expect(membership?.role).toBe('pm');
+      expect(membership?.role).toBe('member');
 
       // Verify invite is marked as accepted
       const inviteRepo = dataSource.getRepository(OrgInvite);
@@ -232,7 +232,7 @@ describe('Organization Invites (E2E)', () => {
         'SecurePass123!@#',
       );
 
-      await createInvite(app, inviterToken, orgId, inviteeEmail, 'pm');
+      await createInvite(app, inviterToken, orgId, inviteeEmail, 'member');
 
       // Register and verify invitee
       const { userId: inviteeId } = await registerUser(
@@ -306,7 +306,7 @@ describe('Organization Invites (E2E)', () => {
         'SecurePass123!@#',
       );
 
-      await createInvite(app, inviterToken, orgId, inviteeEmail, 'pm');
+      await createInvite(app, inviterToken, orgId, inviteeEmail, 'member');
 
       // Register invitee
       const { userId: inviteeId } = await registerUser(
@@ -376,7 +376,7 @@ describe('Organization Invites (E2E)', () => {
           .set('Authorization', `Bearer ${accessToken}`)
           .send({
             email: `test-${timestamp}@test.com`,
-            role: 'pm',
+            role: 'member',
           })
           .expect(403);
 

--- a/zephix-backend/test/org-invite-workspace-assign.e2e-spec.ts
+++ b/zephix-backend/test/org-invite-workspace-assign.e2e-spec.ts
@@ -188,7 +188,7 @@ describe('Org Invite with Workspace Assignments (e2e)', () => {
         password: hashedPassword,
         firstName: 'Member',
         lastName: 'TwoWS',
-        role: 'pm',
+        role: 'member',
         organizationId: orgId,
       });
       const savedUser = await userRepo.save(newUser);
@@ -309,7 +309,7 @@ describe('Org Invite with Workspace Assignments (e2e)', () => {
         password: hashedPassword,
         firstName: 'Existing',
         lastName: 'User',
-        role: 'pm',
+        role: 'member',
         organizationId: orgId,
       });
       const savedUser = await userRepo.save(existingUser);
@@ -318,7 +318,7 @@ describe('Org Invite with Workspace Assignments (e2e)', () => {
       await userOrgRepo.save({
         userId: savedUser.id,
         organizationId: orgId,
-        role: 'pm',
+        role: 'member',
         isActive: true,
         joinedAt: new Date(),
       });

--- a/zephix-backend/test/portfolios-programs.e2e-spec.ts
+++ b/zephix-backend/test/portfolios-programs.e2e-spec.ts
@@ -66,13 +66,13 @@ describe('Portfolios and Programs Phase 4.1 (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     orgId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const uoRepo = dataSource.getRepository(UserOrganization);
     return uoRepo.save({
       userId,
       organizationId: orgId,
-      role: role as 'owner' | 'admin' | 'pm' | 'viewer',
+      role: role as 'owner' | 'admin' | 'member' | 'viewer',
     });
   }
 

--- a/zephix-backend/test/resource-risk.e2e-spec.ts
+++ b/zephix-backend/test/resource-risk.e2e-spec.ts
@@ -442,7 +442,7 @@ describe('Resource Risk Scoring (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     organizationId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const userOrgRepo =
       dataSource.getRepository(UserOrganization) as Repository<UserOrganization>;

--- a/zephix-backend/test/resource-seed-guard.e2e-spec.ts
+++ b/zephix-backend/test/resource-seed-guard.e2e-spec.ts
@@ -75,7 +75,7 @@ describe('Resource Seed Controller Guard (e2e)', () => {
     const memberUserOrg = userOrgRepo.create({
       userId: memberUserId,
       organizationId: orgId,
-      role: 'pm', // 'pm' is the member role in UserOrganization
+      role: 'member', // org-level MEMBER (stored as member)
       isActive: true,
     });
     await userOrgRepo.save([adminUserOrg, memberUserOrg]);

--- a/zephix-backend/test/resources-phase2.e2e-spec.ts
+++ b/zephix-backend/test/resources-phase2.e2e-spec.ts
@@ -61,13 +61,13 @@ describe('Resources Phase 2 E2E Tests', () => {
   async function createUserOrganization(
     userId: string,
     orgId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const uoRepo = dataSource.getRepository(UserOrganization);
     return uoRepo.save({
       userId,
       organizationId: orgId,
-      role: role as 'owner' | 'admin' | 'pm' | 'viewer',
+      role: role as 'owner' | 'admin' | 'member' | 'viewer',
     });
   }
 

--- a/zephix-backend/test/resources.e2e-spec.ts
+++ b/zephix-backend/test/resources.e2e-spec.ts
@@ -449,7 +449,7 @@ describe('Resource Intelligence v1 (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     organizationId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const userOrgRepo = dataSource.getRepository(UserOrganization);
     const userOrg = userOrgRepo.create({

--- a/zephix-backend/test/template-application.e2e-spec.ts
+++ b/zephix-backend/test/template-application.e2e-spec.ts
@@ -473,7 +473,7 @@ describe('Template Application (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     organizationId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const userOrgRepo = dataSource.getRepository(UserOrganization);
     const userOrg = userOrgRepo.create({

--- a/zephix-backend/test/work-management-list-query-validation.e2e-spec.ts
+++ b/zephix-backend/test/work-management-list-query-validation.e2e-spec.ts
@@ -60,7 +60,7 @@ describe('List work tasks query validation (e2e)', () => {
     });
 
     const uoRepo = dataSource.getRepository(UserOrganization);
-    await uoRepo.save({ userId: user.id, organizationId: org.id, role: 'pm' });
+    await uoRepo.save({ userId: user.id, organizationId: org.id, role: 'member' });
 
     const workspaceRepo = dataSource.getRepository(Workspace);
     const workspace = await workspaceRepo.save({

--- a/zephix-backend/test/work-management-roles.e2e-spec.ts
+++ b/zephix-backend/test/work-management-roles.e2e-spec.ts
@@ -95,12 +95,12 @@ describe('Work Management Roles (e2e)', () => {
     await uoRepo.save({
       userId: stakeholderUser.id,
       organizationId: org1.id,
-      role: 'pm',
+      role: 'member',
     });
     await uoRepo.save({
       userId: deliveryOwnerUser.id,
       organizationId: org1.id,
-      role: 'pm',
+      role: 'member',
     });
 
     // Login to get tokens

--- a/zephix-backend/test/work-management-routing.e2e-spec.ts
+++ b/zephix-backend/test/work-management-routing.e2e-spec.ts
@@ -53,13 +53,13 @@ describe('Work Management Routing E2E Tests', () => {
   async function createUserOrganization(
     userId: string,
     orgId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const uoRepo = dataSource.getRepository(UserOrganization);
     return uoRepo.save({
       userId,
       organizationId: orgId,
-      role: role as 'owner' | 'admin' | 'pm' | 'viewer',
+      role: role as 'owner' | 'admin' | 'member' | 'viewer',
     });
   }
 

--- a/zephix-backend/test/work-management-traffic-counters.e2e-spec.ts
+++ b/zephix-backend/test/work-management-traffic-counters.e2e-spec.ts
@@ -64,7 +64,7 @@ describe('Work task traffic counters (e2e)', () => {
     });
 
     const uoRepo = dataSource.getRepository(UserOrganization);
-    await uoRepo.save({ userId: user.id, organizationId: org.id, role: 'pm' });
+    await uoRepo.save({ userId: user.id, organizationId: org.id, role: 'member' });
 
     const workspaceRepo = dataSource.getRepository(Workspace);
     const workspace = await workspaceRepo.save({

--- a/zephix-backend/test/work-management-viewer-filtering.e2e-spec.ts
+++ b/zephix-backend/test/work-management-viewer-filtering.e2e-spec.ts
@@ -94,8 +94,8 @@ describe('Work Management VIEWER filtering (e2e)', () => {
     });
 
     const uoRepo = dataSource.getRepository(UserOrganization);
-    await uoRepo.save({ userId: viewerA.id, organizationId: org.id, role: 'pm' });
-    await uoRepo.save({ userId: memberA.id, organizationId: org.id, role: 'pm' });
+    await uoRepo.save({ userId: viewerA.id, organizationId: org.id, role: 'member' });
+    await uoRepo.save({ userId: memberA.id, organizationId: org.id, role: 'member' });
 
     const workspaceRepo = dataSource.getRepository(Workspace);
     workspaceA = await workspaceRepo.save({

--- a/zephix-backend/test/workspace-backfill.e2e-spec.ts
+++ b/zephix-backend/test/workspace-backfill.e2e-spec.ts
@@ -74,7 +74,7 @@ describe('Workspace Backfill (E2E)', () => {
 
     // Create UserOrganization entries
     await createUserOrganization(orgAdmin.id, org1.id, 'admin');
-    await createUserOrganization(regularUser.id, org1.id, 'pm');
+    await createUserOrganization(regularUser.id, org1.id, 'member');
   });
 
   afterAll(async () => {
@@ -209,7 +209,7 @@ describe('Workspace Backfill (E2E)', () => {
       );
 
       // Create UserOrganization with non-admin role
-      await createUserOrganization(earliestUser.id, orgWithoutAdmin.id, 'pm');
+      await createUserOrganization(earliestUser.id, orgWithoutAdmin.id, 'member');
 
       // Create workspace without ownerId
       workspaceNoAdmin = await createTestWorkspace(
@@ -435,7 +435,7 @@ describe('Workspace Backfill (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     organizationId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const userOrgRepo = dataSource.getRepository(UserOrganization);
     const userOrg = userOrgRepo.create({

--- a/zephix-backend/test/workspace-join.e2e-spec.ts
+++ b/zephix-backend/test/workspace-join.e2e-spec.ts
@@ -101,7 +101,7 @@ describe('Workspace Join (e2e)', () => {
       {
         userId: memberUserId,
         organizationId: orgId,
-        role: 'pm',
+        role: 'member',
         isActive: true,
       },
       {

--- a/zephix-backend/test/workspace-members-suspend.e2e-spec.ts
+++ b/zephix-backend/test/workspace-members-suspend.e2e-spec.ts
@@ -84,7 +84,7 @@ describe('Workspace Members Suspend (e2e)', () => {
       {
         userId: memberUserId,
         organizationId: orgId,
-        role: 'pm',
+        role: 'member',
         isActive: true,
       },
     ]);

--- a/zephix-backend/test/workspace-membership-filtering.e2e-spec.ts
+++ b/zephix-backend/test/workspace-membership-filtering.e2e-spec.ts
@@ -83,8 +83,8 @@ describe('Workspace Membership Filtering (E2E)', () => {
 
     // Create UserOrganization entries (required for workspace membership feature flag)
     await createUserOrganization(adminUser.id, org1.id, 'admin');
-    await createUserOrganization(memberUser.id, org1.id, 'pm');
-    await createUserOrganization(nonMemberUser.id, org1.id, 'pm');
+    await createUserOrganization(memberUser.id, org1.id, 'member');
+    await createUserOrganization(nonMemberUser.id, org1.id, 'member');
 
     // Create test workspaces
     workspace1 = await createTestWorkspace('Workspace 1', org1.id, adminUser.id);
@@ -345,7 +345,7 @@ describe('Workspace Membership Filtering (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     organizationId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const userOrgRepo = dataSource.getRepository(UserOrganization);
     const userOrg = userOrgRepo.create({

--- a/zephix-backend/test/workspace-rbac.e2e-spec.ts
+++ b/zephix-backend/test/workspace-rbac.e2e-spec.ts
@@ -73,8 +73,8 @@ describe('Workspace RBAC (E2E)', () => {
 
     // Create UserOrganization entries (required for workspace member management)
     await createUserOrganization(orgAdmin.id, org1.id, 'admin');
-    await createUserOrganization(userOwner.id, org1.id, 'pm');
-    await createUserOrganization(userMember.id, org1.id, 'pm');
+    await createUserOrganization(userOwner.id, org1.id, 'member');
+    await createUserOrganization(userMember.id, org1.id, 'member');
     await createUserOrganization(userViewer.id, org1.id, 'viewer');
 
     // Create test workspace
@@ -179,7 +179,7 @@ describe('Workspace RBAC (E2E)', () => {
         const timestamp = Date.now();
         testUser = await createTestUser(`testuser-${timestamp}@rbac-test.com`, 'Test', 'User', org1.id, 'member');
         // Create UserOrganization entry for testUser
-        await createUserOrganization(testUser.id, org1.id, 'pm');
+        await createUserOrganization(testUser.id, org1.id, 'member');
         testUserToken = await getAuthToken(testUser.email, 'password123');
       });
 
@@ -272,7 +272,7 @@ describe('Workspace RBAC (E2E)', () => {
       it('Only org admin can call change owner endpoint', async () => {
         const newOwner = await createTestUser(`newowner-${Date.now()}@rbac-test.com`, 'New', 'Owner', org1.id, 'member');
         // Create UserOrganization entry for newOwner
-        await createUserOrganization(newOwner.id, org1.id, 'pm');
+        await createUserOrganization(newOwner.id, org1.id, 'member');
         await createWorkspaceMember(workspace1.id, newOwner.id, 'workspace_member');
 
         const response = await request(app.getHttpServer())
@@ -394,7 +394,7 @@ describe('Workspace RBAC (E2E)', () => {
         const timestamp = Date.now();
         const nonMember = await createTestUser(`nonmember-${timestamp}@rbac-test.com`, 'Non', 'Member', org1.id, 'member');
         // Create UserOrganization entry for nonMember
-        await createUserOrganization(nonMember.id, org1.id, 'pm');
+        await createUserOrganization(nonMember.id, org1.id, 'member');
         const nonMemberToken = await getAuthToken(nonMember.email, 'password123');
 
       // Try to create project
@@ -461,7 +461,7 @@ describe('Workspace RBAC (E2E)', () => {
     it('Should create workspace with owner atomically (happy path)', async () => {
       const timestamp = Date.now();
       const testUser = await createTestUser(`trans-test-${timestamp}@rbac-test.com`, 'Trans', 'Test', org1.id, 'member');
-      await createUserOrganization(testUser.id, org1.id, 'pm');
+      await createUserOrganization(testUser.id, org1.id, 'member');
       const testToken = await getAuthToken(orgAdmin.email, 'password123');
 
       const workspaceName = `Transaction Test WS ${timestamp}`;
@@ -654,7 +654,7 @@ describe('Workspace RBAC (E2E)', () => {
   async function createUserOrganization(
     userId: string,
     organizationId: string,
-    role: 'owner' | 'admin' | 'pm' | 'viewer',
+    role: 'owner' | 'admin' | 'member' | 'viewer',
   ): Promise<UserOrganization> {
     const userOrgRepo = dataSource.getRepository(UserOrganization);
     const userOrg = userOrgRepo.create({

--- a/zephix-backend/test/workspaces-admin-create.e2e-spec.ts
+++ b/zephix-backend/test/workspaces-admin-create.e2e-spec.ts
@@ -97,7 +97,7 @@ describe('Workspaces Admin Create (e2e)', () => {
       {
         userId: memberUserId,
         organizationId: orgId,
-        role: 'pm',
+        role: 'member',
         isActive: true,
       },
       {


### PR DESCRIPTION
## Scope
Two Engine 1 cleanups, two separate commits:

### Commit 1 (63644cb7): Orphan password reset token fix
Pattern A (compensation) implementation per architect decision:
- Token write transaction commits as today
- sendPasswordResetEmail wrapped in try/catch
- On email failure: delete just-written token, log error server-side
- Audit + structured log moved INSIDE try (only fires on successful send)
- Method never throws to controller from email failure
- Returns neutral response regardless of email outcome

Aligns with Engineering Quality Standards #5 (graceful errors)
and #8 (idempotent writes) per blueprint Section 10.2.

Test added: `deletes token and returns neutral response when email send fails`.
Happy-path test updated to assert audit fires only on success.

### Commit 2 (7d8ce608): pm org-role migration to member (AD-011)
Per AD-011, org-level role enum is Admin / Member / Viewer.
'pm' was a deprecated bridge to MEMBER; this commit removes it.

Changes:
- Migration `18000000000076-ReplaceLegacyOrgRolePmWithMember.ts`:
  updates `user_organizations.role` and `invitations`/`org_invites`
  when present
- Pre-migration staging count: 59 rows (all test/seed data:
  zephix.dev, zephix.ai, staging/sandbox/test addresses; zero real
  user accounts)
- Postgres enum: `member` added via `ADD VALUE IF NOT EXISTS`;
  existing `pm` enum value remains (Postgres limitation, acceptable)
- Entities, DTOs, OpenAPI enums updated to `member`
- Removed admin controller `member → pm` legacy shim
- RolesGuard hierarchy updated to `member`
- Admin demo matrix: `name: 'pm'` → `name: 'member'`
- Seeds, dev scripts, scale-seed generators aligned
- Tests updated: org-level `pm` → `member`
- Migration unit test added

Inbound compatibility: `LEGACY_ROLE_MAPPING.pm` retained for
normalizing legacy JWT/payload tokens still carrying `pm`.

## Excluded from this PR
- `document-lifecycle.service.ts` workflow role label `pm`
  (different semantic, separate cleanup later if AD-011 reconciliation extends)
- `users.role` column (different table, different blast radius,
  deferred follow-up)
- `pm@zephix.ai` email local-part, `/api/pm/` routes, `../pm/`
  module paths (not org-roles)

## Verification
- Backend tsc: PASS (both commits)
- Cleanup 1 tests: 14/14 password-reset suite passes
- Cleanup 2 tests: migration unit test, guard spec, platform-roles spec all PASS
- No new failures vs baseline

## References
- `docs/architecture/ZEPHIX_ARCHITECTURE_BLUEPRINT_v2.md`
  (Engine 1 in Section 4, AD-011 in Section 2)
- V16 evidence (org-level pm role analysis)
- Phase 3 diagnostic from password reset 500 investigation

## Migration safety
Migration is one-way (no rollback to `pm` since this is the cleanup
path). Documented in migration `down()` method. Pre-migration
verification confirms 0 real-user accounts affected.

## Reviewer
- Architectural review: Senior Solution Architect (Claude)
- Execution: Cursor

Four architect review gates passed during execution: plan review (Gate 1),
Cleanup 1 commit review (Gate 2), Cleanup 2 discovery scope review (Gate 3),
Cleanup 2 commit review with pre-migration data confirmation (Gate 4).
