### PR TITLE
docs: add AD_INDEX + V21 audit template; align source-of-truth references

### DIFF
--- a/.cursor/rules/architecture-principles.mdc
+++ b/.cursor/rules/architecture-principles.mdc
@@ -13,9 +13,13 @@ alwaysApply: true
   decisions, STOP and ask for clarification.
 
 ## Source of truth
-- `docs/architecture/ZEPHIX_ARCHITECTURE_BLUEPRINT_v2.md` is the binding
-  architectural source of truth (21 ADs locked: AD-007 through AD-026).
-- `CANONICAL.md` lists pre-existing ADs (AD-001 to AD-006).
+- **`CANONICAL.md`** and **`docs/architecture/AD_INDEX.md`** (which links all
+  in-tree ADs and external pointers) are the architectural source of truth in
+  this repository. Do not treat missing or external-only documents as in-repo
+  authority unless `AD_INDEX.md` lists them explicitly.
+- **`CANONICAL.md`** contains the locked AD log for AD-001 through AD-009 and
+  engine canonical/deprecated status. **`AD_INDEX.md`** is the AD-by-number
+  inventory and entry point for `AD-027_LOCKED.md` and related artifacts.
 - All architectural decisions (ADs) are numbered. Once locked, an AD is
   binding until explicitly superseded by a higher-numbered AD.
 
@@ -24,7 +28,7 @@ alwaysApply: true
 - Frontend root: `zephix-frontend/src/`
 - Architecture docs: `docs/architecture/`
 
-## Engineering Quality Standards (per blueprint Section 10.2)
+## Engineering Quality Standards (platform baseline)
 1. TypeScript strict mode. ESLint enforced. Test coverage ≥ 80% on critical paths.
 2. Multi-tenant isolation: every query scopes by workspace_id.
 3. RBAC: every endpoint has authorization check tested against AD-011 role matrix.

--- a/CANONICAL.md
+++ b/CANONICAL.md
@@ -4,6 +4,8 @@
 **Status:** Living document — updated when engines change canonical/deprecated status
 **Maintained by:** Architectural decisions documented in PRs that change status
 
+**See also:** [`docs/architecture/AD_INDEX.md`](docs/architecture/AD_INDEX.md) — AD-by-number inventory and links to in-tree locked artifacts.
+
 ---
 
 ## How To Use This Document

