### PR TITLE
feat: AD-027 permission matrix test harness (tenancy-aware)

### DIFF
--- a/zephix-backend/package.json
+++ b/zephix-backend/package.json
@@ -21,6 +21,8 @@
       "lint": "eslint \"{src,apps,libs}/**/*.ts\" --fix",
       "lint:changed": "bash scripts/lint-changed.sh",
       "test": "jest",
+      "test:permission-matrix": "jest --config ./test/jest-permission-matrix.json --runInBand",
+      "test:permission-matrix:example": "node -e \"if(!process.env.DATABASE_URL){console.log('SKIP: no DATABASE_URL');process.exit(0)}\" && jest --config ./test/jest-permission-matrix.example.json --runInBand --forceExit",
       "test:gating": "jest --config jest.gating.config.js --passWithNoTests --forceExit",
       "test:unit": "jest --testPathIgnorePatterns=\"e2e|integration\" --passWithNoTests",
       "test:watch": "jest --watch",

--- a/zephix-backend/test/jest-permission-matrix.example.json
+++ b/zephix-backend/test/jest-permission-matrix.example.json
@@ -1,0 +1,14 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testMatch": ["**/test/permission-matrix/matrix-example.*.e2e-spec.ts"],
+  "transform": {
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "tsconfig": "<rootDir>/tsconfig.spec.json"
+      }
+    ]
+  }
+}

--- a/zephix-backend/test/jest-permission-matrix.json
+++ b/zephix-backend/test/jest-permission-matrix.json
@@ -1,0 +1,14 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testMatch": ["**/test/permission-matrix/__tests__/**/*.spec.ts"],
+  "transform": {
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "tsconfig": "<rootDir>/tsconfig.spec.json"
+      }
+    ]
+  }
+}

--- a/zephix-backend/test/permission-matrix/__tests__/harness.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/harness.spec.ts
@@ -1,0 +1,71 @@
+import type { INestApplication } from '@nestjs/common';
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  expectAccessible,
+  expectAuditEvent,
+  expectForbidden,
+  expectNotFound,
+  expectUnauthenticated,
+} from '../assertions';
+import { getMatrixTestCaseCount, runMatrixTest } from '../matrix-test';
+
+describe('AD-027 permission-matrix harness (unit)', () => {
+  it('getMatrixTestCaseCount: workspace → 5, org/platform → 4', () => {
+    expect(getMatrixTestCaseCount('workspace')).toBe(5);
+    expect(getMatrixTestCaseCount('org')).toBe(4);
+    expect(getMatrixTestCaseCount('platform')).toBe(4);
+  });
+
+  it('expectAccessible accepts 2xx', () => {
+    expectAccessible({ status: 200 });
+    expectAccessible({ status: 204 });
+  });
+
+  it('expectForbidden defaults to 403', () => {
+    expectForbidden({ status: 403 }, 403);
+    expect(() => expectForbidden({ status: 200 }, 403)).toThrow();
+  });
+
+  it('expectForbidden honors 404 override', () => {
+    expectForbidden({ status: 404 }, 404);
+  });
+
+  it('expectNotFound', () => {
+    expectNotFound({ status: 404 });
+    expect(() => expectNotFound({ status: 403 })).toThrow();
+  });
+
+  it('expectUnauthenticated', () => {
+    expectUnauthenticated({ status: 401 });
+    expect(() => expectUnauthenticated({ status: 200 })).toThrow();
+  });
+
+  it('runMatrixTest throws for non-workspace scope (v1)', () => {
+    expect(() =>
+      runMatrixTest('n/a', 'GET', '/api/x/:id', {
+        app: {} as INestApplication,
+        getFixtures: () => ({}) as never,
+        scope: 'org',
+        requiredWorkspaceRole: 'workspace_owner',
+        targetWorkspace: 'workspaceA1',
+      }),
+    ).toThrow(/only scope "workspace"/);
+  });
+
+  it('expectAuditEvent returns true and logs (stub)', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const out = await expectAuditEvent({
+      decision: 'DENY',
+      endpoint: 'PATCH /api/workspaces/:id/settings',
+      actorId: 'user-1',
+      requiredRole: 'workspace_owner',
+      actualRole: 'workspace_member',
+    });
+    expect(out).toBe(true);
+    expect(log).toHaveBeenCalledWith(
+      'AUDIT_EVENT_STUB',
+      expect.objectContaining({ decision: 'DENY', actorId: 'user-1' }),
+    );
+    log.mockRestore();
+  });
+});

