### PR TITLE
feat: AD-027 guard-audit infrastructure (interceptor + recordGuardEvent)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,6 +783,12 @@ jobs:
           echo "Running db:verify..."
           node dist/src/scripts/db/verify.js
           echo "✅ Gate 2 passed: migrations idempotent"
+      - name: "Gate 2b: Permission matrix harness + guard-audit integration"
+        working-directory: zephix-backend
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/zephix_gate
+          NODE_ENV: test
+        run: npm run test:permission-matrix
       - name: Generate CI secrets
         run: |
           echo "JWT_SECRET=ci_$(openssl rand -hex 32)" >> "$GITHUB_ENV"

--- a/zephix-backend/src/app.module.ts
+++ b/zephix-backend/src/app.module.ts
@@ -5,7 +5,14 @@ import {
   NestModule,
 } from '@nestjs/common';
 import { SentryGlobalFilter, SentryModule } from '@sentry/nestjs/setup';
-import { APP_FILTER, APP_GUARD, APP_PIPE, APP_INTERCEPTOR } from '@nestjs/core';
+import {
+  APP_FILTER,
+  APP_GUARD,
+  APP_PIPE,
+  APP_INTERCEPTOR,
+  DiscoveryModule,
+  MetadataScanner,
+} from '@nestjs/core';
 import { CsrfGuard } from './modules/auth/guards/csrf.guard';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -54,6 +61,9 @@ import { OrganizationsModule } from './organizations/organizations.module';
 import { AdminModule } from './admin/admin.module';
 import { TenancyModule } from './modules/tenancy/tenancy.module';
 import { TenantContextInterceptor } from './modules/tenancy/tenant-context.interceptor';
+import { GuardAuditRouteRegistry } from './common/audit/guard-audit-route-registry.service';
+import { GuardAuditInterceptor } from './common/audit/guard-audit.interceptor';
+import { GuardAuditAuthzExceptionFilter } from './common/audit/guard-audit-authz-exception.filter';
 import { DocsModule } from './modules/docs/docs.module';
 import { FormsModule } from './modules/forms/forms.module';
 import { TemplateCenterModule } from './modules/template-center/template-center.module';
@@ -109,6 +119,7 @@ if (!(global as any).crypto) {
       : []),
 
     SharedModule,
+    DiscoveryModule,
     TenancyModule, // Must be imported early for global tenant context
     WorkspaceAccessModule, // Must be imported early - provides WorkspaceAccessService used by many modules
     EntitlementsModule, // Phase 3A: Global entitlement service — must be early
@@ -167,6 +178,12 @@ if (!(global as any).crypto) {
   ],
   controllers: [AppController],
   providers: [
+    MetadataScanner,
+    GuardAuditRouteRegistry,
+    {
+      provide: APP_FILTER,
+      useClass: GuardAuditAuthzExceptionFilter,
+    },
     {
       provide: APP_FILTER,
       useClass: SentryGlobalFilter,
@@ -177,6 +194,10 @@ if (!(global as any).crypto) {
     {
       provide: APP_INTERCEPTOR,
       useClass: TenantContextInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: GuardAuditInterceptor,
     },
     // {
     //   provide: APP_PIPE,

--- a/zephix-backend/src/common/audit/audit-guard-decision.decorator.ts
+++ b/zephix-backend/src/common/audit/audit-guard-decision.decorator.ts
@@ -1,0 +1,13 @@
+import { SetMetadata } from '@nestjs/common';
+import {
+  AUDIT_GUARD_DECISION_METADATA_KEY,
+  AuditGuardDecisionMetadata,
+} from './guard-audit.constants';
+
+/**
+ * Marks a route for optional guard-audit emission (AD-027 Section 12.3).
+ * Only `config` and `destructive` categories emit at the interceptor/filter layer;
+ * `read` / `write` are reserved for future extension.
+ */
+export const AuditGuardDecision = (metadata: AuditGuardDecisionMetadata) =>
+  SetMetadata(AUDIT_GUARD_DECISION_METADATA_KEY, metadata);

--- a/zephix-backend/src/common/audit/guard-audit-authz-exception.filter.spec.ts
+++ b/zephix-backend/src/common/audit/guard-audit-authz-exception.filter.spec.ts
@@ -1,0 +1,113 @@
+import { ArgumentsHost, ForbiddenException } from '@nestjs/common';
+import { GuardAuditAuthzExceptionFilter } from './guard-audit-authz-exception.filter';
+
+describe('GuardAuditAuthzExceptionFilter', () => {
+  let filter: GuardAuditAuthzExceptionFilter;
+  let audit: { recordGuardEvent: jest.Mock };
+  let registry: { resolve: jest.Mock };
+  const reply = jest.fn();
+  const end = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    audit = { recordGuardEvent: jest.fn().mockResolvedValue({}) };
+    registry = {
+      resolve: jest.fn().mockReturnValue({
+        action: 'config',
+        scope: 'workspace',
+        requiredRole: 'workspace_owner',
+      }),
+    };
+    filter = new GuardAuditAuthzExceptionFilter(
+      audit as any,
+      registry as any,
+      {
+        httpAdapter: {
+          isHeadersSent: () => false,
+          reply,
+          end,
+        },
+      } as any,
+    );
+  });
+
+  function host(req: Record<string, unknown>): ArgumentsHost {
+    const res = {};
+    return {
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+      }),
+      getArgByIndex: (i: number) => (i === 0 ? req : res),
+    } as ArgumentsHost;
+  }
+
+  it('emits DENY then delegates to BaseExceptionFilter', async () => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/probe/x',
+      path: '/api/probe/x',
+      headers: {},
+      params: {},
+      query: {},
+      user: {
+        id: '22222222-2222-4222-8222-222222222222',
+        organizationId: '11111111-1111-4111-8111-111111111111',
+        platformRole: 'ADMIN',
+      },
+    };
+
+    await filter.catch(new ForbiddenException('no'), host(req));
+
+    expect(registry.resolve).toHaveBeenCalledWith('GET', '/api/probe/x');
+    expect(audit.recordGuardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'DENY',
+        denyReason: 'no',
+      }),
+    );
+    expect(reply).toHaveBeenCalled();
+  });
+
+  it('skips when registry has no audit metadata', async () => {
+    registry.resolve.mockReturnValue(undefined);
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/x',
+      path: '/api/x',
+      headers: {},
+      params: {},
+      query: {},
+      user: {
+        id: '22222222-2222-4222-8222-222222222222',
+        organizationId: '11111111-1111-4111-8111-111111111111',
+      },
+    };
+
+    await filter.catch(new ForbiddenException(), host(req));
+
+    expect(audit.recordGuardEvent).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+
+  it('propagates audit persistence failures', async () => {
+    audit.recordGuardEvent.mockRejectedValueOnce(new Error('db'));
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/probe/x',
+      path: '/api/probe/x',
+      headers: {},
+      params: {},
+      query: {},
+      user: {
+        id: '22222222-2222-4222-8222-222222222222',
+        organizationId: '11111111-1111-4111-8111-111111111111',
+        platformRole: 'ADMIN',
+      },
+    };
+
+    await expect(
+      filter.catch(new ForbiddenException(), host(req)),
+    ).rejects.toThrow('db');
+  });
+});

