### PR TITLE
feat: extend RequireWorkspaceAccessGuard for slug resolution (AD-027 1a-i precursor)

### DIFF
--- a/zephix-backend/src/modules/workspaces/guards/cross-tenant-status.decorator.ts
+++ b/zephix-backend/src/modules/workspaces/guards/cross-tenant-status.decorator.ts
@@ -1,0 +1,36 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Metadata for HTTP status codes when `RequireWorkspaceAccessGuard` resolves the
+ * workspace via `params.slug` (AD-027 batch 1a precursor).
+ *
+ * **Defaults (slug routes, no decorator):** `403` for both "slug did not resolve
+ * to a workspace in the caller's org" and "resolved but caller lacks access".
+ *
+ * **`@CrossTenantStatus(404)`:** Sets **both** statuses to `404` so endpoints
+ * that mask existence (e.g. `GET slug/:slug/home`) match legacy behavior.
+ *
+ * **`SlugAccessErrorSemantics`:** Per-route tuning — use in PR #229 when a slug
+ * endpoint needs `404` for unknown slug but `403` for forbidden (e.g. resolve
+ * routes).
+ */
+export const WORKSPACE_ACCESS_SLUG_ERROR_SEMANTICS =
+  'workspaceAccessSlugErrorSemantics';
+
+export interface SlugAccessErrorSemantics {
+  /** Slug did not match a workspace in the caller's organization */
+  notFoundStatus?: 403 | 404;
+  /** Workspace matched but caller failed membership / capability checks */
+  forbiddenStatus?: 403 | 404;
+}
+
+/** Fine-grained status codes for slug-param routes (optional per Architect Decision B). */
+export const SlugAccessErrorSemantics = (semantics: SlugAccessErrorSemantics) =>
+  SetMetadata(WORKSPACE_ACCESS_SLUG_ERROR_SEMANTICS, semantics);
+
+/** Shorthand: same status for slug-not-found and access-denied (existence masking). */
+export const CrossTenantStatus = (status: 403 | 404) =>
+  SlugAccessErrorSemantics({
+    notFoundStatus: status,
+    forbiddenStatus: status,
+  });

--- a/zephix-backend/src/modules/workspaces/guards/require-workspace-access.guard.spec.ts
+++ b/zephix-backend/src/modules/workspaces/guards/require-workspace-access.guard.spec.ts
@@ -1,6 +1,12 @@
 import { RequireWorkspaceAccessGuard } from './require-workspace-access.guard';
 import { Reflector } from '@nestjs/core';