--- a/zephix-backend/test/permission-matrix/assertions.ts
+++ b/zephix-backend/test/permission-matrix/assertions.ts
@@ -1,0 +1,87 @@
+import { expect } from '@jest/globals';
+import { assertCrossTenantWorkspace403 } from '../tenancy/helpers/cross-tenant-workspace.test-helper';
+import type { INestApplication } from '@nestjs/common';
+import type { Test } from 'supertest';
+import { createSupertestMethodFn } from './request-builder';
+
+export interface AuditEventExpectation {
+  decision: 'ALLOW' | 'DENY';
+  endpoint: string;
+  actorId: string;
+  requiredRole: string;
+  actualRole: string;
+}
+
+/**
+ * AD-027 Section 12.3 — Guard-audit correlation (deferred).
+ * TODO: wire when `GuardAuditInterceptor` lands; assert `audit_events` row.
+ *
+ * @returns always `true`; does not throw. Logs expected shape for future wiring.
+ */
+export async function expectAuditEvent(
+  args: AuditEventExpectation,
+): Promise<true> {
+  console.log('AUDIT_EVENT_STUB', args);
+  return true;
+}
+
+/** Response shape from supertest (superagent). */
+export function expectAccessible(res: { status: number }): void {
+  expect(res.status).toBeGreaterThanOrEqual(200);
+  expect(res.status).toBeLessThan(300);
+}
+
+export function expectForbidden(
+  res: { status: number },
+  expectedStatus: 403 | 404 = 403,
+): void {
+  expect(res.status).toBe(expectedStatus);
+}
+
+export function expectNotFound(res: { status: number }): void {
+  expect(res.status).toBe(404);
+}
+
+export function expectUnauthenticated(res: { status: number }): void {
+  expect(res.status).toBe(401);
+}
+
+export interface CrossTenantForbiddenArgs {
+  app: INestApplication;
+  token: string;
+  workspaceId: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  /** Path with :id or :workspaceId placeholder; replaced by shared helper */
+  endpointTemplate: string;
+  body?: object;
+  query?: Record<string, string>;
+  /** Default 403 per platform policy; override to 404 for existence-masking routes */
+  expectedStatus?: 403 | 404;
+}
+
+/**
+ * Test 5 (workspace scope): reuses `assertCrossTenantWorkspace403` — do not duplicate
+ * cross-tenant assertion logic.
+ */
+export async function expectCrossTenantForbidden(
+  args: CrossTenantForbiddenArgs,
+): Promise<void> {
+  const requestFn = createSupertestMethodFn(args.app);
+  // supertest agent is not typed as `(method, path) => Test`; bridge matches `cross-tenant-workspace.test-helper` contract
+  await assertCrossTenantWorkspace403({
+    request: requestFn,
+    token: args.token,
+    workspaceId: args.workspaceId,
+    method: args.method,
+    endpoint: args.endpointTemplate,
+    body: args.body,
+    query: args.query,
+    expectedStatus: args.expectedStatus ?? 403,
+  });
+}
+
+/** Execute supertest chain and return response (does not assert status). */
+export async function execRequest(chain: Test): Promise<{ status: number; body: unknown }> {
+  const res = await chain;
+  return { status: res.status, body: res.body };
+}