--- a/zephix-backend/src/common/audit/guard-audit-authz-exception.filter.ts
+++ b/zephix-backend/src/common/audit/guard-audit-authz-exception.filter.ts
@@ -1,0 +1,76 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core';
+import { AuditService } from '../../modules/audit/services/audit.service';
+import { AuthRequest } from '../http/auth-request';
+import { getAuthContextOptional } from '../http/get-auth-context-optional';
+import { resolvePlatformRoleFromRequestUser } from '../auth/platform-roles';
+import { shouldEmitGuardAuditAction } from './guard-audit.constants';
+import { GuardAuditRouteRegistry } from './guard-audit-route-registry.service';
+import {
+  correlationIdFromRequest,
+  endpointPathForAudit,
+  extractWorkspaceIdForAudit,
+  httpExceptionMessage,
+} from './guard-audit.utils';
+
+/**
+ * Emits DENY guard audits for 401/403 (guard-thrown or handler-thrown).
+ * Uses {@link GuardAuditRouteRegistry} because {@link ArgumentsHost} here has no handler ref
+ * (see Nest RouterProxy). {@link GuardAuditInterceptor} only emits ALLOW to avoid double DENY.
+ */
+@Catch(ForbiddenException, UnauthorizedException)
+export class GuardAuditAuthzExceptionFilter extends BaseExceptionFilter {
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly registry: GuardAuditRouteRegistry,
+    adapterHost: HttpAdapterHost,
+  ) {
+    super(adapterHost.httpAdapter);
+  }
+
+  async catch(
+    exception: ForbiddenException | UnauthorizedException,
+    host: ArgumentsHost,
+  ): Promise<void> {
+    await this.emitDenyFromRoute(host, exception);
+    super.catch(exception, host);
+  }
+
+  private async emitDenyFromRoute(
+    host: ArgumentsHost,
+    exception: ForbiddenException | UnauthorizedException,
+  ): Promise<void> {
+    const req = host.switchToHttp().getRequest<AuthRequest>();
+    const pathname =
+      (req.originalUrl || req.url || req.path || '/').split('?')[0] || '/';
+    const meta = this.registry.resolve(req.method, pathname);
+    if (!meta || !shouldEmitGuardAuditAction(meta.action)) return;
+
+    const requiredRole = meta.requiredRole?.trim();
+    if (!requiredRole) return;
+
+    const auth = getAuthContextOptional(req);
+    if (!auth.organizationId || !auth.userId) return;
+
+    await this.auditService.recordGuardEvent({
+      organizationId: auth.organizationId,
+      workspaceId: extractWorkspaceIdForAudit(req),
+      actorUserId: auth.userId,
+      actorPlatformRole: resolvePlatformRoleFromRequestUser(req.user),
+      actorWorkspaceRole: null,
+      endpoint: {
+        method: req.method,
+        path: endpointPathForAudit(req),
+      },
+      decision: 'DENY',
+      denyReason: httpExceptionMessage(exception),
+      requiredRole,
+      correlationId: correlationIdFromRequest(req),
+    });
+  }
+}

