### PR TITLE
fix(ci): wait for migrations before auth-dev-path demo bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,7 +506,57 @@ jobs:
           INTEGRATION_ENCRYPTION_KEY: ${{ env.INTEGRATION_ENCRYPTION_KEY }}
         run: |
           (npm run start:prod &)
-          sleep 15
+          echo "Wait for migrations to complete (poll information_schema; max 60s, exponential backoff)"
+          node <<'NODE'
+          const { Client } = require('pg');
+          const tables = ['organizations', 'users', 'user_organizations', 'workspaces'];
+          const url = process.env.DATABASE_URL;
+          if (!url) {
+            console.error('DATABASE_URL is required');
+            process.exit(1);
+          }
+          const deadline = Date.now() + 60000;
+          let delayMs = 1000;
+          const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+          (async () => {
+            while (Date.now() < deadline) {
+              const c = new Client({ connectionString: url });
+              try {
+                await c.connect();
+                let allPresent = true;
+                for (const t of tables) {
+                  const r = await c.query(
+                    `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1`,
+                    [t],
+                  );
+                  if (r.rowCount === 0) {
+                    allPresent = false;
+                    break;
+                  }
+                }
+                await c.end();
+                if (allPresent) {
+                  console.log('✓ All expected tables present (migrations reached demo-bootstrap prerequisites)');
+                  process.exit(0);
+                }
+              } catch {
+                try {
+                  await c.end();
+                } catch {
+                  /* ignore */
+                }
+              }
+              console.log(`Tables not ready yet; sleeping ${delayMs}ms...`);
+              await sleep(delayMs);
+              delayMs = Math.min(delayMs * 2, 16000);
+            }
+            console.error('✗ Timeout: expected tables not present after 60s (organizations, users, user_organizations, workspaces)');
+            process.exit(1);
+          })().catch((e) => {
+            console.error(e);
+            process.exit(1);
+          });
+          NODE
           node dist/src/scripts/demo/bootstrap.js || true
           BASE_URL=http://localhost:3000 bash scripts/smoke-auth-health.sh
 


### PR DESCRIPTION
## Summary
Eliminates the race in `Auth dev path (AUTO_MIGRATE)` where `demo/bootstrap.js` and smoke could run while `AUTO_MIGRATE` (inside `start:prod`) was still applying migrations.

## Evidence
- PR #222: first CI run failed (`organizations` missing); retry passed — timing lottery.
- Root cause: fixed `sleep 15` was not tied to migration completion.

## Change
- Replace fixed sleep with a Node script (uses existing `pg` from `zephix-backend`) that polls `information_schema.tables` for `organizations`, `users`, `user_organizations`, `workspaces` with exponential backoff (1s → 16s cap) until all exist or 60s timeout.

## Out of scope
- **auth-prod-path:** already runs `npm run db:migrate` before demo bootstrap — no race.
- No app or migration changes.

## Standard
Reliability / bounded waits (Engineering Quality Standard #8).

Reviewer: Architect (Claude)  
Executor: Cursor

Made with [Cursor](https://cursor.com)