--- a/zephix-backend/test/permission-matrix/fixtures.ts
+++ b/zephix-backend/test/permission-matrix/fixtures.ts
@@ -1,0 +1,255 @@
+import * as bcrypt from 'bcrypt';
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { Organization } from '../../src/organizations/entities/organization.entity';
+import { UserOrganization } from '../../src/organizations/entities/user-organization.entity';
+import { User } from '../../src/modules/users/entities/user.entity';
+import { Workspace } from '../../src/modules/workspaces/entities/workspace.entity';
+import { WorkspaceMember } from '../../src/modules/workspaces/entities/workspace-member.entity';
+import { loginUser } from '../helpers/auth-test-helpers';
+
+export type WorkspaceMembershipRole =
+  | 'workspace_owner'
+  | 'delivery_owner'
+  | 'workspace_member'
+  | 'workspace_viewer';
+
+export type RequiredWorkspaceRoleForMatrix =
+  | 'workspace_owner'
+  | 'delivery_owner'
+  | 'workspace_member'
+  | 'workspace_viewer';
+
+export interface PermissionMatrixFixtures {
+  orgA: Organization;
+  orgB: Organization;
+  workspaceA1: Workspace;
+  workspaceA2: Workspace;
+  workspaceB1: Workspace;
+  users: {
+    platformAdminA: User;
+    memberNoWorkspace: User;
+    ownerA1: User;
+    ownerB1: User;
+    deliveryOwnerA1: User;
+    memberA1: User;
+    viewerA1: User;
+    dualOwnerA1A2: User;
+  };
+  tokens: {
+    platformAdminA: string;
+    memberNoWorkspace: string;
+    ownerA1: string;
+    ownerB1: string;
+    deliveryOwnerA1: string;
+    memberA1: string;
+    viewerA1: string;
+    dualOwnerA1A2: string;
+  };
+}
+
+const PASSWORD = 'password123';
+
+async function tokenFor(app: INestApplication, email: string): Promise<string> {
+  const { accessToken } = await loginUser(app, email, PASSWORD);
+  return accessToken;
+}
+
+/**
+ * Seeds Org_A, Org_B, three workspaces, and users at every tier required by AD-027 Section 5.2.
+ * Uses `loginUser` from `auth-test-helpers` — does not modify existing E2E files.
+ */
+export async function buildPermissionMatrixFixtures(
+  app: INestApplication,
+): Promise<PermissionMatrixFixtures> {
+  const ds = app.get(DataSource);
+  const ts = Date.now();
+  const suffix = `${ts}-${Math.floor(Math.random() * 1e6)}`;
+
+  const orgRepo = ds.getRepository(Organization);
+  const userRepo = ds.getRepository(User);
+  const uoRepo = ds.getRepository(UserOrganization);
+  const wsRepo = ds.getRepository(Workspace);
+  const wmRepo = ds.getRepository(WorkspaceMember);
+
+  const slug = (base: string) => `${base}-${suffix}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+
+  const orgA = await orgRepo.save(
+    orgRepo.create({
+      name: `AD027 Org A ${suffix}`,
+      slug: slug('org-a'),
+      status: 'trial',
+    }),
+  );
+  const orgB = await orgRepo.save(
+    orgRepo.create({
+      name: `AD027 Org B ${suffix}`,
+      slug: slug('org-b'),
+      status: 'trial',
+    }),
+  );
+
+  async function createUser(
+    emailLocal: string,
+    orgId: string,
+    userRole: string,
+    uoRole: 'owner' | 'admin' | 'member' | 'viewer',
+  ): Promise<User> {
+    const hashed = await bcrypt.hash(PASSWORD, 10);
+    const u = await userRepo.save(
+      userRepo.create({
+        email: `${emailLocal}-${suffix}@ad027-matrix.test`,
+        password: hashed,
+        firstName: emailLocal,
+        lastName: 'Matrix',
+        organizationId: orgId,
+        role: userRole,
+        isActive: true,
+        isEmailVerified: true,
+      }),
+    );
+    await uoRepo.save(
+      uoRepo.create({
+        userId: u.id,
+        organizationId: orgId,
+        role: uoRole,
+        isActive: true,
+        joinedAt: new Date(),
+      }),
+    );
+    return u;
+  }
+
+  const platformAdminA = await createUser('adm', orgA.id, 'admin', 'admin');
+  const memberNoWorkspace = await createUser('nows', orgA.id, 'member', 'member');
+  const ownerA1 = await createUser('owna1', orgA.id, 'member', 'member');
+  const dualOwnerA1A2 = await createUser('dual', orgA.id, 'member', 'member');
+  const deliveryOwnerA1 = await createUser('deliv', orgA.id, 'member', 'member');
+  const memberA1 = await createUser('mem', orgA.id, 'member', 'member');
+  const viewerA1 = await createUser('view', orgA.id, 'member', 'viewer');
+  const ownerB1 = await createUser('ownb1', orgB.id, 'member', 'member');
+
+  const workspaceA1 = await wsRepo.save(
+    wsRepo.create({
+      name: `Workspace A1 ${suffix}`,
+      slug: slug('ws-a1'),
+      organizationId: orgA.id,
+      createdBy: ownerA1.id,
+      ownerId: ownerA1.id,
+      isPrivate: false,
+    }),
+  );
+  const workspaceA2 = await wsRepo.save(
+    wsRepo.create({
+      name: `Workspace A2 ${suffix}`,
+      slug: slug('ws-a2'),
+      organizationId: orgA.id,
+      createdBy: dualOwnerA1A2.id,
+      ownerId: dualOwnerA1A2.id,
+      isPrivate: false,
+    }),
+  );
+  const workspaceB1 = await wsRepo.save(
+    wsRepo.create({
+      name: `Workspace B1 ${suffix}`,
+      slug: slug('ws-b1'),
+      organizationId: orgB.id,
+      createdBy: ownerB1.id,
+      ownerId: ownerB1.id,
+      isPrivate: false,
+    }),
+  );
+
+  async function addMember(
+    organizationId: string,
+    workspaceId: string,
+    userId: string,
+    role: WorkspaceMembershipRole,
+    createdBy: string,
+  ): Promise<void> {
+    await wmRepo.save(
+      wmRepo.create({
+        organizationId,
+        workspaceId,
+        userId,
+        role,
+        createdBy,
+      }),
+    );
+  }
+
+  await addMember(orgA.id, workspaceA1.id, ownerA1.id, 'workspace_owner', ownerA1.id);
+  await addMember(orgA.id, workspaceA1.id, dualOwnerA1A2.id, 'workspace_owner', ownerA1.id);
+  await addMember(orgA.id, workspaceA2.id, dualOwnerA1A2.id, 'workspace_owner', dualOwnerA1A2.id);
+  await addMember(orgB.id, workspaceB1.id, ownerB1.id, 'workspace_owner', ownerB1.id);
+
+  await addMember(orgA.id, workspaceA1.id, deliveryOwnerA1.id, 'delivery_owner', ownerA1.id);
+  await addMember(orgA.id, workspaceA1.id, memberA1.id, 'workspace_member', ownerA1.id);
+  await addMember(orgA.id, workspaceA1.id, viewerA1.id, 'workspace_viewer', ownerA1.id);
+
+  const users = {
+    platformAdminA,
+    memberNoWorkspace,
+    ownerA1,
+    ownerB1,
+    deliveryOwnerA1,
+    memberA1,
+    viewerA1,
+    dualOwnerA1A2,
+  };
+
+  const tokens = {
+    platformAdminA: await tokenFor(app, platformAdminA.email),
+    memberNoWorkspace: await tokenFor(app, memberNoWorkspace.email),
+    ownerA1: await tokenFor(app, ownerA1.email),
+    ownerB1: await tokenFor(app, ownerB1.email),
+    deliveryOwnerA1: await tokenFor(app, deliveryOwnerA1.email),
+    memberA1: await tokenFor(app, memberA1.email),
+    viewerA1: await tokenFor(app, viewerA1.email),
+    dualOwnerA1A2: await tokenFor(app, dualOwnerA1A2.email),
+  };
+
+  return {
+    orgA,
+    orgB,
+    workspaceA1,
+    workspaceA2,
+    workspaceB1,
+    users,
+    tokens,
+  };
+}
+
+/** Workspace-role ladder: higher index = stronger (approximate for matrix Test 2). */
+const ROLE_LADDER: RequiredWorkspaceRoleForMatrix[] = [
+  'workspace_viewer',
+  'workspace_member',
+  'delivery_owner',
+  'workspace_owner',
+];
+
+export function tierBelow(
+  required: RequiredWorkspaceRoleForMatrix,
+): RequiredWorkspaceRoleForMatrix | null {
+  const idx = ROLE_LADDER.indexOf(required);
+  if (idx <= 0) return null;
+  return ROLE_LADDER[idx - 1]!;
+}
+
+/** Map abstract tier to which fixture token key to use for requests against workspace A1 */
+export function tokenKeyForWorkspaceTier(
+  tier: RequiredWorkspaceRoleForMatrix,
+): keyof PermissionMatrixFixtures['tokens'] {
+  switch (tier) {
+    case 'workspace_owner':
+      return 'ownerA1';
+    case 'delivery_owner':
+      return 'deliveryOwnerA1';
+    case 'workspace_member':
+      return 'memberA1';
+    case 'workspace_viewer':
+      return 'viewerA1';
+    default:
+      return 'viewerA1';
+  }
+}

--- a/zephix-backend/test/permission-matrix/index.ts
+++ b/zephix-backend/test/permission-matrix/index.ts
@@ -1,0 +1,34 @@
+export {
+  buildPermissionMatrixFixtures,
+  tierBelow,
+  tokenKeyForWorkspaceTier,
+  type PermissionMatrixFixtures,
+  type RequiredWorkspaceRoleForMatrix,
+  type WorkspaceMembershipRole,
+} from './fixtures';
+export { supertestMethodBridge } from '../tenancy/helpers/cross-tenant-workspace.test-helper';
+export {
+  applyPathTemplate,
+  createSupertestMethodFn,
+  createTestRequest,
+  type HttpMethod,
+  type TestRequestContext,
+} from './request-builder';
+export {
+  expectAccessible,
+  expectAuditEvent,
+  expectCrossTenantForbidden,
+  expectForbidden,
+  expectNotFound,
+  expectUnauthenticated,
+  execRequest,
+  type AuditEventExpectation,
+  type CrossTenantForbiddenArgs,
+} from './assertions';
+export {
+  getMatrixTestCaseCount,
+  runMatrixTest,
+  type MatrixScope,
+  type RunMatrixTestOptions,
+  type TargetWorkspaceKey,
+} from './matrix-test';

--- a/zephix-backend/test/permission-matrix/matrix-example.workspace-settings-patch.e2e-spec.ts
+++ b/zephix-backend/test/permission-matrix/matrix-example.workspace-settings-patch.e2e-spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical AD-027 example: matrix tests against a real workspace-scoped endpoint
+ * that requires `workspace_owner` via `RequireWorkspacePermissionGuard`
+ * (`edit_workspace_settings`).
+ *
+ * Requires DATABASE_URL (same as other E2E-style tests). Skipped when unset.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from '../../src/app.module';
+import {
+  buildPermissionMatrixFixtures,
+  runMatrixTest,
+  type PermissionMatrixFixtures,
+} from './index';
+
+/** Requires a reachable DB (use `npm run test:permission-matrix:example` when DATABASE_URL is set). */
+const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
+
+describeOrSkip('AD-027 matrix example — PATCH /api/workspaces/:id/settings', () => {
+  jest.setTimeout(120000);
+
+  let app: INestApplication;
+  let fixtures: PermissionMatrixFixtures;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    fixtures = await buildPermissionMatrixFixtures(app);
+  });
+
+  afterAll(async () => {
+    try {
+      await app?.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  runMatrixTest(
+    'PATCH /api/workspaces/:id/settings (workspace_owner, edit_workspace_settings)',
+    'PATCH',
+    '/api/workspaces/:id/settings',
+    {
+      app,
+      getFixtures: () => fixtures,
+      scope: 'workspace',
+      requiredWorkspaceRole: 'workspace_owner',
+      targetWorkspace: 'workspaceA1',
+      action: 'config',
+      body: { name: `matrix-example-${Date.now()}` },
+    },
+  );
+});

--- a/zephix-backend/test/permission-matrix/matrix-test.ts
+++ b/zephix-backend/test/permission-matrix/matrix-test.ts
@@ -1,0 +1,180 @@
+import type { INestApplication } from '@nestjs/common';
+import {
+  PermissionMatrixFixtures,
+  RequiredWorkspaceRoleForMatrix,
+  tierBelow,
+  tokenKeyForWorkspaceTier,
+} from './fixtures';
+import {
+  expectAccessible,
+  expectCrossTenantForbidden,
+  expectForbidden,
+  expectUnauthenticated,
+  execRequest,
+} from './assertions';
+import { applyPathTemplate, createTestRequest, type HttpMethod } from './request-builder';
+
+export type MatrixScope = 'workspace' | 'org' | 'platform';
+
+export type TargetWorkspaceKey = 'workspaceA1' | 'workspaceA2' | 'workspaceB1';
+
+export interface RunMatrixTestOptions {
+  app: INestApplication;
+  /** Lazy access so fixtures can be created in `beforeAll` */
+  getFixtures: () => PermissionMatrixFixtures;
+  scope: MatrixScope;
+  /** Workspace role required for success (maps to fixture tokens). */
+  requiredWorkspaceRole: RequiredWorkspaceRoleForMatrix;
+  /** Which workspace id is substituted into the path template. */
+  targetWorkspace: TargetWorkspaceKey;
+  body?: unknown;
+  query?: Record<string, string>;
+  /** Extra `:param` replacements beyond `id` / `workspaceId` / `wsId`. */
+  extraPathParams?: Record<string, string>;
+  /**
+   * Status for generic forbidden (Tests 2–3). Default 403.
+   * Use 404 for routes that mask existence (AD-027 — document per endpoint).
+   */
+  forbiddenStatus?: 403 | 404;
+  /** Cross-tenant (Test 5). Default 403; use 404 when endpoint masks existence. */
+  crossTenantExpectedStatus?: 403 | 404;
+  /** Document-only until guard-audit lands (AD-027 Section 12). */
+  action?: string;
+}
+
+export function getMatrixTestCaseCount(scope: MatrixScope): number {
+  return scope === 'workspace' ? 5 : 4;
+}
+
+function workspaceIdOf(
+  f: PermissionMatrixFixtures,
+  key: TargetWorkspaceKey,
+): string {
+  return f[key].id;
+}
+
+function tokenForRequiredRole(f: PermissionMatrixFixtures, role: RequiredWorkspaceRoleForMatrix): string {
+  const k = tokenKeyForWorkspaceTier(role);
+  return f.tokens[k];
+}
+
+function tokenOneTierBelow(
+  f: PermissionMatrixFixtures,
+  required: RequiredWorkspaceRoleForMatrix,
+): string {
+  const below = tierBelow(required);
+  if (!below) {
+    return f.tokens.memberNoWorkspace;
+  }
+  const k = tokenKeyForWorkspaceTier(below);
+  return f.tokens[k];
+}
+
+function buildPath(
+  pathTemplate: string,
+  workspaceId: string,
+  extra?: Record<string, string>,
+): string {
+  const base = { id: workspaceId, workspaceId, wsId: workspaceId };
+  return applyPathTemplate(pathTemplate, { ...base, ...extra });
+}
+
+/**
+ * AD-027 Section 5 — generates standard matrix cases for an endpoint.
+ * Workspace scope: 5 tests (includes mandatory cross-tenant isolation).
+ * Org/platform scope: 4 tests (cross-tenant pattern differs; extend in later batch).
+ */
+export function runMatrixTest(
+  describeTitle: string,
+  method: HttpMethod,
+  pathTemplate: string,
+  opts: RunMatrixTestOptions,
+): void {
+  if (opts.scope !== 'workspace') {
+    throw new Error(
+      'permission-matrix runMatrixTest (v1): only scope "workspace" is implemented. Extend harness for org/platform batch.',
+    );
+  }
+
+  describe(describeTitle, () => {
+    const forbidden = opts.forbiddenStatus ?? 403;
+
+    it('Test 1: required workspace role can access → success', async () => {
+      const f = opts.getFixtures();
+      const wsId = workspaceIdOf(f, opts.targetWorkspace);
+      const path = buildPath(pathTemplate, wsId, opts.extraPathParams);
+      const token = tokenForRequiredRole(f, opts.requiredWorkspaceRole);
+      const res = await execRequest(
+        createTestRequest(method, path, {
+          app: opts.app,
+          accessToken: token,
+          body: opts.body,
+          query: opts.query,
+        }),
+      );
+      expectAccessible(res);
+    });
+
+    it('Test 2: role one tier below required → forbidden', async () => {
+      const f = opts.getFixtures();
+      const wsId = workspaceIdOf(f, opts.targetWorkspace);
+      const path = buildPath(pathTemplate, wsId, opts.extraPathParams);
+      const token = tokenOneTierBelow(f, opts.requiredWorkspaceRole);
+      const res = await execRequest(
+        createTestRequest(method, path, {
+          app: opts.app,
+          accessToken: token,
+          body: opts.body,
+          query: opts.query,
+        }),
+      );
+      expectForbidden(res, forbidden);
+    });
+
+    it('Test 3: user in org but no workspace membership → forbidden', async () => {
+      const f = opts.getFixtures();
+      const wsId = workspaceIdOf(f, opts.targetWorkspace);
+      const path = buildPath(pathTemplate, wsId, opts.extraPathParams);
+      const res = await execRequest(
+        createTestRequest(method, path, {
+          app: opts.app,
+          accessToken: f.tokens.memberNoWorkspace,
+          body: opts.body,
+          query: opts.query,
+        }),
+      );
+      expectForbidden(res, forbidden);
+    });
+
+    it('Test 4: unauthenticated → 401', async () => {
+      const f = opts.getFixtures();
+      const wsId = workspaceIdOf(f, opts.targetWorkspace);
+      const path = buildPath(pathTemplate, wsId, opts.extraPathParams);
+      const res = await execRequest(
+        createTestRequest(method, path, {
+          app: opts.app,
+          body: opts.body,
+          query: opts.query,
+        }),
+      );
+      expectUnauthenticated(res);
+    });
+
+    if (opts.scope === 'workspace') {
+      it('Test 5: user with valid role in different org/workspace cannot access target workspace (cross-tenant)', async () => {
+        const f = opts.getFixtures();
+        const wsId = workspaceIdOf(f, opts.targetWorkspace);
+        await expectCrossTenantForbidden({
+          app: opts.app,
+          token: f.tokens.ownerB1,
+          workspaceId: wsId,
+          method,
+          endpointTemplate: pathTemplate,
+          body: opts.body as object | undefined,
+          query: opts.query,
+          expectedStatus: opts.crossTenantExpectedStatus ?? 403,
+        });
+      });
+    }
+  });
+}

--- a/zephix-backend/test/permission-matrix/request-builder.ts
+++ b/zephix-backend/test/permission-matrix/request-builder.ts
@@ -1,0 +1,68 @@
+import { INestApplication } from '@nestjs/common';
+import type { Test } from 'supertest';
+import { supertestMethodBridge } from '../tenancy/helpers/cross-tenant-workspace.test-helper';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface TestRequestContext {
+  app: INestApplication;
+  accessToken?: string;
+  /** e.g. { id: workspaceId, workspaceId: '...' } */
+  pathParams?: Record<string, string>;
+  body?: unknown;
+  query?: Record<string, string>;
+  extraHeaders?: Record<string, string>;
+}
+
+/**
+ * Supertest's `request(app)` returns an agent with `.get()`, `.post()`, etc.
+ * The shared cross-tenant helper expects a `(method, path) => Test` function.
+ * This adapter is the single bridge used by the permission matrix harness and
+ * `assertCrossTenantWorkspace403`.
+ */
+export function createSupertestMethodFn(
+  app: INestApplication,
+): (method: string, path: string) => Test {
+  return supertestMethodBridge(app.getHttpServer());
+}
+
+/**
+ * Replace `:id`, `:workspaceId`, `:wsId` in a path template using pathParams and fallbacks.
+ */
+export function applyPathTemplate(
+  pathTemplate: string,
+  pathParams: Record<string, string> = {},
+): string {
+  let p = pathTemplate;
+  for (const [key, value] of Object.entries(pathParams)) {
+    p = p.replace(new RegExp(`:${key}\\b`, 'g'), value);
+  }
+  return p;
+}
+
+/**
+ * Build a supertest chain with Authorization and optional body/query/headers.
+ */
+export function createTestRequest(
+  method: HttpMethod,
+  path: string,
+  ctx: TestRequestContext,
+): Test {
+  const fn = createSupertestMethodFn(ctx.app);
+  let chain = fn(method, path);
+  if (ctx.accessToken) {
+    chain = chain.set('Authorization', `Bearer ${ctx.accessToken}`);
+  }
+  if (ctx.query && Object.keys(ctx.query).length > 0) {
+    chain = chain.query(ctx.query);
+  }
+  if (ctx.extraHeaders) {
+    for (const [k, v] of Object.entries(ctx.extraHeaders)) {
+      chain = chain.set(k, v);
+    }
+  }
+  if (ctx.body !== undefined && method !== 'GET') {
+    chain = chain.send(ctx.body as object);
+  }
+  return chain;
+}

--- a/zephix-backend/test/tenancy/helpers/cross-tenant-workspace.test-helper.ts
+++ b/zephix-backend/test/tenancy/helpers/cross-tenant-workspace.test-helper.ts
@@ -6,19 +6,40 @@
  * information leakage about workspace existence in other organizations.
  *
  * Usage:
- *   await assertCrossTenantWorkspace403(
- *     request(app.getHttpServer()),
- *     tokenA,
- *     workspaceB.id,
- *     'GET',
- *     '/api/workspaces'
- *   );
+ *   await assertCrossTenantWorkspace403({
+ *     request: createSupertestMethodFn(app),
+ *     token: tokenA,
+ *     workspaceId: workspaceB.id,
+ *     method: 'GET',
+ *     endpoint: '/api/workspaces/:id',
+ *   });
+ *
+ * Or: `request: supertestMethodBridge(app.getHttpServer())`
  */
 
-import { Request } from 'supertest';
+import type { Server } from 'http';
+import request from 'supertest';
+import type { Test } from 'supertest';
 
+/**
+ * Supertest agent bridge: `agent.get(path)` style exposed as `(method, path) => Test`
+ * for use with `assertCrossTenantWorkspace403`.
+ */
+export function supertestMethodBridge(server: Server): (method: string, path: string) => Test {
+  const agent = request(server);
+  return (method: string, path: string): Test => {
+    const m = method.toLowerCase();
+    const fn = (agent as unknown as Record<string, (url: string) => Test>)[m];
+    if (typeof fn !== 'function') {
+      throw new Error(`supertestMethodBridge: unsupported method "${method}"`);
+    }
+    return fn.call(agent, path);
+  };
+}
+
+/** Supertest bridge: `(method, path) => Test` (see `createSupertestMethodFn` in permission-matrix harness). */
 export interface CrossTenantWorkspaceTestOptions {
-  request: Request;
+  request: (method: string, endpoint: string) => Test;
   token: string;
   workspaceId: string;
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -83,12 +104,12 @@ export async function assertCrossTenantWorkspace403(
  */
 export async function assertMultipleCrossTenantWorkspace403(
   scenarios: Array<Omit<CrossTenantWorkspaceTestOptions, 'request'>>,
-  requestFn: (method: string, endpoint: string) => Request,
+  requestFn: (method: string, endpoint: string) => Test,
 ): Promise<void> {
   for (const scenario of scenarios) {
     await assertCrossTenantWorkspace403({
       ...scenario,
-      request: requestFn(scenario.method, scenario.endpoint),
+      request: requestFn,
     });
   }
 }

--- a/zephix-backend/test/tenancy/tenant-isolation.e2e-spec.ts
+++ b/zephix-backend/test/tenancy/tenant-isolation.e2e-spec.ts
@@ -12,7 +12,10 @@ import { Workspace } from '../../src/modules/workspaces/entities/workspace.entit
 import { UserOrganization } from '../../src/organizations/entities/user-organization.entity';
 import * as bcrypt from 'bcrypt';
 import { TenantContextService } from '../../src/modules/tenancy/tenant-context.service';
-import { assertCrossTenantWorkspace403 } from './helpers/cross-tenant-workspace.test-helper';
+import {
+  assertCrossTenantWorkspace403,
+  supertestMethodBridge,
+} from './helpers/cross-tenant-workspace.test-helper';
 
 describe('Tenant Isolation (E2E)', () => {
   let app: INestApplication;
@@ -287,7 +290,7 @@ describe('Tenant Isolation (E2E)', () => {
     it('User from Org A cannot access Org B workspace via route param', async () => {
       // Use shared test helper to enforce 403 policy
       await assertCrossTenantWorkspace403({
-        request: request(app.getHttpServer()),
+        request: supertestMethodBridge(app.getHttpServer()),
         token: tokenA,
         workspaceId: workspaceB.id,
         method: 'GET',
@@ -299,7 +302,7 @@ describe('Tenant Isolation (E2E)', () => {
     it('User from Org B cannot access Org A workspace via route param', async () => {
       // Use shared test helper to enforce 403 policy
       await assertCrossTenantWorkspace403({
-        request: request(app.getHttpServer()),
+        request: supertestMethodBridge(app.getHttpServer()),
         token: tokenB,
         workspaceId: workspaceA.id,
         method: 'GET',


### PR DESCRIPTION
## Summary
Tenancy-aware permission matrix test harness per AD-027 Section 5 / 5.2, with audit assertion stub for Section 12.3.

## Includes
- `test/permission-matrix/`: fixtures, request-builder, assertions, `runMatrixTest`, index exports
- `npm run test:permission-matrix`: harness unit tests (no DB)
- `npm run test:permission-matrix:example`: optional E2E example (`PATCH /api/workspaces/:id/settings`) when `DATABASE_URL` is set
- `supertestMethodBridge` on cross-tenant helper + tenant-isolation call site fix; `assertMultipleCrossTenantWorkspace403` passes bridge correctly

## Deferred
- `expectAuditEvent` wiring when GuardAuditInterceptor lands
- `runMatrixTest` org/platform scope (throws until extended)

## Verification
- `npx tsc --noEmit` (backend): PASS
- `npm run test:permission-matrix`: 8 tests PASS
- Full `npm test`: same suite counts as local baseline (env DB failures unchanged)

Made with [Cursor](https://cursor.com)