### PR TITLE
feat: Engine 1 validation — AD-027 enforcement on auth controllers

### DIFF
--- a/zephix-backend/src/common/auth/public.decorator.ts
+++ b/zephix-backend/src/common/auth/public.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from '@nestjs/common';
+
+/** Reflect metadata key — checked by {@link JwtAuthGuard} (AD-027 public allowlist / explicit surface). */
+export const IS_PUBLIC_KEY = 'zephix:is_public';
+
+/**
+ * Marks a route as intentionally public (no JWT required).
+ * AD-027 Gate 2: enumerate public auth surface; reviewers grep `@Public()`.
+ */
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/zephix-backend/src/modules/auth/auth-security-guards.spec.ts
+++ b/zephix-backend/src/modules/auth/auth-security-guards.spec.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
 import { AuthController } from './auth.controller';
+import { AUDIT_GUARD_DECISION_METADATA_KEY } from '../../common/audit/guard-audit.constants';
+import { IS_PUBLIC_KEY } from '../../common/auth/public.decorator';
 import { RateLimiterGuard } from '../../common/guards/rate-limiter.guard';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from './guards/optional-jwt-auth.guard';
@@ -47,6 +49,23 @@ describe('AuthController — Security Guard Enforcement', () => {
     expect(guards).toContain(SmokeKeyGuard);
   });
 