--- a/docs/architecture/AD_INDEX.md
+++ b/docs/architecture/AD_INDEX.md
@@ -1,0 +1,86 @@
+# Architecture Decision (AD) index
+
+**Purpose:** Single lookup for “what is locked, and where is it written?” Cursor and engineers should start here, then open the linked artifact.
+
+**Maintenance rule:** When a new AD is locked in-repo, add or update a row in this index in the same PR (or immediately after). If an AD exists only outside the repo, keep it under **External / not in tree** with a pointer you control (shared drive, blueprint export, etc.)—never invent a path.
+
+**Evidence rule:** Repo-state claims in memos must cite grep output + path, or be labeled **UNVERIFIED**.
+
+---
+
+## Quick links (in-repo anchors)
+
+| Anchor | Path |
+|--------|------|
+| Engine locations, deprecations, AD-001–009 log | [`CANONICAL.md`](../../CANONICAL.md) |
+| Cursor-wide principles (references AD-010–026, AD-011 matrix) | [`.cursor/rules/architecture-principles.mdc`](../../.cursor/rules/architecture-principles.mdc) |
+| Permission matrix (locked) | [`docs/architecture/AD-027_LOCKED.md`](./AD-027_LOCKED.md) |
+| AD-027 batch 1 endpoint mapping | [`docs/architecture/AD-027_BATCH_1_ENDPOINT_MAPPING_FINAL.md`](./AD-027_BATCH_1_ENDPOINT_MAPPING_FINAL.md) |
+| RBAC / access control narrative | [`docs/architecture/RBAC_AND_ACCESS_CONTROL_ARCHITECTURE.md`](./RBAC_AND_ACCESS_CONTROL_ARCHITECTURE.md) |
+
+---
+
+## AD listing
+
+### AD-001 — AD-009 (locked, in `CANONICAL.md`)
+
+Full decision text: **`CANONICAL.md` → Section 4: Architectural Decisions Log.**
+
+| AD | Title (short) | In-repo source |
+|----|----------------|----------------|
+| AD-001 | Work Items vs Work Management separation | `CANONICAL.md` §4 |
+| AD-002 | PM surface migration | `CANONICAL.md` §4 |
+| AD-003 | Custom fields defer | `CANONICAL.md` §4 |
+| AD-004 | Workflow engine dormancy | `CANONICAL.md` §4 |
+| AD-005 | Sequential engine validation | `CANONICAL.md` §4 |
+| AD-006 | No parallel feature work during validation | `CANONICAL.md` §4 |
+| AD-007 | Password reset token storage | `CANONICAL.md` §4 |
+| AD-008 | Reset token URL shape | `CANONICAL.md` §4 |
+| AD-009 | Defensive revocation of legacy refresh_tokens | `CANONICAL.md` §4 |
+
+### AD-010 — AD-026 (referenced in `.cursor/rules/architecture-principles.mdc`)
+
+**Status:** Principles file summarizes locked outcomes (role model, work entity, capabilities, tabs, etc.). **Standalone `AD-0xx_LOCKED.md` files for AD-010–026 are not present** in this workspace as of index creation.
+
+| AD | Topic (per principles file) | In-repo source |
+|----|------------------------------|----------------|
+| AD-010 | Unified work entity / `work_tasks` | `.cursor/rules/architecture-principles.mdc` |
+| AD-011 | Role matrix (platform / workspace / project) | `.cursor/rules/architecture-principles.mdc` |
+| AD-012 | Work item types / discriminator | `.cursor/rules/architecture-principles.mdc` |
+| AD-013 | Project tabs (not sibling lists) | `.cursor/rules/architecture-principles.mdc` |
+| AD-014 | Four-layer capability architecture | `.cursor/rules/architecture-principles.mdc` |
+| AD-015 — AD-017 | Methodology / templates / default tabs (numbered in blueprint narrative) | **UNVERIFIED full text in-tree** — see principles + future blueprint commit |
+| AD-018 — AD-026 | As summarized in binding blueprint (per principles) | **UNVERIFIED individual files in-tree** |
+
+**Tech debt — documentation completeness (AD-010 through AD-026):** These ADs are **not** in-tree as standalone locked files. Primary documentation exists in **(a)** `ZEPHIX_ARCHITECTURE_BLUEPRINT_v2.md` (**external** to this repo; maintained outside this tree, e.g. architect blueprint export), and **(b)** summarized in `.cursor/rules/architecture-principles.mdc`. Neither (a) nor (b) is a durable in-repo record by itself. **Resolution:** migrate substantive content into `CANONICAL.md` proper sections **or** create standalone locked `AD-0xx_LOCKED.md` files when each AD is next touched (**lazy-commit pattern**). Cursor rules remain execution hints; they must not be the only long-lived record for locked decisions.
+
+### AD-027 (locked, full text in repo)
+
+| AD | Title | In-repo source |
+|----|--------|----------------|
+| AD-027 | Permission matrix framework | [`AD-027_LOCKED.md`](./AD-027_LOCKED.md), [`AD-027_BATCH_1_ENDPOINT_MAPPING_FINAL.md`](./AD-027_BATCH_1_ENDPOINT_MAPPING_FINAL.md) |
+
+**Related:** Production readiness Gate 1 (`ZEPHIX_WS_MEMBERSHIP_V1`) is defined in AD-027 context; runtime value must be proven under `docs/architecture/proofs/` (Gate Zero).
+
+### AD-028 and above (draft / follow-up / external)
+
+| AD | Topic | In-repo source |
+|----|--------|----------------|
+| AD-028 | Service-to-service auth; audit store reconciliation (multiple follow-ups cited in AD-027) | **Not locked in-tree** — see `AD-027_LOCKED.md` mentions |
+| AD-029 | Tier classification (referenced from batch mapping) | **Referenced** in `AD-027_BATCH_1_ENDPOINT_MAPPING_FINAL.md` — **no standalone `AD-029_LOCKED.md` in tree** |
+| AD-030+ | As drafted by architect | Add rows when files land or pointer is stable |
+
+---
+
+## Foundations / cross-cutting (not AD rows)
+
+Use **`CANONICAL.md`** engine sections + [`V21_CURRENT_STATE_AUDIT.md`](./V21_CURRENT_STATE_AUDIT.md) for evidence-backed status of audit (F-A), notifications (F-B), billing code vs commercial motion, email worker, etc.
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-01 | Initial index: CANONICAL ADs, principles-backed AD-010–026 note, AD-027 links, blueprint path mismatch called out |
+| 2026-05-01 | AD-010–026 tech debt paragraph; align with CANONICAL.md + AD_INDEX as in-tree source of truth |

