### PR TITLE
chore: add branch hygiene rule for Cursor discovery prompts

### DIFF
--- a/.cursor/rules/architecture-principles.mdc
+++ b/.cursor/rules/architecture-principles.mdc
@@ -79,6 +79,25 @@ alwaysApply: true
 - One AD = one commit when feasible
 - If unsure: STOP and ask, do not guess
 
+## Branch hygiene before discovery
+
+Before any audit, discovery, or grep-based investigation prompt:
+
+1. git fetch origin
+2. git checkout staging (or current default branch)
+3. git pull origin staging
+4. Verify: git log --oneline | head -3 should show recent merges
+5. Only then run discovery commands
+
+If the architect's prompt requires investigating a different branch
+specifically, the prompt will say so explicitly. Default is always:
+discovery runs on origin/staging.
+
+Why: Discovery on a stale branch produces false-positive findings
+("this code has a bug" when it was already fixed by a merge the
+local branch is missing). This wastes architect review cycles and
+erodes trust in audit reports.
+
 ## Stop conditions (always STOP and report)
 - Pre-flight verification fails
 - TypeScript compilation introduces NEW errors


### PR DESCRIPTION
Adds 'Branch hygiene before discovery' section to .cursor/rules/architecture-principles.mdc.

Without this rule, discovery prompts run on stale branches can produce false-positive 'regression' findings (as occurred when investigating Category D items in PR #221's wake — investigation was on stale fix/ci-auth-dev-path-migration-race branch which predated PR #221's merge into staging).

Single file modification. No code changes. Pure persistent-context update.

Reviewer: Senior Solution Architect (Claude)
Executor: Cursor

Made with [Cursor](https://cursor.com)