-import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+} from '@nestjs/common';
+import { WORKSPACE_ACCESS_SLUG_ERROR_SEMANTICS } from './cross-tenant-status.decorator';
 
 /**
  * Unit tests for RequireWorkspaceAccessGuard.
@@ -23,16 +29,29 @@ function mockUser(overrides: Record<string, any> = {}) {
 function mockContext(
   mode: string | undefined,
   user: any,
-  workspaceId = 'ws-1',
+  params: Record<string, string> = { workspaceId: 'ws-1' },
+  slugSemanticsMeta?: { notFoundStatus?: 403 | 404; forbiddenStatus?: 403 | 404 },
 ): { context: ExecutionContext; reflector: Reflector } {
   const request = {
     user,
-    params: { workspaceId },
+    params,
     workspaceRole: undefined as any,
   };
 
   const reflector = {
-    get: jest.fn().mockReturnValue(mode),
+    get: jest.fn((key: string) => {
+      if (key === 'workspaceAccessMode') return mode;
+      return undefined;
+    }),
+    getAllAndOverride: jest.fn((key: string) => {
+      if (
+        key === WORKSPACE_ACCESS_SLUG_ERROR_SEMANTICS &&
+        slugSemanticsMeta !== undefined
+      ) {
+        return slugSemanticsMeta;
+      }
+      return undefined;
+    }),
   } as any;
 
   const context = {
@@ -40,6 +59,7 @@ function mockContext(
       getRequest: () => request,
     }),
     getHandler: () => ({}),
+    getClass: () => ({}),
   } as unknown as ExecutionContext;
 
   return { context, reflector };
@@ -50,6 +70,7 @@ function createGuard(
   workspace: any | null,
   member: any | null,
   tenantOrgId: string | null = 'org-1',
+  workspaceAccessService?: { canAccessWorkspace: jest.Mock },
 ) {
   const wmRepo = {
     findOne: jest.fn().mockResolvedValue(member),
@@ -61,12 +82,16 @@ function createGuard(
     getOrganizationId: jest.fn().mockReturnValue(tenantOrgId),
     runWithTenant: jest.fn((_ctx, fn) => fn()),
   };
+  const accessSvc = workspaceAccessService ?? {
+    canAccessWorkspace: jest.fn().mockResolvedValue(true),
+  };
 
   return new RequireWorkspaceAccessGuard(
     reflector,
     wmRepo as any,
     wsRepo as any,
     tenantContextService as any,
+    accessSvc as any,
   );
 }
 
@@ -266,5 +291,199 @@ describe('RequireWorkspaceAccessGuard', () => {
     await expect(guard.canActivate(context)).rejects.toThrow(
       ForbiddenException,
     );
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Missing id / slug
+  // ──────────────────────────────────────────────────────────
+  it('throws NotFoundException when neither id, workspaceId, nor slug is present', async () => {
+    const user = mockUser({ permissions: { isAdmin: false } });
+    const { context, reflector } = mockContext('read', user, {});
+    const guard = createGuard(reflector, WORKSPACE, null);
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // Slug resolution (AD-027 precursor)
+  // ──────────────────────────────────────────────────────────
+  describe('slug param resolution', () => {
+    function slugWsRepoDual(
+      slugLookupResult: { id: string; organizationId: string } | null,
+      byIdResult: typeof WORKSPACE | null = WORKSPACE,
+    ) {
+      return {
+        findOne: jest
+          .fn()
+          .mockImplementation(async (opts: { where: Record<string, unknown> }) => {
+            if ('slug' in opts.where) {
+              return slugLookupResult;
+            }
+            return byIdResult;
+          }),
+      };
+    }
+
+    async function expectHttpStatus(
+      guard: RequireWorkspaceAccessGuard,
+      context: ExecutionContext,
+      status: number,
+    ): Promise<void> {
+      try {
+        await guard.canActivate(context);
+        throw new Error('expected guard to throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HttpException);
+        expect((e as HttpException).getStatus()).toBe(status);
+      }
+    }
+
+    it('allows when slug resolves in org and canAccessWorkspace is true', async () => {
+      const user = mockUser({ role: 'member', permissions: { isAdmin: false } });
+      const member = { role: 'workspace_viewer', status: 'active' };
+      const { context, reflector } = mockContext('viewer', user, {
+        slug: 'acme-corp',
+      });
+      const wmRepo = { findOne: jest.fn().mockResolvedValue(member) };
+      const wsRepo = slugWsRepoDual({
+        id: 'ws-1',
+        organizationId: 'org-1',
+      });
+      const access = { canAccessWorkspace: jest.fn().mockResolvedValue(true) };
+      const tenantContextService = {
+        getOrganizationId: jest.fn().mockReturnValue('org-1'),
+        runWithTenant: jest.fn((_ctx: unknown, fn: () => Promise<unknown>) =>
+          fn(),
+        ),
+      };
+      const guard = new RequireWorkspaceAccessGuard(
+        reflector as any,
+        wmRepo as any,
+        wsRepo as any,
+        tenantContextService as any,
+        access as any,
+      );
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(access.canAccessWorkspace).toHaveBeenCalledWith(
+        'ws-1',
+        'org-1',
+        user.id,
+        expect.anything(),
+      );
+    });
+
+    it('returns 403 when slug resolves in org but canAccessWorkspace is false', async () => {
+      const user = mockUser({ role: 'member', permissions: { isAdmin: false } });
+      const { context, reflector } = mockContext('viewer', user, {
+        slug: 'secret-ws',
+      });
+      const wmRepo = { findOne: jest.fn().mockResolvedValue(null) };
+      const wsRepo = slugWsRepoDual({
+        id: 'ws-1',
+        organizationId: 'org-1',
+      });
+      const access = { canAccessWorkspace: jest.fn().mockResolvedValue(false) };
+      const tenantContextService = {
+        getOrganizationId: jest.fn().mockReturnValue('org-1'),
+        runWithTenant: jest.fn((_ctx: unknown, fn: () => Promise<unknown>) =>
+          fn(),
+        ),
+      };
+      const guard = new RequireWorkspaceAccessGuard(
+        reflector as any,
+        wmRepo as any,
+        wsRepo as any,
+        tenantContextService as any,
+        access as any,
+      );
+      await expectHttpStatus(guard, context, 403);
+    });
+
+    it('returns 403 when slug does not resolve in caller org (default semantics)', async () => {
+      const user = mockUser({ role: 'member', permissions: { isAdmin: false } });
+      const { context, reflector } = mockContext('viewer', user, {
+        slug: 'unknown-slug',
+      });
+      const wmRepo = { findOne: jest.fn() };
+      const wsRepo = {
+        findOne: jest.fn().mockResolvedValueOnce(null),
+      };
+      const access = { canAccessWorkspace: jest.fn() };
+      const tenantContextService = {
+        getOrganizationId: jest.fn().mockReturnValue('org-1'),
+        runWithTenant: jest.fn((_ctx: unknown, fn: () => Promise<unknown>) =>
+          fn(),
+        ),
+      };
+      const guard = new RequireWorkspaceAccessGuard(
+        reflector as any,
+        wmRepo as any,
+        wsRepo as any,
+        tenantContextService as any,
+        access as any,
+      );
+      await expectHttpStatus(guard, context, 403);
+      expect(access.canAccessWorkspace).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when slug does not resolve and metadata opts into 404', async () => {
+      const user = mockUser({ role: 'member', permissions: { isAdmin: false } });
+      const { context, reflector } = mockContext(
+        'viewer',
+        user,
+        { slug: 'other-org-slug' },
+        { notFoundStatus: 404, forbiddenStatus: 404 },
+      );
+      const wmRepo = { findOne: jest.fn() };
+      const wsRepo = {
+        findOne: jest.fn().mockResolvedValueOnce(null),
+      };
+      const access = { canAccessWorkspace: jest.fn() };
+      const tenantContextService = {
+        getOrganizationId: jest.fn().mockReturnValue('org-1'),
+        runWithTenant: jest.fn((_ctx: unknown, fn: () => Promise<unknown>) =>
+          fn(),
+        ),
+      };
+      const guard = new RequireWorkspaceAccessGuard(
+        reflector as any,
+        wmRepo as any,
+        wsRepo as any,
+        tenantContextService as any,
+        access as any,
+      );
+      await expectHttpStatus(guard, context, 404);
+    });
+
+    it('returns 404 when slug resolves but access denied and metadata uses 404 for forbidden', async () => {
+      const user = mockUser({ role: 'member', permissions: { isAdmin: false } });
+      const { context, reflector } = mockContext(
+        'viewer',
+        user,
+        { slug: 'masked' },
+        { notFoundStatus: 403, forbiddenStatus: 404 },
+      );
+      const wmRepo = { findOne: jest.fn().mockResolvedValue(null) };
+      const wsRepo = slugWsRepoDual({
+        id: 'ws-1',
+        organizationId: 'org-1',
+      });
+      const access = { canAccessWorkspace: jest.fn().mockResolvedValue(false) };
+      const tenantContextService = {
+        getOrganizationId: jest.fn().mockReturnValue('org-1'),
+        runWithTenant: jest.fn((_ctx: unknown, fn: () => Promise<unknown>) =>
+          fn(),
+        ),
+      };
+      const guard = new RequireWorkspaceAccessGuard(
+        reflector as any,
+        wmRepo as any,
+        wsRepo as any,
+        tenantContextService as any,
+        access as any,
+      );
+      await expectHttpStatus(guard, context, 404);
+    });
   });
 });

--- a/zephix-backend/src/modules/workspaces/guards/require-workspace-access.guard.ts
+++ b/zephix-backend/src/modules/workspaces/guards/require-workspace-access.guard.ts
@@ -5,6 +5,12 @@
  * This provides consistent "permission denied" semantics and prevents
  * information leakage about workspace existence in other organizations.
  *
+ * **Slug routes:** When `params.slug` is present and neither `params.id` nor
+ * `params.workspaceId` is set, the guard resolves the workspace **within the
+ * caller's organization only**, then applies the same checks as UUID routes.
+ * Use `@CrossTenantStatus` / `SlugAccessErrorSemantics` for per-route 404 masking
+ * (AD-027 batch 1a precursor).
+ *
  * See: docs/PHASE2A_MIGRATION_PLAYBOOK.md for policy details.
  */
 import {
@@ -15,19 +21,25 @@ import {
   NotFoundException,
   SetMetadata,
   Inject,
+  HttpException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { IsNull } from 'typeorm';
 import { WorkspaceMember } from '../entities/workspace-member.entity';
 import { Workspace } from '../entities/workspace.entity';
 import { WorkspaceRole } from '../entities/workspace.entity';
 import {
   normalizePlatformRole,
-  PlatformRole,
   isAdminRole,
 } from '../../../shared/enums/platform-roles.enum';
 import { TenantAwareRepository } from '../../tenancy/tenant-aware.repository';
 import { getTenantAwareRepositoryToken } from '../../tenancy/tenant-aware.repository';
 import { TenantContextService } from '../../tenancy/tenant-context.service';
+import { WorkspaceAccessService } from '../../workspace-access/workspace-access.service';
+import {
+  WORKSPACE_ACCESS_SLUG_ERROR_SEMANTICS,
+  type SlugAccessErrorSemantics,
+} from './cross-tenant-status.decorator';
 
 export type WorkspaceAccessMode =
   | 'read'
@@ -39,6 +51,12 @@ export type WorkspaceAccessMode =
 export const RequireWorkspaceAccess = (mode: WorkspaceAccessMode) =>
   SetMetadata('workspaceAccessMode', mode);
 
+/** Effective HTTP statuses for slug-param resolution (defaults 403 / 403). */
+type EffectiveSlugSemantics = {
+  notFoundStatus: 403 | 404;
+  forbiddenStatus: 403 | 404;
+};
+
 @Injectable()
 export class RequireWorkspaceAccessGuard implements CanActivate {
   constructor(
@@ -48,6 +66,7 @@ export class RequireWorkspaceAccessGuard implements CanActivate {
     @Inject(getTenantAwareRepositoryToken(Workspace))
     private wsRepo: TenantAwareRepository<Workspace>,
     private readonly tenantContextService: TenantContextService,
+    private readonly workspaceAccessService: WorkspaceAccessService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -67,27 +86,123 @@ export class RequireWorkspaceAccessGuard implements CanActivate {
       return true; // No access requirement
     }
 
-    const workspaceId = request.params.id || request.params.workspaceId;
-    if (!workspaceId) {
-      throw new NotFoundException('Workspace ID required');
-    }
-
-    // Ensure tenant context is set for TenantAwareRepository.
-    // The global interceptor may not populate AsyncLocalStorage before guards run.
     const organizationId = user.organizationId;
     if (!organizationId) {
       throw new ForbiddenException('Organization context required');
     }
 
-    // If tenant context is missing, wrap the entire guard logic in runWithTenant
     if (!this.tenantContextService.getOrganizationId()) {
-      return this.tenantContextService.runWithTenant(
-        { organizationId, workspaceId },
-        () => this.doActivate(request, user, mode, workspaceId),
-      );
+      return this.tenantContextService.runWithTenant({ organizationId }, async () => {
+        const resolved = await this.resolveWorkspaceRouting(
+          request,
+          organizationId,
+          context,
+        );
+        return this.tenantContextService.runWithTenant(
+          { organizationId, workspaceId: resolved.workspaceId },
+          () =>
+            this.doActivate(
+              request,
+              user,
+              mode,
+              resolved.workspaceId,
+              resolved.resolvedViaSlug,
+              resolved.slugSemantics,
+            ),
+        );
+      });
     }
 
-    return this.doActivate(request, user, mode, workspaceId);
+    const resolved = await this.resolveWorkspaceRouting(
+      request,
+      organizationId,
+      context,
+    );
+    return this.doActivate(
+      request,
+      user,
+      mode,
+      resolved.workspaceId,
+      resolved.resolvedViaSlug,
+      resolved.slugSemantics,
+    );
+  }
+
+  /**
+   * Reads optional metadata for slug routes. Defaults preserve AD-027 / playbook
+   * cross-tenant policy unless `@CrossTenantStatus` / `SlugAccessErrorSemantics` overrides.
+   */
+  private resolveSlugSemantics(
+    context: ExecutionContext,
+  ): EffectiveSlugSemantics {
+    const raw = this.reflector.getAllAndOverride<
+      SlugAccessErrorSemantics | undefined
+    >(WORKSPACE_ACCESS_SLUG_ERROR_SEMANTICS, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    return {
+      notFoundStatus: raw?.notFoundStatus ?? 403,
+      forbiddenStatus: raw?.forbiddenStatus ?? 403,
+    };
+  }
+
+  /**
+   * Resolves `workspaceId` from `params.id`, `params.workspaceId`, or tenant-scoped `params.slug`.
+   */
+  private async resolveWorkspaceRouting(
+    request: { params: Record<string, string | undefined> },
+    organizationId: string,
+    context: ExecutionContext,
+  ): Promise<{
+    workspaceId: string;
+    resolvedViaSlug: boolean;
+    slugSemantics: EffectiveSlugSemantics | null;
+  }> {
+    const fromId = request.params.id || request.params.workspaceId;
+    if (fromId) {
+      return {
+        workspaceId: fromId,
+        resolvedViaSlug: false,
+        slugSemantics: null,
+      };
+    }
+
+    const slug = request.params.slug;
+    if (slug) {
+      const slugSemantics = this.resolveSlugSemantics(context);
+      const workspaceId = await this.resolveWorkspaceIdFromSlug(
+        slug,
+        organizationId,
+      );
+      if (!workspaceId) {
+        throw new HttpException(
+          slugSemantics.notFoundStatus === 404
+            ? 'Workspace not found'
+            : 'Workspace does not belong to your organization',
+          slugSemantics.notFoundStatus,
+        );
+      }
+      return { workspaceId, resolvedViaSlug: true, slugSemantics };
+    }
+
+    throw new NotFoundException('Workspace ID required');
+  }
+
+  /** Tenant-scoped slug lookup; never returns workspaces outside caller org. */
+  private async resolveWorkspaceIdFromSlug(
+    slug: string,
+    organizationId: string,
+  ): Promise<string | null> {
+    const workspace = await this.wsRepo.findOne({
+      where: {
+        slug,
+        organizationId,
+        deletedAt: IsNull(),
+      },
+      select: ['id', 'organizationId'],
+    });
+    return workspace?.id ?? null;
   }
 
   private async doActivate(
@@ -95,6 +210,8 @@ export class RequireWorkspaceAccessGuard implements CanActivate {
     user: any,
     mode: string,
     workspaceId: string,
+    resolvedViaSlug: boolean,
+    slugSemantics: EffectiveSlugSemantics | null,
   ): Promise<boolean> {
     // Verify workspace exists and belongs to user's organization
     // TenantAwareRepository automatically scopes by organizationId from context
@@ -151,13 +268,33 @@ export class RequireWorkspaceAccessGuard implements CanActivate {
     request.workspaceRole = wsRole;
 
     // Check access based on mode.
-    // 'read' is an explicit alias for 'viewer' (any workspace member can read).
+    // 'read' is an explicit alias for 'viewer' (membership + feature flag via WorkspaceAccessService).
     // 'write' is an explicit alias for 'member' (owner or member can write).
     switch (mode) {
       case 'read':
-      case 'viewer':
-        // Any workspace role (or admin) can read — if not suspended.
+      case 'viewer': {
+        const allowed = await this.workspaceAccessService.canAccessWorkspace(
+          workspaceId,
+          user.organizationId,
+          user.id,
+          user.platformRole ?? user.role,
+        );
+        if (!allowed) {
+          if (resolvedViaSlug && slugSemantics) {
+            const st = slugSemantics.forbiddenStatus;
+            throw new HttpException(
+              st === 404
+                ? 'Workspace not found'
+                : 'You do not have access to this workspace',
+              st,
+            );
+          }
+          throw new ForbiddenException(
+            'You do not have access to this workspace',
+          );
+        }
         return true;
+      }
 
       case 'write':
       case 'member':

--- a/zephix-backend/src/modules/workspaces/workspaces.service.ts
+++ b/zephix-backend/src/modules/workspaces/workspaces.service.ts
@@ -121,6 +121,17 @@ export class WorkspacesService {
     }
   }
 
+  /**
+   * Tenant-scoped slug lookup (AD-027): slug must resolve within the given org only.
+   * Delegates to {@link findBySlug}; argument order matches guard/service consumers.
+   */
+  async findBySlugInOrg(
+    slug: string,
+    organizationId: string,
+  ): Promise<Workspace | null> {
+    return this.findBySlug(organizationId, slug);
+  }
+
   // ✅ NORMAL LIST with visibility filtering when feature flag enabled
   // Never throws - returns empty array on error or empty tables
   async listByOrg(organizationId: string, userId?: string, userRole?: string) {


### PR DESCRIPTION
## Summary
Precursor infrastructure for **AD-027 batch 1a-i**: `RequireWorkspaceAccessGuard` resolves workspaces from `params.slug` when `id` / `workspaceId` are absent, using **tenant-scoped** slug lookup. Adds `@CrossTenantStatus` / `SlugAccessErrorSemantics` metadata for per-route **403 vs 404** (Architect Decision B).

## Dependencies
- **After:** PR #229 (batch 1a-i consumer — controller migration) should merge **after** this PR.

## Key changes
- `require-workspace-access.guard.ts`: slug resolution; optional HTTP semantics via reflector metadata; **read/viewer** modes call `WorkspaceAccessService.canAccessWorkspace` for parity with membership feature flag (required for removing imperative checks in 1a-i).
- `cross-tenant-status.decorator.ts`: `CrossTenantStatus(404)`, `SlugAccessErrorSemantics({ ... })`.
- `workspaces.service.ts`: `findBySlugInOrg(slug, organizationId)` delegating to existing `findBySlug`.
- Unit tests extended (slug + semantics + missing param).

## Verification
- `npx tsc --noEmit`: PASS
- `npm run build`: PASS
- `npm run test:permission-matrix`: 8 passed; 3 DB integration failures unchanged without Postgres (baseline)
- Guard unit suite: 25 tests PASS

## Constraints honored
- **No controller changes** in this PR.
- **No new npm dependencies.**

Made with [Cursor](https://cursor.com)