### PR TITLE
cleanup: Engine 1 — replace workspace_admin alias with workspace_owner (AD-011, V17)

### DIFF
--- a/zephix-backend/src/modules/work-management/services/task-comments.service.ts
+++ b/zephix-backend/src/modules/work-management/services/task-comments.service.ts
@@ -90,7 +90,7 @@ export class TaskCommentsService {
     const role = normalizeWorkspaceRole(
       await this.workspaceRoleGuard.getWorkspaceRole(workspaceId, auth.userId),
     );
-    const elevatedRoles: WorkspaceRole[] = ['workspace_admin', 'delivery_owner'];
+    const elevatedRoles: WorkspaceRole[] = ['workspace_owner', 'delivery_owner'];
     if (role && elevatedRoles.includes(role)) {
       return;
     }

--- a/zephix-backend/src/modules/workspace-access/workspace-access.service.ts
+++ b/zephix-backend/src/modules/workspace-access/workspace-access.service.ts
@@ -247,7 +247,6 @@ export class WorkspaceAccessService {
   /**
    * Check if actual role satisfies required role.
    * User-facing workspace roles: workspace_owner > workspace_member > workspace_viewer.
-   * `workspace_admin` is a legacy alias for workspace_owner (same level).
    * `delivery_owner` and `stakeholder` are project-scoped labels that may still appear on
    * membership rows; they remain in this map only for safe comparison with existing data.
    *
@@ -265,7 +264,6 @@ export class WorkspaceAccessService {
 
     const roleHierarchy: Record<WorkspaceRole, number> = {
       workspace_owner: 4,
-      workspace_admin: 4, // canonical alias for workspace_owner — same privilege level
       delivery_owner: 3,
       workspace_member: 2,
       workspace_viewer: 1,

--- a/zephix-backend/src/modules/workspace-access/workspace-role-guard.service.ts
+++ b/zephix-backend/src/modules/workspace-access/workspace-role-guard.service.ts
@@ -71,8 +71,8 @@ export class WorkspaceRoleGuardService {
       });
     }
 
-    // Write roles: delivery_owner and workspace_owner (workspace_admin is the canonical alias — accept both)
-    const writeRoles: WorkspaceRole[] = ['delivery_owner', 'workspace_owner', 'workspace_admin'];
+    // Write roles: delivery_owner and workspace_owner
+    const writeRoles: WorkspaceRole[] = ['delivery_owner', 'workspace_owner'];
 
     if (!writeRoles.includes(membership.role)) {
       throw new ForbiddenException({

--- a/zephix-backend/src/modules/workspaces/entities/workspace.entity.ts
+++ b/zephix-backend/src/modules/workspaces/entities/workspace.entity.ts
@@ -48,8 +48,7 @@ export enum WorkspaceVisibility {
  * - These provide granular permissions that Linear and Monday don't have
  */
 export type WorkspaceRole =
-  | 'workspace_owner'  // Legacy DB value — use workspace_admin in new code
-  | 'workspace_admin'  // Canonical alias for workspace_owner (DB still stores workspace_owner)
+  | 'workspace_owner'  // Canonical workspace owner role
   | 'workspace_member' // Internal: Workspace Member access
   | 'workspace_viewer' // Internal: Workspace Viewer access
   | 'delivery_owner'   // Project-scoped: DO NOT MIGRATE - remains project-level
@@ -57,17 +56,14 @@ export type WorkspaceRole =
 
 /**
  * Normalize a raw workspace role string.
- * Maps the legacy DB value workspace_owner → canonical workspace_admin.
- * All other values are returned unchanged.
- * Backward compatibility: workspace_owner is still accepted everywhere.
+ * Returns workspace role when it matches the canonical role set.
  */
 export function normalizeWorkspaceRole(
   role: string | null | undefined,
 ): WorkspaceRole | null {
   if (!role) return null;
-  if (role === 'workspace_owner') return 'workspace_admin';
   const valid: WorkspaceRole[] = [
-    'workspace_admin',
+    'workspace_owner',
     'workspace_member',
     'workspace_viewer',
     'delivery_owner',

--- a/zephix-frontend/src/utils/__tests__/access.test.ts
+++ b/zephix-frontend/src/utils/__tests__/access.test.ts
@@ -10,7 +10,7 @@ import {
   isWorkspaceMember,
   isWorkspaceViewer,
   canSeeCost,
-  canSeeWorkspaceAdmin,
+  canSeeWorkspaceOwner,
   canSeeOrgAdmin,
   canManageTemplates,
   canInviteToWorkspace,
@@ -114,18 +114,18 @@ describe('access utility', () => {
     });
   });
 
-  describe('canSeeWorkspaceAdmin', () => {
+  describe('canSeeWorkspaceOwner', () => {
     it('returns true for platform admin', () => {
-      expect(canSeeWorkspaceAdmin(null, 'ADMIN')).toBe(true);
+      expect(canSeeWorkspaceOwner(null, 'ADMIN')).toBe(true);
     });
     it('returns true for workspace_owner', () => {
-      expect(canSeeWorkspaceAdmin('workspace_owner', 'MEMBER')).toBe(true);
+      expect(canSeeWorkspaceOwner('workspace_owner', 'MEMBER')).toBe(true);
     });
     it('returns false for workspace_member + MEMBER', () => {
-      expect(canSeeWorkspaceAdmin('workspace_member', 'MEMBER')).toBe(false);
+      expect(canSeeWorkspaceOwner('workspace_member', 'MEMBER')).toBe(false);
     });
     it('returns false for VIEWER', () => {
-      expect(canSeeWorkspaceAdmin('workspace_viewer', 'VIEWER')).toBe(false);
+      expect(canSeeWorkspaceOwner('workspace_viewer', 'VIEWER')).toBe(false);
     });
   });
 

--- a/zephix-frontend/src/utils/access.ts
+++ b/zephix-frontend/src/utils/access.ts
@@ -96,8 +96,8 @@ export function canSeeCost(
   return normalized !== PLATFORM_ROLE.VIEWER;
 }
 
-/** Workspace admin (settings, invite) — workspace_owner or platform admin */
-export function canSeeWorkspaceAdmin(
+/** Workspace owner (settings, invite) — workspace_owner or platform admin */
+export function canSeeWorkspaceOwner(
   workspaceRole: string | null | undefined,
   platformRole: string | null | undefined,
 ): boolean {


### PR DESCRIPTION
## Scope
Per AD-011, canonical workspace role is `workspace_owner`. The
`workspace_admin` alias was a TypeScript-only convenience that
was never stored in the database for role columns. This PR
removes the alias from all active code surfaces.

## Changes (commit 999289e8)
17 occurrences renamed across 6 files:

**Backend (4 files):**
- `zephix-backend/src/modules/workspaces/entities/workspace.entity.ts`
- `zephix-backend/src/modules/workspace-access/workspace-role-guard.service.ts`
- `zephix-backend/src/modules/workspace-access/workspace-access.service.ts`
- `zephix-backend/src/modules/work-management/services/task-comments.service.ts`

**Frontend (2 files):**
- `zephix-frontend/src/utils/access.ts` (function rename: `canSeeWorkspaceAdmin` → `canSeeWorkspaceOwner`)
- `zephix-frontend/src/utils/__tests__/access.test.ts`

**Changes:**
- Type unions, role-map keys, function names aligned to `workspace_owner`
- WorkspaceRole union deduplicated after rename
- Test fixtures updated

## Discovery accuracy
V17 audit estimated 12 occurrences. Actual: 19 total (17 active +
2 in migrations). +7 variance acceptable; audit was approximately
right. Migrations excluded by architect decision.

## Excluded from this PR (architect decision)
- **Migration files** (immutable historical record):
  - `1765000000004-AddAdminRoleToWorkspaceMembers.ts` (comment retained)
  - `18000000000071-GovernanceCatalogNinePolicies.ts` (seed data retained)
- **Backlog item:** Governance catalog seed data may have policy
  params referencing `workspace_admin`. Separate audit prompt
  needed to determine if data migration is warranted.

## Verification
- Backend tsc: PASS
- Frontend tsc: PASS
- Backend tests: 2077 pass / 47 fail (no new failures vs baseline)
- Frontend tests: 834 pass / 121 fail (no new failures vs baseline)
- Residual `workspace_admin` references: 2 (both in migrations,
  per architect-decided exclusion)

## References
- `docs/architecture/ZEPHIX_ARCHITECTURE_BLUEPRINT_v2.md` Section 2 (AD-011)
- V17 evidence (workspace_admin alias analysis)
- `.cursor/rules/architecture-principles.mdc` (canonical role model)

## Reviewer
- Architectural review: Senior Solution Architect (Claude)
- Execution: Cursor

Three architect review gates passed: plan review, discovery scope
(Gate 2 — migration exclusion decided), commit review (Gate 4).