--- a/zephix-backend/src/common/audit/guard-audit-route-registry.service.ts
+++ b/zephix-backend/src/common/audit/guard-audit-route-registry.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, Logger, OnModuleInit, Type } from '@nestjs/common';
+import { PATH_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
+import { RequestMethod } from '@nestjs/common/enums/request-method.enum';
+import { DiscoveryService, MetadataScanner } from '@nestjs/core';
+import { match } from 'path-to-regexp';
+import {
+  AUDIT_GUARD_DECISION_METADATA_KEY,
+  AuditGuardDecisionMetadata,
+  NEST_HTTP_GLOBAL_PREFIX,
+} from './guard-audit.constants';
+
+function addLeadingSlash(route: string): string {
+  if (!route?.length) return '';
+  return route.startsWith('/') ? route : `/${route}`;
+}
+
+function joinHttpRoute(
+  globalPrefix: string,
+  controllerPath: string,
+  methodPath: string,
+): string {
+  const gp = globalPrefix.replace(/^\/+|\/+$/g, '');
+  const cp = controllerPath.replace(/^\/+|\/+$/g, '');
+  const mp = methodPath.replace(/^\/+|\/+$/g, '');
+  const parts = [gp, cp, mp].filter((p) => p.length > 0);
+  return `/${parts.join('/')}`;
+}
+
+function httpMethodToNestEnum(method: string): RequestMethod | undefined {
+  const upper = method.toUpperCase();
+  const map: Record<string, RequestMethod> = {
+    GET: RequestMethod.GET,
+    POST: RequestMethod.POST,
+    PUT: RequestMethod.PUT,
+    PATCH: RequestMethod.PATCH,
+    DELETE: RequestMethod.DELETE,
+    OPTIONS: RequestMethod.OPTIONS,
+    HEAD: RequestMethod.HEAD,
+    ALL: RequestMethod.ALL,
+  };
+  return map[upper];
+}
+
+interface RegisteredGuardAuditRoute {
+  nestMethod: RequestMethod;
+  matcher: ReturnType<typeof match>;
+  meta: AuditGuardDecisionMetadata;
+}
+
+/**
+ * Maps HTTP requests to {@link AuditGuardDecisionMetadata} for routes decorated at bootstrap.
+ * Required for guard-thrown 401/403 because global exception filters do not receive handler refs.
+ */
+@Injectable()
+export class GuardAuditRouteRegistry implements OnModuleInit {
+  private readonly logger = new Logger(GuardAuditRouteRegistry.name);
+  private routes: RegisteredGuardAuditRoute[] = [];
+
+  constructor(
+    private readonly discovery: DiscoveryService,
+    private readonly metadataScanner: MetadataScanner,
+  ) {}
+
+  onModuleInit(): void {
+    const discovered: RegisteredGuardAuditRoute[] = [];
+    for (const wrapper of this.discovery.getControllers()) {
+      const { instance, metatype } = wrapper;
+      if (!instance || !metatype || typeof metatype !== 'function') continue;
+
+      const prototype = Object.getPrototypeOf(instance);
+      if (!prototype) continue;
+
+      const controllerPaths = this.controllerBasePaths(metatype as Type<object>);
+
+      for (const methodName of this.metadataScanner.getAllMethodNames(prototype)) {
+        if (methodName === 'constructor') continue;
+
+        const handlerFn = prototype[methodName];
+        if (typeof handlerFn !== 'function') continue;
+
+        const routePathMeta = Reflect.getMetadata(PATH_METADATA, handlerFn);
+        if (routePathMeta === undefined || routePathMeta === null) continue;
+
+        const methodFlag = Reflect.getMetadata(METHOD_METADATA, handlerFn);
+        if (methodFlag === undefined || methodFlag === null) continue;
+
+        const auditMeta = Reflect.getMetadata(
+          AUDIT_GUARD_DECISION_METADATA_KEY,
+          handlerFn,
+        ) as AuditGuardDecisionMetadata | undefined;
+        if (!auditMeta) continue;
+
+        const methodFragments = this.methodRouteFragments(routePathMeta);
+
+        for (const ctrlPath of controllerPaths) {
+          for (const mFrag of methodFragments) {
+            const fullPath = joinHttpRoute(
+              NEST_HTTP_GLOBAL_PREFIX,
+              ctrlPath,
+              mFrag,
+            );
+            try {
+              discovered.push({
+                nestMethod: methodFlag as RequestMethod,
+                matcher: match(fullPath),
+                meta: auditMeta,
+              });
+            } catch (e) {
+              this.logger.warn(
+                `Skipping guard-audit route pattern "${fullPath}": ${(e as Error).message}`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    this.routes = discovered;
+    this.logger.log(`Guard-audit route patterns registered: ${this.routes.length}`);
+  }
+
+  resolve(
+    httpMethod: string,
+    pathname: string,
+  ): AuditGuardDecisionMetadata | undefined {
+    const nestMethod = httpMethodToNestEnum(httpMethod);
+    if (nestMethod === undefined) return undefined;
+
+    const pathOnly = pathname.split('?')[0] || '/';
+
+    for (const entry of this.routes) {
+      if (entry.nestMethod !== nestMethod) continue;
+      const hit = entry.matcher(pathOnly);
+      if (hit !== false) return entry.meta;
+    }
+    return undefined;
+  }
+
+  private controllerBasePaths(metatype: Type<object>): string[] {
+    const raw = Reflect.getMetadata(PATH_METADATA, metatype);
+    if (raw === undefined || raw === null) {
+      return [''];
+    }
+    const paths = Array.isArray(raw) ? raw : [raw];
+    return paths.map((p: string) =>
+      typeof p === 'string' && p.length ? addLeadingSlash(p).replace(/^\/+|\/+$/g, '') : '',
+    );
+  }
+
+  private methodRouteFragments(routePathMeta: string | string[]): string[] {
+    const paths = Array.isArray(routePathMeta) ? routePathMeta : [routePathMeta];
+    return paths.map((p) =>
+      typeof p === 'string' && p.length ? addLeadingSlash(p).replace(/^\/+|\/+$/g, '') : '',
+    );
+  }
+}

--- a/zephix-backend/src/common/audit/guard-audit.constants.ts
+++ b/zephix-backend/src/common/audit/guard-audit.constants.ts
@@ -1,0 +1,31 @@
+/** Reflect metadata key for {@link AuditGuardDecision} */
+export const AUDIT_GUARD_DECISION_METADATA_KEY = 'zephix:audit_guard_decision';
+
+/** Must stay aligned with {@link main.ts} `setGlobalPrefix` */
+export const NEST_HTTP_GLOBAL_PREFIX = 'api';
+
+export type GuardAuditActionCategory =
+  | 'read'
+  | 'write'
+  | 'config'
+  | 'destructive';
+
+export type GuardAuditScope =
+  | 'organization'
+  | 'workspace'
+  | 'project'
+  | 'global';
+
+export interface AuditGuardDecisionMetadata {
+  action: GuardAuditActionCategory;
+  scope: GuardAuditScope;
+  /** Required when action is config/destructive (emission skipped if empty). */
+  requiredRole?: string;
+}
+
+/** AD-027 Section 12: only config/destructive emit at guard/interceptor layer. */
+export function shouldEmitGuardAuditAction(
+  action: GuardAuditActionCategory,
+): boolean {
+  return action === 'config' || action === 'destructive';
+}

--- a/zephix-backend/src/common/audit/guard-audit.interceptor.spec.ts
+++ b/zephix-backend/src/common/audit/guard-audit.interceptor.spec.ts
@@ -1,0 +1,138 @@
+import { lastValueFrom, of } from 'rxjs';
+import { Reflector } from '@nestjs/core';
+import { GuardAuditInterceptor } from './guard-audit.interceptor';
+import { AUDIT_GUARD_DECISION_METADATA_KEY } from './guard-audit.constants';
+
+describe('GuardAuditInterceptor', () => {
+  let interceptor: GuardAuditInterceptor;
+  let audit: { recordGuardEvent: jest.Mock };
+  let reflector: Reflector;
+
+  function makeHandler() {
+    return function probeHandler() {};
+  }
+
+  function httpCtx(handler: object, statusCode = 200) {
+    return {
+      getHandler: () => handler,
+      switchToHttp: () => ({
+        getResponse: () => ({ statusCode }),
+        getRequest: () =>
+          ({
+            method: 'GET',
+            path: '/api/probe',
+            baseUrl: '',
+            route: { path: '/probe' },
+            headers: {},
+            params: {},
+            query: {},
+            user: {
+              id: '22222222-2222-4222-8222-222222222222',
+              organizationId: '11111111-1111-4111-8111-111111111111',
+              platformRole: 'ADMIN',
+              email: 't@test.dev',
+            },
+          }) as any,
+      }),
+    } as any;
+  }
+
+  beforeEach(() => {
+    audit = { recordGuardEvent: jest.fn().mockResolvedValue({}) };
+    reflector = new Reflector();
+    interceptor = new GuardAuditInterceptor(audit as any, reflector);
+  });
+
+  it('emits ALLOW for config action on 2xx', async () => {
+    const handler = makeHandler();
+    Reflect.defineMetadata(
+      AUDIT_GUARD_DECISION_METADATA_KEY,
+      {
+        action: 'config',
+        scope: 'workspace',
+        requiredRole: 'workspace_owner',
+      },
+      handler,
+    );
+
+    await lastValueFrom(
+      interceptor.intercept(httpCtx(handler), { handle: () => of({ ok: true }) }),
+    );
+
+    expect(audit.recordGuardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'ALLOW',
+        requiredRole: 'workspace_owner',
+      }),
+    );
+  });
+
+  it('skips read action', async () => {
+    const handler = makeHandler();
+    Reflect.defineMetadata(
+      AUDIT_GUARD_DECISION_METADATA_KEY,
+      {
+        action: 'read',
+        scope: 'workspace',
+        requiredRole: 'workspace_owner',
+      },
+      handler,
+    );
+
+    await lastValueFrom(
+      interceptor.intercept(httpCtx(handler), { handle: () => of({ ok: true }) }),
+    );
+
+    expect(audit.recordGuardEvent).not.toHaveBeenCalled();
+  });
+
+  it('skips when decorator absent', async () => {
+    const handler = makeHandler();
+    await lastValueFrom(
+      interceptor.intercept(httpCtx(handler), { handle: () => of({ ok: true }) }),
+    );
+
+    expect(audit.recordGuardEvent).not.toHaveBeenCalled();
+  });
+
+  it('skips non-2xx responses', async () => {
+    const handler = makeHandler();
+    Reflect.defineMetadata(
+      AUDIT_GUARD_DECISION_METADATA_KEY,
+      {
+        action: 'config',
+        scope: 'workspace',
+        requiredRole: 'workspace_owner',
+      },
+      handler,
+    );
+
+    await lastValueFrom(
+      interceptor.intercept(httpCtx(handler, 403), {
+        handle: () => of(null),
+      }),
+    );
+
+    expect(audit.recordGuardEvent).not.toHaveBeenCalled();
+  });
+
+  it('propagates when recordGuardEvent rejects', async () => {
+    const handler = makeHandler();
+    Reflect.defineMetadata(
+      AUDIT_GUARD_DECISION_METADATA_KEY,
+      {
+        action: 'destructive',
+        scope: 'workspace',
+        requiredRole: 'workspace_owner',
+      },
+      handler,
+    );
+    audit.recordGuardEvent.mockRejectedValueOnce(new Error('audit failed'));
+
+    await expect(
+      lastValueFrom(
+        interceptor.intercept(httpCtx(handler), { handle: () => of({ ok: true }) }),
+      ),
+    ).rejects.toThrow('audit failed');
+  });
+});

--- a/zephix-backend/src/common/audit/guard-audit.interceptor.ts
+++ b/zephix-backend/src/common/audit/guard-audit.interceptor.ts
@@ -1,0 +1,76 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable, from } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import type { Response } from 'express';
+import { AuditService } from '../../modules/audit/services/audit.service';
+import { getAuthContextOptional } from '../http/get-auth-context-optional';
+import type { AuthRequest } from '../http/auth-request';
+import { resolvePlatformRoleFromRequestUser } from '../auth/platform-roles';
+import {
+  AUDIT_GUARD_DECISION_METADATA_KEY,
+  AuditGuardDecisionMetadata,
+  shouldEmitGuardAuditAction,
+} from './guard-audit.constants';
+import {
+  correlationIdFromRequest,
+  endpointPathForAudit,
+  extractWorkspaceIdForAudit,
+} from './guard-audit.utils';
+
+/**
+ * Emits ALLOW guard audits after successful handler completion (config/destructive only).
+ * DENY for 401/403 is handled by {@link GuardAuditAuthzExceptionFilter} so each denied request
+ * is audited exactly once (guards run before interceptors).
+ */
+@Injectable()
+export class GuardAuditInterceptor implements NestInterceptor {
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      mergeMap((body) =>
+        from(this.emitAllowIfNeeded(context).then(() => body)),
+      ),
+    );
+  }
+
+  private async emitAllowIfNeeded(context: ExecutionContext): Promise<void> {
+    const http = context.switchToHttp();
+    const res = http.getResponse<Response>();
+    const status = Number(res.statusCode);
+    if (!Number.isFinite(status) || status < 200 || status >= 300) return;
+
+    const handler = context.getHandler();
+    const meta = this.reflector.get<AuditGuardDecisionMetadata | undefined>(
+      AUDIT_GUARD_DECISION_METADATA_KEY,
+      handler,
+    );
+    if (!meta || !shouldEmitGuardAuditAction(meta.action)) return;
+
+    const requiredRole = meta.requiredRole?.trim();
+    if (!requiredRole) return;
+
+    const req = http.getRequest<AuthRequest>();
+    const auth = getAuthContextOptional(req);
+    if (!auth.organizationId || !auth.userId) return;
+
+    await this.auditService.recordGuardEvent({
+      organizationId: auth.organizationId,
+      workspaceId: extractWorkspaceIdForAudit(req),
+      actorUserId: auth.userId,
+      actorPlatformRole: resolvePlatformRoleFromRequestUser(req.user),
+      actorWorkspaceRole: null,
+      endpoint: {
+        method: req.method,
+        path: endpointPathForAudit(req),
+      },
+      decision: 'ALLOW',
+      requiredRole,
+      correlationId: correlationIdFromRequest(req),
+    });
+  }
+}

--- a/zephix-backend/src/common/audit/guard-audit.utils.ts
+++ b/zephix-backend/src/common/audit/guard-audit.utils.ts
@@ -1,0 +1,88 @@
+import { createHash, randomUUID } from 'crypto';
+import type { Request } from 'express';
+import { HttpException } from '@nestjs/common';
+import { extractValidUuid } from '../utils/uuid-validator.util';
+import type { AuthRequest } from '../http/auth-request';
+import type { GuardAuditEventInput } from '../../modules/audit/dto/guard-audit-event.input';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuidString(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+/**
+ * entity_id for authorization_decision rows: correlationId when it is a UUID,
+ * otherwise a deterministic UUID derived from the decision context.
+ */
+export function resolveGuardAuditEntityId(input: GuardAuditEventInput): string {
+  if (input.correlationId && isUuidString(input.correlationId)) {
+    return input.correlationId;
+  }
+  const seed = [
+    input.organizationId,
+    input.actorUserId,
+    input.endpoint.method,
+    input.endpoint.path,
+    input.decision,
+    input.correlationId ?? '',
+    input.requiredRole,
+  ].join('|');
+  return deterministicUuidFromSeed(seed);
+}
+
+function deterministicUuidFromSeed(seed: string): string {
+  const hash = createHash('sha256').update(seed, 'utf8').digest();
+  const buf = Buffer.alloc(16);
+  hash.copy(buf, 0, 0, 16);
+  buf[6] = (buf[6] & 0x0f) | 0x50;
+  buf[8] = (buf[8] & 0x3f) | 0x80;
+  const hex = buf.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/** Correlation id when request id is missing or non-UUID */
+export function fallbackCorrelationId(): string {
+  return randomUUID();
+}
+
+/** Pattern-style path for audit (Express route template when available). */
+export function endpointPathForAudit(req: Request): string {
+  const base = String((req as { baseUrl?: string }).baseUrl || '');
+  const route = (req as { route?: { path?: string } }).route;
+  const routePath = route?.path ? String(route.path) : '';
+  if (routePath) {
+    const joined = `${base}${routePath}`.replace(/\/{2,}/g, '/') || '/';
+    return joined.startsWith('/') ? joined : `/${joined}`;
+  }
+  const p = req.path || '/';
+  return p.startsWith('/') ? p : `/${p}`;
+}
+
+export function extractWorkspaceIdForAudit(req: AuthRequest): string | null {
+  const fromHeader = extractValidUuid(req.headers?.['x-workspace-id']);
+  if (fromHeader) return fromHeader;
+  const fromParam = extractValidUuid(req.params?.workspaceId);
+  if (fromParam) return fromParam;
+  const fromQuery = extractValidUuid(req.query?.workspaceId);
+  return fromQuery ?? null;
+}
+
+export function correlationIdFromRequest(req: Request): string | undefined {
+  const raw = req.headers['x-request-id'];
+  const s = typeof raw === 'string' ? raw.trim() : '';
+  if (s && isUuidString(s)) return s;
+  return undefined;
+}
+
+export function httpExceptionMessage(exception: HttpException): string | undefined {
+  const body = exception.getResponse();
+  if (typeof body === 'string') return body;
+  if (body && typeof body === 'object' && 'message' in body) {
+    const m = (body as { message?: unknown }).message;
+    if (Array.isArray(m)) return m.map(String).join('; ');
+    if (m !== undefined && m !== null) return String(m);
+  }
+  return undefined;
+}

--- a/zephix-backend/src/migrations/18000000000077-AddGuardAuditConstraints.ts
+++ b/zephix-backend/src/migrations/18000000000077-AddGuardAuditConstraints.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * AD-027 Section 12 — expand audit_events CHECK constraints for guard authorization rows.
+ */
+export class AddGuardAuditConstraints18000000000077 implements MigrationInterface {
+  name = 'AddGuardAuditConstraints18000000000077';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS "CHK_audit_events_entity_type";
+    `);
+    await queryRunner.query(`
+      ALTER TABLE audit_events ADD CONSTRAINT "CHK_audit_events_entity_type"
+      CHECK (entity_type IN (
+        'organization','workspace','project','portfolio',
+        'work_task','work_risk','doc','attachment',
+        'scenario_plan','scenario_action','scenario_result',
+        'baseline','capacity_calendar','billing_plan','entitlement',
+        'webhook','board_move',
+        'PHASE','TASK','SPRINT','RISK','ALLOCATION',
+        'CHANGE_REQUEST','DOCUMENT','BUDGET','GATE','POLICY',
+        'TEMPLATE','TEMPLATE_ACTIVATION','TAILORING_PROFILE',
+        'user','email_verification',
+        'authorization_decision'
+      ));
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "audit_events" DROP CONSTRAINT IF EXISTS "CHK_audit_events_action"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "audit_events" ADD CONSTRAINT "CHK_audit_events_action"
+      CHECK (action IN (
+        'create', 'update', 'delete', 'activate', 'compute',
+        'attach', 'detach', 'invite', 'accept', 'suspend', 'reinstate',
+        'upload_complete', 'download_link', 'presign_create',
+        'quota_block', 'plan_status_block', 'wip_override', 'role_change',
+        'PHASE_CREATED', 'PHASE_UPDATED', 'PHASE_REORDERED', 'PHASE_RESTORED', 'PHASE_DELETED',
+        'TASK_CREATED', 'TASK_UPDATED', 'TASK_DELETED', 'TASK_RESTORED',
+        'TASK_STATUS_CHANGED', 'TASK_ASSIGNED', 'TASK_MOVED',
+        'SPRINT_CREATED', 'SPRINT_UPDATED', 'SPRINT_STARTED', 'SPRINT_COMPLETED',
+        'CHANGE_REQUEST_CREATED', 'CHANGE_REQUEST_UPDATED', 'CHANGE_REQUEST_APPROVED', 'CHANGE_REQUEST_REJECTED',
+        'DOCUMENT_CREATED', 'DOCUMENT_UPDATED', 'DOCUMENT_DELETED',
+        'BUDGET_UPDATED', 'BUDGET_APPROVED',
+        'GATE_CREATED', 'GATE_EVALUATED', 'GATE_PASSED', 'GATE_FAILED',
+        'POLICY_CREATED', 'POLICY_UPDATED', 'POLICY_DELETED',
+        'TEMPLATE_ACTIVATED', 'TEMPLATE_DEACTIVATED',
+        'PHASE_TRANSITION_REQUESTED', 'PHASE_TRANSITION_APPROVED', 'PHASE_TRANSITION_REJECTED',
+        'user_registered', 'org_created',
+        'email_verification_sent', 'email_verified', 'resend_verification',
+        'email_verification_bypassed',
+        'governance_evaluate',
+        'guard_allow', 'guard_deny'
+      ))
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS "CHK_audit_events_entity_type";
+    `);
+    await queryRunner.query(`
+      ALTER TABLE audit_events ADD CONSTRAINT "CHK_audit_events_entity_type"
+      CHECK (entity_type IN (
+        'organization','workspace','project','portfolio',
+        'work_task','work_risk','doc','attachment',
+        'scenario_plan','scenario_action','scenario_result',
+        'baseline','capacity_calendar','billing_plan','entitlement',
+        'webhook','board_move',
+        'PHASE','TASK','SPRINT','RISK','ALLOCATION',
+        'CHANGE_REQUEST','DOCUMENT','BUDGET','GATE','POLICY',
+        'TEMPLATE','TEMPLATE_ACTIVATION','TAILORING_PROFILE',
+        'user','email_verification'
+      ));
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "audit_events" DROP CONSTRAINT IF EXISTS "CHK_audit_events_action"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "audit_events" ADD CONSTRAINT "CHK_audit_events_action"
+      CHECK (action IN (
+        'create', 'update', 'delete', 'activate', 'compute',
+        'attach', 'detach', 'invite', 'accept', 'suspend', 'reinstate',
+        'upload_complete', 'download_link', 'presign_create',
+        'quota_block', 'plan_status_block', 'wip_override', 'role_change',
+        'PHASE_CREATED', 'PHASE_UPDATED', 'PHASE_REORDERED', 'PHASE_RESTORED', 'PHASE_DELETED',
+        'TASK_CREATED', 'TASK_UPDATED', 'TASK_DELETED', 'TASK_RESTORED',
+        'TASK_STATUS_CHANGED', 'TASK_ASSIGNED', 'TASK_MOVED',
+        'SPRINT_CREATED', 'SPRINT_UPDATED', 'SPRINT_STARTED', 'SPRINT_COMPLETED',
+        'CHANGE_REQUEST_CREATED', 'CHANGE_REQUEST_UPDATED', 'CHANGE_REQUEST_APPROVED', 'CHANGE_REQUEST_REJECTED',
+        'DOCUMENT_CREATED', 'DOCUMENT_UPDATED', 'DOCUMENT_DELETED',
+        'BUDGET_UPDATED', 'BUDGET_APPROVED',
+        'GATE_CREATED', 'GATE_EVALUATED', 'GATE_PASSED', 'GATE_FAILED',
+        'POLICY_CREATED', 'POLICY_UPDATED', 'POLICY_DELETED',
+        'TEMPLATE_ACTIVATED', 'TEMPLATE_DEACTIVATED',
+        'PHASE_TRANSITION_REQUESTED', 'PHASE_TRANSITION_APPROVED', 'PHASE_TRANSITION_REJECTED',
+        'user_registered', 'org_created',
+        'email_verification_sent', 'email_verified', 'resend_verification',
+        'email_verification_bypassed',
+        'governance_evaluate'
+      ))
+    `);
+  }
+}

--- a/zephix-backend/src/migrations/__tests__/18000000000077-AddGuardAuditConstraints.spec.ts
+++ b/zephix-backend/src/migrations/__tests__/18000000000077-AddGuardAuditConstraints.spec.ts
@@ -1,0 +1,43 @@
+import { AddGuardAuditConstraints18000000000077 } from '../18000000000077-AddGuardAuditConstraints';
+
+describe('Migration 18000000000077 — guard audit CHECK constraints', () => {
+  it('up references authorization_decision and guard audit actions', async () => {
+    const queries: string[] = [];
+    const qr = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+      }),
+    };
+
+    const migration = new AddGuardAuditConstraints18000000000077();
+    await migration.up(qr as any);
+
+    const joined = queries.join('\n');
+    expect(joined).toContain('authorization_decision');
+    expect(joined).toContain('guard_allow');
+    expect(joined).toContain('guard_deny');
+    expect(
+      queries.some((q) => q.includes('CHK_audit_events_entity_type')),
+    ).toBe(true);
+    expect(queries.some((q) => q.includes('CHK_audit_events_action'))).toBe(
+      true,
+    );
+  });
+
+  it('down omits new guard audit literals', async () => {
+    const queries: string[] = [];
+    const qr = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+      }),
+    };
+
+    const migration = new AddGuardAuditConstraints18000000000077();
+    await migration.down(qr as any);
+
+    const joined = queries.join('\n');
+    expect(joined).not.toContain('authorization_decision');
+    expect(joined).not.toContain('guard_allow');
+    expect(joined).not.toContain('guard_deny');
+  });
+});

--- a/zephix-backend/src/modules/audit/__tests__/audit.service.spec.ts
+++ b/zephix-backend/src/modules/audit/__tests__/audit.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuditService, sanitizeJson } from '../services/audit.service';
 import { AuditEvent } from '../entities/audit-event.entity';
 import { AuditEntityType, AuditAction, AuditSource } from '../audit.constants';
+import { PlatformRole } from '../../../common/auth/platform-roles';
 
 describe('AuditService', () => {
   let service: AuditService;
@@ -340,5 +341,49 @@ describe('AuditService', () => {
     });
 
     expect(mockQb.orderBy).toHaveBeenCalledWith('ae.createdAt', 'DESC');
+  });
+
+  describe('recordGuardEvent', () => {
+    it('persists guard_allow with metadataJson fields', async () => {
+      await service.recordGuardEvent({
+        organizationId: '11111111-1111-4111-8111-111111111111',
+        workspaceId: null,
+        actorUserId: '22222222-2222-4222-8222-222222222222',
+        actorPlatformRole: PlatformRole.ADMIN,
+        actorWorkspaceRole: null,
+        endpoint: { method: 'PATCH', path: '/api/workspaces/:id' },
+        decision: 'ALLOW',
+        requiredRole: 'workspace_owner',
+        correlationId: '33333333-3333-4333-8333-333333333333',
+      });
+
+      expect(mockRepo.save).toHaveBeenCalled();
+      const arg = mockRepo.save.mock.calls[0][0];
+      expect(arg.entityType).toBe(AuditEntityType.AUTHORIZATION_DECISION);
+      expect(arg.action).toBe(AuditAction.GUARD_ALLOW);
+      expect(arg.metadataJson.endpoint.method).toBe('PATCH');
+      expect(arg.metadataJson.endpoint.path).toBe('/api/workspaces/:id');
+      expect(arg.metadataJson.requiredRole).toBe('workspace_owner');
+      expect(arg.metadataJson.correlationId).toBe(
+        '33333333-3333-4333-8333-333333333333',
+      );
+      expect(arg.entityId).toBe('33333333-3333-4333-8333-333333333333');
+    });
+
+    it('rethrows when repository save fails', async () => {
+      mockRepo.save.mockRejectedValueOnce(new Error('db down'));
+      await expect(
+        service.recordGuardEvent({
+          organizationId: '11111111-1111-4111-8111-111111111111',
+          workspaceId: null,
+          actorUserId: '22222222-2222-4222-8222-222222222222',
+          actorPlatformRole: PlatformRole.MEMBER,
+          actorWorkspaceRole: null,
+          endpoint: { method: 'GET', path: '/api/x' },
+          decision: 'DENY',
+          requiredRole: 'workspace_owner',
+        }),
+      ).rejects.toThrow('db down');
+    });
   });
 });

--- a/zephix-backend/src/modules/audit/audit.constants.ts
+++ b/zephix-backend/src/modules/audit/audit.constants.ts
@@ -25,6 +25,8 @@ export enum AuditEntityType {
   USER = 'user',
   EMAIL_VERIFICATION = 'email_verification',
   PASSWORD_RESET = 'password_reset',
+  /** AD-027 Section 12: authorization guard decisions */
+  AUTHORIZATION_DECISION = 'authorization_decision',
 }
 
 export enum AuditAction {
@@ -63,6 +65,10 @@ export enum AuditAction {
   RETENTION_PURGE_BATCH = 'retention_purge_batch',
   /** Single-entity permanent delete from trash */
   PERMANENT_DELETE_FROM_TRASH = 'permanent_delete_from_trash',
+  /** AD-027 Section 12.2: guard allowed request (config/destructive, 2xx) */
+  GUARD_ALLOW = 'guard_allow',
+  /** AD-027 Section 12.2: guard denied request (401/403 on audited routes) */
+  GUARD_DENY = 'guard_deny',
 }
 
 /** Keys that must be stripped from any JSONB payload before persistence. */

--- a/zephix-backend/src/modules/audit/dto/guard-audit-event.input.ts
+++ b/zephix-backend/src/modules/audit/dto/guard-audit-event.input.ts
@@ -1,0 +1,20 @@
+import { PlatformRole } from '../../../common/auth/platform-roles';
+import type { WorkspaceRole } from '../../workspaces/entities/workspace.entity';
+
+/**
+ * Typed input for {@link AuditService.recordGuardEvent}.
+ * AD-027 Section 12.2 — guard-layer authorization audit payload.
+ */
+export interface GuardAuditEventInput {
+  organizationId: string;
+  workspaceId: string | null;
+  actorUserId: string;
+  actorPlatformRole: PlatformRole;
+  actorWorkspaceRole: WorkspaceRole | string | null;
+  endpoint: { method: string; path: string };
+  decision: 'ALLOW' | 'DENY';
+  denyReason?: string;
+  /** Declared requirement, e.g. workspace_owner or workspace_owner|delivery_owner */
+  requiredRole: string;
+  correlationId?: string;
+}

--- a/zephix-backend/src/modules/audit/services/audit.service.ts
+++ b/zephix-backend/src/modules/audit/services/audit.service.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, EntityManager, SelectQueryBuilder } from 'typeorm';
 import { AuditEvent } from '../entities/audit-event.entity';
 import { AuditEntityType, AuditAction, SANITIZE_KEYS } from '../audit.constants';
+import type { GuardAuditEventInput } from '../dto/guard-audit-event.input';
+import { resolveGuardAuditEntityId } from '../../../common/audit/guard-audit.utils';
 
 /** Input for recording an audit event */
 export interface AuditRecordInput {
@@ -90,6 +92,50 @@ export class AuditService {
         error.stack,
       );
       return event;
+    }
+  }
+
+  /**
+   * AD-027 Section 12.2 — strict guard authorization audit write.
+   *
+   * Unlike {@link AuditService.record}, persistence failures are logged and **rethrown**
+   * so callers cannot treat a failed write as successful.
+   */
+  async recordGuardEvent(input: GuardAuditEventInput): Promise<AuditEvent> {
+    const entityId = resolveGuardAuditEntityId(input);
+    const action =
+      input.decision === 'ALLOW'
+        ? AuditAction.GUARD_ALLOW
+        : AuditAction.GUARD_DENY;
+    const metadata = sanitizeJson({
+      endpoint: input.endpoint,
+      denyReason: input.denyReason,
+      requiredRole: input.requiredRole,
+      correlationId: input.correlationId,
+    });
+
+    const event = new AuditEvent();
+    event.organizationId = input.organizationId;
+    event.workspaceId = input.workspaceId ?? null;
+    event.actorUserId = input.actorUserId;
+    event.actorPlatformRole = input.actorPlatformRole;
+    event.actorWorkspaceRole = input.actorWorkspaceRole ?? null;
+    event.entityType = AuditEntityType.AUTHORIZATION_DECISION;
+    event.entityId = entityId;
+    event.action = action;
+    event.beforeJson = null;
+    event.afterJson = null;
+    event.metadataJson = metadata;
+
+    try {
+      return await this.repo.save(event);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(
+        `GUARD_AUDIT_WRITE_FAILED | decision=${input.decision} action=${action} entityId=${entityId} org=${input.organizationId} actor=${input.actorUserId} | ${error.message}`,
+        error.stack,
+      );
+      throw err;
     }
   }
 

--- a/zephix-backend/test/permission-matrix/__tests__/guard-audit.integration.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/guard-audit.integration.spec.ts
@@ -2,7 +2,16 @@
  * DB-backed smoke for guard-audit wiring (requires migrated schema including 18000000000077).
  * Skipped when DATABASE_URL is unset (same gate as matrix example E2E).
  */
-import { Controller, ForbiddenException, Get, INestApplication } from '@nestjs/common';
+import {
+  CanActivate,
+  Controller,
+  ExecutionContext,
+  ForbiddenException,
+  Get,
+  INestApplication,
+  Injectable,
+  UseGuards,
+} from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -20,6 +29,14 @@ import type { AuthRequest } from '../../../src/common/http/auth-request';
 
 const ORG = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const USER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+/** Nest converts `canActivate === false` to ForbiddenException (RouterExecutionContext). */
+@Injectable()
+class GuardThatReturnsFalse implements CanActivate {
+  canActivate(_context: ExecutionContext): boolean {
+    return false;
+  }
+}
 
 @Controller('permission-matrix/guard-audit-probe')
 class GuardAuditProbeController {
@@ -41,6 +58,17 @@ class GuardAuditProbeController {
   })
   deny() {
     throw new ForbiddenException('probe-deny');
+  }
+
+  @Get('guard-false')
+  @UseGuards(GuardThatReturnsFalse)
+  @AuditGuardDecision({
+    action: 'config',
+    scope: 'workspace',
+    requiredRole: 'workspace_owner',
+  })
+  guardFalse() {
+    return { unexpected: true };
   }
 }
 
@@ -64,6 +92,7 @@ describeOrSkip('guard-audit integration (DATABASE_URL)', () => {
       providers: [
         MetadataScanner,
         GuardAuditRouteRegistry,
+        GuardThatReturnsFalse,
         { provide: APP_INTERCEPTOR, useClass: GuardAuditInterceptor },
         { provide: APP_FILTER, useClass: GuardAuditAuthzExceptionFilter },
       ],
@@ -128,5 +157,20 @@ describeOrSkip('guard-audit integration (DATABASE_URL)', () => {
       [ORG],
     );
     expect(rows.some((r: { action: string }) => r.action === 'guard_deny')).toBe(true);
+  });
+
+  it('writes guard_deny when guard returns false (Nest ForbiddenException)', async () => {
+    await request(app.getHttpServer())
+      .get('/api/permission-matrix/guard-audit-probe/guard-false')
+      .expect(403);
+
+    const rows = await dataSource.query(
+      `SELECT action, metadata_json FROM audit_events WHERE organization_id = $1 ORDER BY created_at DESC LIMIT 15`,
+      [ORG],
+    );
+    const denyRows = rows.filter((r: { action: string }) => r.action === 'guard_deny');
+    expect(denyRows.length).toBeGreaterThan(0);
+    const sample = denyRows[0] as { metadata_json?: { denyReason?: string } };
+    expect(sample.metadata_json).toBeTruthy();
   });
 });

--- a/zephix-backend/test/permission-matrix/__tests__/guard-audit.integration.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/guard-audit.integration.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * DB-backed smoke for guard-audit wiring (requires migrated schema including 18000000000077).
+ * Skipped when DATABASE_URL is unset (same gate as matrix example E2E).
+ */
+import { Controller, ForbiddenException, Get, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { APP_FILTER, APP_INTERCEPTOR, DiscoveryModule, MetadataScanner } from '@nestjs/core';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+
+import { databaseConfig } from '../../../src/config/database.config';
+import { AuditModule } from '../../../src/modules/audit/audit.module';
+import { AuditGuardDecision } from '../../../src/common/audit/audit-guard-decision.decorator';
+import { GuardAuditRouteRegistry } from '../../../src/common/audit/guard-audit-route-registry.service';
+import { GuardAuditInterceptor } from '../../../src/common/audit/guard-audit.interceptor';
+import { GuardAuditAuthzExceptionFilter } from '../../../src/common/audit/guard-audit-authz-exception.filter';
+import type { AuthRequest } from '../../../src/common/http/auth-request';
+
+const ORG = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const USER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+@Controller('permission-matrix/guard-audit-probe')
+class GuardAuditProbeController {
+  @Get('allow')
+  @AuditGuardDecision({
+    action: 'config',
+    scope: 'workspace',
+    requiredRole: 'workspace_owner',
+  })
+  allow() {
+    return { ok: true };
+  }
+
+  @Get('deny')
+  @AuditGuardDecision({
+    action: 'destructive',
+    scope: 'workspace',
+    requiredRole: 'workspace_owner',
+  })
+  deny() {
+    throw new ForbiddenException('probe-deny');
+  }
+}
+
+const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
+
+describeOrSkip('guard-audit integration (DATABASE_URL)', () => {
+  jest.setTimeout(120000);
+
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot(databaseConfig),
+        AuditModule,
+        DiscoveryModule,
+      ],
+      controllers: [GuardAuditProbeController],
+      providers: [
+        MetadataScanner,
+        GuardAuditRouteRegistry,
+        { provide: APP_INTERCEPTOR, useClass: GuardAuditInterceptor },
+        { provide: APP_FILTER, useClass: GuardAuditAuthzExceptionFilter },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.use((req: AuthRequest, _res, next) => {
+      req.user = {
+        id: USER,
+        email: 'probe@test.dev',
+        organizationId: ORG,
+        platformRole: 'ADMIN',
+      };
+      next();
+    });
+    await app.init();
+    dataSource = app.get(DataSource);
+  });
+
+  afterAll(async () => {
+    try {
+      await dataSource?.query(`DELETE FROM audit_events WHERE organization_id = $1`, [
+        ORG,
+      ]);
+    } catch {
+      /* ignore */
+    }
+    try {
+      await app?.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('writes guard_allow for decorated 2xx route', async () => {
+    await request(app.getHttpServer())
+      .get('/api/permission-matrix/guard-audit-probe/allow')
+      .expect(200);
+
+    const rows = await dataSource.query(
+      `SELECT action, entity_type FROM audit_events WHERE organization_id = $1 ORDER BY created_at DESC LIMIT 3`,
+      [ORG],
+    );
+    expect(rows.some((r: { action: string }) => r.action === 'guard_allow')).toBe(
+      true,
+    );
+    expect(
+      rows.some(
+        (r: { entity_type: string }) => r.entity_type === 'authorization_decision',
+      ),
+    ).toBe(true);
+  });
+
+  it('writes guard_deny for decorated Forbidden route', async () => {
+    await request(app.getHttpServer())
+      .get('/api/permission-matrix/guard-audit-probe/deny')
+      .expect(403);
+
+    const rows = await dataSource.query(
+      `SELECT action FROM audit_events WHERE organization_id = $1 ORDER BY created_at DESC LIMIT 5`,
+      [ORG],
+    );
+    expect(rows.some((r: { action: string }) => r.action === 'guard_deny')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements AD-027 Section 12 guard-audit emission infrastructure: `AuditService.recordGuardEvent` (strict DB failure), `@AuditGuardDecision`, global `GuardAuditInterceptor` (ALLOW on 2xx for config/destructive), and `GuardAuditAuthzExceptionFilter` + `GuardAuditRouteRegistry` (DENY on 401/403). Migration `18000000000077` extends `audit_events` CHECK constraints for `authorization_decision`, `guard_allow`, `guard_deny`.

## Notes
- `AuditService.record` unchanged (tolerant failure preserved).
- No production controllers decorated in this PR (batch 1 will add `@AuditGuardDecision` per endpoint).
- DENY is handled only in the exception filter to avoid double emission (guards run before interceptors; Nest exception host has no handler ref).
- Integration probe: `test/permission-matrix/__tests__/guard-audit.integration.spec.ts` (requires `DATABASE_URL` + applied migrations).

## Dependency
- PR #225 permission-matrix harness (merged on `staging` as 21b9d649).

## Commit
c95279a0

Made with [Cursor](https://cursor.com)