+  it('POST /auth/smoke-login is not marked @Public()', () => {
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.smokeLogin)).not.toBe(true);
+  });
+
+  // ── Explicit @Public() metadata (AD-027 Gate 2) ─────────────────────────
+
+  it('public auth handlers carry IS_PUBLIC_KEY metadata', () => {
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.register)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.resendVerification)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.forgotPassword)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.postResetPassword)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.verifyEmail)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.login)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.refreshToken)).toBe(true);
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, proto.getCsrfToken)).toBe(true);
+  });
+
   it('POST /auth/refresh has RateLimiterGuard', () => {
     const guards = getMethodGuards(proto, 'refreshToken');
     expect(guards).toContain(RateLimiterGuard);
@@ -87,6 +106,16 @@ describe('AuthController — Security Guard Enforcement', () => {
   it('POST /auth/change-password has JwtAuthGuard', () => {
     const guards = getMethodGuards(proto, 'postChangePassword');
     expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('POST /auth/change-password has config AuditGuardDecision (AD-027)', () => {
+    const meta = Reflect.getMetadata(
+      AUDIT_GUARD_DECISION_METADATA_KEY,
+      proto.postChangePassword,
+    );
+    expect(meta?.action).toBe('config');
+    expect(meta?.scope).toBe('global');
+    expect(meta?.requiredRole).toBe('authenticated');
   });
 
   // ── Ensure no @Throttle ghost metadata (it was non-functional) ────

--- a/zephix-backend/src/modules/auth/auth.controller.ts
+++ b/zephix-backend/src/modules/auth/auth.controller.ts
@@ -35,6 +35,8 @@ import {
 import { VerifyEmailDto, VerifyEmailResponseDto } from './dto/verify-email.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from './guards/optional-jwt-auth.guard';
+import { Public } from '../../common/auth/public.decorator';
+import { AuditGuardDecision } from '../../common/audit/audit-guard-decision.decorator';
 import { RateLimiterGuard } from '../../common/guards/rate-limiter.guard';
 import { SmokeKeyGuard } from './guards/smoke-key.guard';
 import { UserOrganization } from '../../organizations/entities/user-organization.entity';
@@ -127,6 +129,7 @@ export class AuthController {
    * - Token hashing (never stores raw tokens)
    * - Rate limiting
    */
+  @Public()
   @Post('register')
   @Post('signup') // Backward compatibility alias
   @HttpCode(HttpStatus.OK)
@@ -187,6 +190,7 @@ export class AuthController {
    * - Neutral response (no account enumeration)
    * - Rate limiting
    */
+  @Public()
   @Post('resend-verification')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RateLimiterGuard)
@@ -239,6 +243,7 @@ export class AuthController {
    *
    * Neutral response (no account enumeration). Rate limited (IP + per-email when store configured).
    */
+  @Public()
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RateLimiterGuard)
@@ -256,6 +261,7 @@ export class AuthController {
    *
    * Completes reset with token from email link; revokes all sessions for the user.
    */
+  @Public()
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RateLimiterGuard)
@@ -273,6 +279,7 @@ export class AuthController {
    * Verify email address using token (Phase 1: GET with query param)
    * Token is single-use and expires after 24 hours
    */
+  @Public()
   @Get('verify-email')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RateLimiterGuard)
@@ -299,6 +306,7 @@ export class AuthController {
     };
   }
 
+  @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RateLimiterGuard)
@@ -462,8 +470,13 @@ export class AuthController {
     return formatResponse(await this.authService.updateUserAccountProfile(userId, dto));
   }
 
-  @UseGuards(JwtAuthGuard)
   @Post('change-password')
+  @AuditGuardDecision({
+    action: 'config',
+    scope: 'global',
+    requiredRole: 'authenticated',
+  })
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Change password for the current user' })
   async postChangePassword(
@@ -491,6 +504,7 @@ export class AuthController {
     return res.json({ message: 'Logged out successfully' });
   }
 
+  @Public()
   @Get('csrf')
   @UseGuards(RateLimiterGuard)
   @ApiOperation({ summary: 'Get CSRF token' })
@@ -519,6 +533,7 @@ export class AuthController {
     return res.json({ token: csrfToken, csrfToken });
   }
 
+  @Public()
   @Post('refresh')
   @UseGuards(RateLimiterGuard)
   async refreshToken(

--- a/zephix-backend/src/modules/auth/auth.module.ts
+++ b/zephix-backend/src/modules/auth/auth.module.ts
@@ -34,6 +34,7 @@ import { EmailService } from '../../shared/services/email.service';
 import { SessionsController } from './controllers/sessions.controller';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { CsrfGuard } from './guards/csrf.guard';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { SmokeKeyGuard } from './guards/smoke-key.guard';
 import { AUTH_RATE_LIMIT_STORE } from './tokens';
 import { NoopAuthRateLimitStore } from './services/auth-rate-limit-store';
@@ -81,6 +82,7 @@ import { UserSettings } from '../users/entities/user-settings.entity';
   ],
   providers: [
     AuthService,
+    JwtAuthGuard,
     JwtStrategy,
     OrganizationSignupService,
     AuthRegistrationService,

--- a/zephix-backend/src/modules/auth/controllers/sessions-security-guards.spec.ts
+++ b/zephix-backend/src/modules/auth/controllers/sessions-security-guards.spec.ts
@@ -1,0 +1,34 @@
+import 'reflect-metadata';
+import { AUDIT_GUARD_DECISION_METADATA_KEY } from '../../../common/audit/guard-audit.constants';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
+import { SessionsController } from './sessions.controller';
+
+/**
+ * Reflect-only checks: AD-027 @AuditGuardDecision on session mutations (Engine 1 PR #1).
+ */
+describe('SessionsController — AD-027 guard audit metadata', () => {
+  function getClassGuards(target: typeof SessionsController): Function[] {
+    const guards = Reflect.getMetadata('__guards__', target) || [];
+    return guards.map((g: any) => (typeof g === 'function' ? g : g?.constructor));
+  }
+
+  const proto = SessionsController.prototype;
+
+  it('controller is JwtAuthGuard-protected', () => {
+    expect(getClassGuards(SessionsController)).toContain(JwtAuthGuard);
+  });
+
+  it('POST :id/revoke carries destructive AuditGuardDecision', () => {
+    const meta = Reflect.getMetadata(AUDIT_GUARD_DECISION_METADATA_KEY, proto.revokeSession);
+    expect(meta?.action).toBe('destructive');
+    expect(meta?.scope).toBe('global');
+    expect(meta?.requiredRole).toBe('authenticated');
+  });
+
+  it('POST revoke-others carries destructive AuditGuardDecision', () => {
+    const meta = Reflect.getMetadata(AUDIT_GUARD_DECISION_METADATA_KEY, proto.revokeOthers);
+    expect(meta?.action).toBe('destructive');
+    expect(meta?.scope).toBe('global');
+    expect(meta?.requiredRole).toBe('authenticated');
+  });
+});

--- a/zephix-backend/src/modules/auth/controllers/sessions.controller.ts
+++ b/zephix-backend/src/modules/auth/controllers/sessions.controller.ts
@@ -6,6 +6,8 @@ import {
   Body,
   UseGuards,
   ForbiddenException,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuditGuardDecision } from '../../../common/audit/audit-guard-decision.decorator';
@@ -55,6 +57,7 @@ export class SessionsController {
   }
 
   @Post(':id/revoke')
+  @HttpCode(HttpStatus.OK)
   @AuditGuardDecision({
     action: 'destructive',
     scope: 'global',
@@ -90,6 +93,7 @@ export class SessionsController {
   }
 
   @Post('revoke-others')
+  @HttpCode(HttpStatus.OK)
   @AuditGuardDecision({
     action: 'destructive',
     scope: 'global',

--- a/zephix-backend/src/modules/auth/controllers/sessions.controller.ts
+++ b/zephix-backend/src/modules/auth/controllers/sessions.controller.ts
@@ -8,6 +8,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { AuditGuardDecision } from '../../../common/audit/audit-guard-decision.decorator';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { CurrentUser } from '../decorators/current-user.decorator';
 import { AuthService } from '../auth.service';
@@ -54,6 +55,11 @@ export class SessionsController {
   }
 
   @Post(':id/revoke')
+  @AuditGuardDecision({
+    action: 'destructive',
+    scope: 'global',
+    requiredRole: 'authenticated',
+  })
   @ApiOperation({ summary: 'Revoke a specific session' })
   @ApiResponse({ status: 200, description: 'Session revoked successfully' })
   async revokeSession(
@@ -84,6 +90,11 @@ export class SessionsController {
   }
 
   @Post('revoke-others')
+  @AuditGuardDecision({
+    action: 'destructive',
+    scope: 'global',
+    requiredRole: 'authenticated',
+  })
   @ApiOperation({ summary: 'Revoke all other sessions (keep current one)' })
   @ApiResponse({
     status: 200,

--- a/zephix-backend/src/modules/auth/guards/jwt-auth.guard.spec.ts
+++ b/zephix-backend/src/modules/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,46 @@
+import 'reflect-metadata';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../../../common/auth/public.decorator';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+describe('JwtAuthGuard', () => {
+  it('allows activation when handler is marked @Public()', () => {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(true),
+    } as unknown as Reflector;
+    const guard = new JwtAuthGuard(reflector);
+    const context = {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(true);
+    expect(reflector.getAllAndOverride).toHaveBeenCalledWith(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+  });
+
+  it('delegates to passport when route is not public', () => {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(undefined),
+    } as unknown as Reflector;
+    const guard = new JwtAuthGuard(reflector);
+    const parentProto = Object.getPrototypeOf(JwtAuthGuard.prototype) as {
+      canActivate: (ctx: ExecutionContext) => boolean | Promise<boolean>;
+    };
+    const spy = jest.spyOn(parentProto, 'canActivate').mockReturnValue(true);
+
+    const context = {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({ getRequest: () => ({}) }),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(true);
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+});

--- a/zephix-backend/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/zephix-backend/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../../../common/auth/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic === true) {
+      return true;
+    }
+    return super.canActivate(context);
+  }
+}

--- a/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * DB-backed: verifies AD-027 @AuditGuardDecision ALLOW rows for auth + sessions
+ * endpoints (Gate 2 — Engine 1 PR #1). Skipped without DATABASE_URL.
+ *
+ * Cross-tenant test 5: N/A for this surface (architect Gate 2 decision).
+ */
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import bcrypt from 'bcrypt';
+
+import { AppModule } from '../../../src/app.module';
+
+const ORG_ID = 'b1111111-1111-4111-8111-111111111111';
+const USER_ID = 'b2222222-2222-4222-8222-222222222222';
+const SESS_A = 'b3333333-3333-4333-8333-333333333333';
+const SESS_B = 'b4444444-4444-4444-8444-444444444444';
+const SESS_C = 'b5555555-5555-4555-8555-555555555555';
+
+const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
+
+describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
+  jest.setTimeout(120000);
+
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let jwtService: JwtService;
+  let email: string;
+  let slug: string;
+
+  async function seedFixtures(): Promise<void> {
+    await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [
+      ORG_ID,
+    ]);
+    await dataSource.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
+
+    const passwordHash = await bcrypt.hash('CurrentPass1!', 10);
+    await dataSource.query(
+      `INSERT INTO organizations (id, name, slug, status, plan_code, plan_status, settings, created_at, updated_at)
+       VALUES ($1, $2, $3, 'trial', 'enterprise', 'active', '{}', NOW(), NOW())`,
+      [ORG_ID, 'AD027 Audit Org', slug],
+    );
+    await dataSource.query(
+      `INSERT INTO users (
+         id, email, password, role, organization_id, is_active, is_email_verified,
+         failed_login_attempts, created_at, updated_at
+       ) VALUES (
+         $1, $2, $3, 'admin', $4, true, true,
+         0, NOW(), NOW()
+       )`,
+      [USER_ID, email, passwordHash, ORG_ID],
+    );
+
+    await dataSource.query(
+      `INSERT INTO auth_sessions (
+         id, organization_id, user_id, user_agent, ip_address,
+         created_at, last_seen_at, revoked_at, revoke_reason,
+         current_refresh_token_hash, refresh_expires_at, last_active_organization_id
+       ) VALUES (
+         $1, $2, $3, 'jest', '127.0.0.1',
+         NOW(), NOW(), NULL, NULL,
+         NULL, NULL, NULL
+       )`,
+      [SESS_A, ORG_ID, USER_ID],
+    );
+  }
+
+  async function addSecondSession(): Promise<void> {
+    await dataSource.query(
+      `INSERT INTO auth_sessions (
+         id, organization_id, user_id, user_agent, ip_address,
+         created_at, last_seen_at, revoked_at, revoke_reason,
+         current_refresh_token_hash, refresh_expires_at, last_active_organization_id
+       ) VALUES (
+         $1, $2, $3, 'jest', '127.0.0.1',
+         NOW(), NOW() - INTERVAL '1 hour', NULL, NULL,
+         NULL, NULL, NULL
+       )`,
+      [SESS_B, ORG_ID, USER_ID],
+    );
+  }
+
+  async function addThirdSessionNewer(): Promise<void> {
+    await dataSource.query(
+      `INSERT INTO auth_sessions (
+         id, organization_id, user_id, user_agent, ip_address,
+         created_at, last_seen_at, revoked_at, revoke_reason,
+         current_refresh_token_hash, refresh_expires_at, last_active_organization_id
+       ) VALUES (
+         $1, $2, $3, 'jest', '127.0.0.1',
+         NOW(), NOW(), NULL, NULL,
+         NULL, NULL, NULL
+       )`,
+      [SESS_C, ORG_ID, USER_ID],
+    );
+  }
+
+  beforeAll(async () => {
+    slug = `ad027-audit-${Date.now()}`;
+    email = `ad027-audit-${Date.now()}@test.dev`;
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    app.use(require('cookie-parser')());
+    await app.init();
+    dataSource = app.get(DataSource);
+    jwtService = app.get(JwtService);
+    await seedFixtures();
+  });
+
+  afterAll(async () => {
+    try {
+      await dataSource?.query(`DELETE FROM audit_events WHERE organization_id = $1`, [
+        ORG_ID,
+      ]);
+      await dataSource?.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
+    } catch {
+      /* ignore */
+    }
+    try {
+      await app?.close();
+      if (dataSource?.isInitialized) await dataSource.destroy();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  function bearer(): string {
+    return jwtService.sign({
+      sub: USER_ID,
+      email,
+      organizationId: ORG_ID,
+      platformRole: 'ADMIN',
+    });
+  }
+
+  it('POST /auth/change-password emits guard_allow with requiredRole authenticated', async () => {
+    await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
+
+    const agent = request.agent(app.getHttpServer());
+    const csrf = await agent.get('/api/auth/csrf').expect(200);
+    const xsrf = csrf.body.csrfToken ?? csrf.body.token;
+
+    await agent
+      .post('/api/auth/change-password')
+      .set('Authorization', `Bearer ${bearer()}`)
+      .set('X-CSRF-Token', xsrf)
+      .send({ currentPassword: 'CurrentPass1!', newPassword: 'NewPassw0rd!' })
+      .expect(200);
+
+    const rows = await dataSource.query<
+      { action: string; metadata_json: { requiredRole?: string } }[]
+    >(
+      `SELECT action, metadata_json FROM audit_events
+       WHERE organization_id = $1 AND entity_type = 'authorization_decision'
+       ORDER BY created_at DESC LIMIT 5`,
+      [ORG_ID],
+    );
+    expect(rows.some((r) => r.action === 'guard_allow')).toBe(true);
+    const allow = rows.find((r) => r.action === 'guard_allow');
+    expect(allow?.metadata_json?.requiredRole).toBe('authenticated');
+  });
+
+  it('POST /auth/sessions/:id/revoke emits guard_allow (destructive)', async () => {
+    await seedFixtures();
+    await addSecondSession();
+    await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
+
+    const agent = request.agent(app.getHttpServer());
+    const csrf = await agent.get('/api/auth/csrf').expect(200);
+    const xsrf = csrf.body.csrfToken ?? csrf.body.token;
+
+    await agent
+      .post(`/api/auth/sessions/${SESS_B}/revoke`)
+      .set('Authorization', `Bearer ${bearer()}`)
+      .set('X-CSRF-Token', xsrf)
+      .send({})
+      .expect(200);
+
+    const rows = await dataSource.query<{ action: string }[]>(
+      `SELECT action FROM audit_events WHERE organization_id = $1 ORDER BY created_at DESC LIMIT 8`,
+      [ORG_ID],
+    );
+    expect(rows.some((r) => r.action === 'guard_allow')).toBe(true);
+  });
+
+  it('POST /auth/sessions/revoke-others emits guard_allow (destructive)', async () => {
+    await seedFixtures();
+    await addSecondSession();
+    await addThirdSessionNewer();
+    await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
+
+    const agent = request.agent(app.getHttpServer());
+    const csrf = await agent.get('/api/auth/csrf').expect(200);
+    const xsrf = csrf.body.csrfToken ?? csrf.body.token;
+
+    await agent
+      .post('/api/auth/sessions/revoke-others')
+      .set('Authorization', `Bearer ${bearer()}`)
+      .set('X-CSRF-Token', xsrf)
+      .send({ currentSessionId: SESS_C })
+      .expect(200);
+
+    const rows = await dataSource.query<{ action: string }[]>(
+      `SELECT action FROM audit_events WHERE organization_id = $1 ORDER BY created_at DESC LIMIT 8`,
+      [ORG_ID],
+    );
+    expect(rows.some((r) => r.action === 'guard_allow')).toBe(true);
+  });
+});

--- a/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
@@ -35,6 +35,7 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
       ORG_ID,
     ]);
     await dataSource.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM user_organizations WHERE user_id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
 
@@ -108,6 +109,7 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
     }).compile();
 
     app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     app.use(require('cookie-parser')());
     await app.init();
@@ -122,6 +124,7 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
         ORG_ID,
       ]);
       await dataSource?.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM user_organizations WHERE user_id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
     } catch {

--- a/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
@@ -31,18 +31,14 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
   let slug: string;
 
   async function seedFixtures(): Promise<void> {
-    // Delete all FK-referencing rows before the user row (37 FK references exist on users.id)
+    // Users has 37 FK references — chasing individual tables is fragile.
+    // Use session_replication_role to bypass FK checks for test cleanup only.
+    await dataSource.query(`SET session_replication_role = 'replica'`);
     await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
     await dataSource.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM email_verification_tokens WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM password_reset_tokens WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM user_organizations WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM user_settings WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM notification_reads WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM notifications WHERE user_id = $1`, [USER_ID]);
-    await dataSource.query(`DELETE FROM workspace_members WHERE user_id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
+    await dataSource.query(`SET session_replication_role = 'origin'`);
 
     const passwordHash = await bcrypt.hash('CurrentPass1!', 10);
     await dataSource.query(
@@ -125,17 +121,12 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
 
   afterAll(async () => {
     try {
+      await dataSource?.query(`SET session_replication_role = 'replica'`);
       await dataSource?.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
       await dataSource?.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM email_verification_tokens WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM password_reset_tokens WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM user_organizations WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM user_settings WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM notification_reads WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM notifications WHERE user_id = $1`, [USER_ID]);
-      await dataSource?.query(`DELETE FROM workspace_members WHERE user_id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
+      await dataSource?.query(`SET session_replication_role = 'origin'`);
     } catch {
       /* ignore */
     }

--- a/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
+++ b/zephix-backend/test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts
@@ -31,11 +31,16 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
   let slug: string;
 
   async function seedFixtures(): Promise<void> {
-    await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [
-      ORG_ID,
-    ]);
+    // Delete all FK-referencing rows before the user row (37 FK references exist on users.id)
+    await dataSource.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
     await dataSource.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM email_verification_tokens WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM password_reset_tokens WHERE user_id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM user_organizations WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM user_settings WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM notification_reads WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM notifications WHERE user_id = $1`, [USER_ID]);
+    await dataSource.query(`DELETE FROM workspace_members WHERE user_id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
     await dataSource.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
 
@@ -120,11 +125,15 @@ describeOrSkip('AD-027 auth + sessions guard-audit (DATABASE_URL)', () => {
 
   afterAll(async () => {
     try {
-      await dataSource?.query(`DELETE FROM audit_events WHERE organization_id = $1`, [
-        ORG_ID,
-      ]);
+      await dataSource?.query(`DELETE FROM audit_events WHERE organization_id = $1`, [ORG_ID]);
       await dataSource?.query(`DELETE FROM auth_sessions WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM email_verification_tokens WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM password_reset_tokens WHERE user_id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM user_organizations WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM user_settings WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM notification_reads WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM notifications WHERE user_id = $1`, [USER_ID]);
+      await dataSource?.query(`DELETE FROM workspace_members WHERE user_id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
       await dataSource?.query(`DELETE FROM organizations WHERE id = $1`, [ORG_ID]);
     } catch {


### PR DESCRIPTION
## Summary
Implements architect Gate 2 for Engine 1 PR #1: `@Public()` on in-scope unauthenticated auth routes, `@AuditGuardDecision` on **3** authenticated config/destructive routes, `requiredRole: 'authenticated'`, `scope: 'global'`.

## Scope (locked)
- **In:** `auth.controller.ts`, `sessions.controller.ts` only (17 handlers).
- **Out:** org-invites, organization-signup, smoke controllers (deferred).

## Public / audit
- **@Public()** on: register/signup, resend-verification, forgot-password, reset-password, verify-email, login, refresh, csrf. **Not** on smoke-login (SmokeKeyGuard only).
- **@AuditGuardDecision** on: `change-password` (config), session `revoke` + `revoke-others` (destructive). **Not** on public routes (interceptor has no auth context for ALLOW per AD-027 / Gate 2).

## Tests
- Unit/reflect: `jwt-auth.guard.spec.ts`, extended `auth-security-guards.spec.ts`, `sessions-security-guards.spec.ts`.
- Integration: `test/permission-matrix/__tests__/auth-ad027-guard-audit.integration.spec.ts` (**requires `DATABASE_URL`**; asserts `guard_allow` + metadata). Cross-tenant test 5: **N/A** (documented).

## Baseline note
Local `npm run test:permission-matrix` failed here (Postgres DB missing). Re-run in CI or with a valid `DATABASE_URL`.

## Parallel
- AD-027 §1.1 allowlist doc patch (code paths canonical): separate PR.

Commit: `4b6b4f41`

Made with [Cursor](https://cursor.com)