--- a/docs/architecture/V21_CURRENT_STATE_AUDIT.md
+++ b/docs/architecture/V21_CURRENT_STATE_AUDIT.md
@@ -1,0 +1,205 @@
+# V21 — Current state audit (template)
+
+**Artifact type:** Evidence-backed snapshot of the platform as built (replaces stale percentage-only narratives).
+
+**Cadence:** Run at milestone boundaries or when sequencing launch-critical work. Archive each completed run under `docs/architecture/proofs/v21/<DATE>-summary.md` (or attach exports there).
+
+**Evidence rule:** Every factual claim cites **command + path** or repo path:line, or is labeled **UNVERIFIED**. Staging/production posture cites **one dated proof** under `docs/architecture/proofs/`.
+
+---
+
+## 0. Run metadata (required)
+
+| Field | Value |
+|-------|--------|
+| Audit ID | V21 |
+| Date (authoritative) | YYYY-MM-DD |
+| Git branch | |
+| Commit SHA | `git rev-parse HEAD` |
+| Auditor(s) | |
+| Repo root | Zephix monorepo |
+
+**Pre-flight (branch hygiene):** Per `.cursor/rules/architecture-principles.mdc` — fetch, checkout integration branch, pull, confirm recent merges — before enumerating.
+
+---
+
+## 1. Gate Zero — runtime flags & identity (same sprint as V21)
+
+**Goal:** One dated artifact answers “what is actually ON in each environment?”—no inference from old docs.
+
+| Check | Staging value | Production value | Proof path |
+|-------|---------------|------------------|------------|
+| `ZEPHIX_WS_MEMBERSHIP_V1` | | | e.g. `docs/architecture/proofs/v21/YYYY-MM-DD-gate-zero-env.md` |
+| Backend image / deploy ID | | | |
+| Notes on RBAC behavior observed | | | |
+
+**UNVERIFIED until proof row is filled.**
+
+---
+
+## 2. Global enforcement metrics (AD-027 + F-A)
+
+Denominator: HTTP handlers on Nest controllers (approximate route count).
+
+**Suggested commands (paste outputs into appendix or proof folder):**
+
+```bash
+# Denominator: route decorators across controllers
+rg '@(Get|Post|Put|Patch|Delete)\(' zephix-backend/src --glob '*.controller.ts' | wc -l
+
+# Metric A1 — permission decorator usage (adjust pattern if renamed)
+rg '@RequireWorkspacePermission\(' zephix-backend/src --glob '*.ts'
+
+# Metric A2 — workspace access decorator
+rg '@RequireWorkspaceAccess\(' zephix-backend/src --glob '*.ts'
+
+# Metric A3 — imperative hotspots (starter set; extend per engine)
+rg 'canAccessWorkspace|WorkspacePolicy\.enforce|normalizePlatformRole' zephix-backend/src --glob '*.ts'
+
+# Metric B — guard audit decorator on live controllers
+rg 'AuditGuardDecision\(' zephix-backend/src --glob '*.controller.ts' | wc -l
+```
+
+| Metric | Definition | Count | % of denominator | Notes |
+|--------|------------|-------|------------------|-------|
+| **A1** | Routes using `@RequireWorkspacePermission` + guard | | | List primary controllers |
+| **A2** | Routes using `@RequireWorkspaceAccess` + guard | | | |
+| **A3** | Routes still relying on imperative / mixed checks (grep-driven set) | | | Qualitative roll-up per engine |
+| **B** | Routes with `@AuditGuardDecision` on **production** `*.controller.ts` | | | Tests-only usage excluded |
+
+**Do not merge A1–A3 into a single “AD-027 %” without a defined formula.** If publishing one KPI, define it explicitly (e.g. “A1 only” vs “A1 ∪ A2 compliant with batch mapping”).
+
+---
+
+## 3. Engine × implementation matrix
+
+Source of truth for engine **names and canonical paths:** [`CANONICAL.md`](../../CANONICAL.md) Section 1.
+
+Duplicate one block per engine (add rows if CANONICAL lists more).
+
+### Template row set
+
+| # | Field | Fill |
+|---|--------|------|
+| 1 | Engine name | |
+| 2 | CANONICAL / MIGRATING / DEPRECATED | |
+| 3 | Backend module path(s) | |
+| 4 | Primary route prefixes | |
+| 5 | **Top 10 routes** (method + path) — customer-critical | |
+| 6 | **Metric A1/A2/A3/B** for those 10 (per route) | |
+| 7 | **Tests:** primary suite paths (unit / integration / e2e) | |
+| 8 | **Test ownership / gap** | |
+| 9 | **MVP blocker?** (Y/N + one line) | |
+| 10 | **Schema / migration debt** | |
+| 11 | **Frontend surfaces** (routes, major components) — UNVERIFIED if not searched | |
+| 12 | **Notes / cross-links** | |
+
+#### Engine: _copy block_
+
+_(Repeat for each engine in CANONICAL.)_
+
+---
+
+## 4. Frontend canonical map (minimum for V21)
+
+**Goal:** Short, factual map of shell + dual paradigms (Work Management vs Work Items per AD-001). Not a full AD suite.
+
+| Area | Canonical entry routes | Key modules | Confirmed in code? (Y/N) | Notes |
+|------|------------------------|-------------|---------------------------|-------|
+| Shell / app layout | | | | |
+| Work Management UX | | | | |
+| Work Items UX | | | | |
+| Onboarding | | | | |
+| Admin entry | | | | |
+
+**Evidence:** List `zephix-frontend/src` paths reviewed.
+
+---
+
+## 5. Operational & commercial readiness
+
+| Item | Code exists? | End-to-end works? | Proof / gap |
+|------|--------------|-------------------|-------------|
+| Email send (verification, reset, invite) | | | |
+| Billing API (`billing/*`) | | | Stripe / live commerce | |
+| Legal (ToS / Privacy) | | | | |
+| Production environment | | | | |
+| Backups / restore drill | | | | |
+| Incident runbook | | | | |
+| Status page | | | | |
+
+---
+
+## 6. Tenancy & isolation (sequencing input)
+
+| Item | Status | Evidence |
+|------|--------|----------|
+| Automated tests asserting org/workspace isolation | | Path to specs |
+| Manual / third-party pen test | | UNVERIFIED / scheduled / done |
+| Known high-risk controllers (data export, admin, search) | | List |
+
+**Ordering reminder:** Scope critical APIs → strengthen tenancy tests → **then** flag-flip decisions.
+
+---
+
+## 7. Track 0 — customer discovery handoff
+
+Not engineering evidence; links PO outputs.
+
+| Week | Interviews | Decision log path | “Will NOT build for SMB v1” |
+|------|------------|-------------------|------------------------------|
+| 1–2 | | | |
+| … | | | |
+
+**Reversible vs non-reversible bets:** List engineering items approved to proceed before discovery completes (e.g. tenancy test harness) vs deferred (e.g. integration breadth).
+
+---
+
+## 8. PO-owned decisions (explicitly unsettled)
+
+Track in PO system of record; mirror status here.
+
+| Decision | Status | Target date |
+|----------|--------|-------------|
+| Pricing model | UNSETTLED | |
+| ICP (10–50 vs 50–500) | UNSETTLED | |
+| Beta source | UNSETTLED | |
+| Hiring trigger | UNSETTLED | |
+| Funding model | UNSETTLED | |
+
+---
+
+## 9. Summary & recommendations
+
+**Top 5 MVP blockers (evidence-backed):**
+
+1.
+2.
+3.
+4.
+5.
+
+**Top 5 intentional deferrals:**
+
+1.
+2.
+3.
+4.
+5.
+
+**Follow-ups for AD_INDEX / docs:**
+
+- [ ] Blueprint path mismatch resolved (`architecture-principles.mdc` vs actual file)
+- [ ] New AD rows added when locked
+
+---
+
+## Appendix A — Raw command outputs
+
+_Paste rg/npm test outputs here or reference files under `docs/architecture/proofs/v21/`._
+
+---
+
+## Appendix B — Endpoint denominator detail (optional)
+
+_Controller list with per-file decorator counts if needed for disputes._


### PR DESCRIPTION
## Summary
- `docs/architecture/AD_INDEX.md` — AD-by-number inventory, AD-010–026 tech-debt callout
- `docs/architecture/V21_CURRENT_STATE_AUDIT.md` — Sprint 1 evidence template
- `.cursor/rules/architecture-principles.mdc` — source of truth: `CANONICAL.md` + `AD_INDEX.md` (removes missing blueprint path)
- `CANONICAL.md` — See also link to AD_INDEX

## Scope
Docs and Cursor rules only. No application code.

## Review
Gate 4 / architect — merge when approved.

Made with [Cursor](https://cursor.com)